### PR TITLE
[Skills] remove redundant ActionEnded

### DIFF
--- a/skills/csharp/calendarskill/Dialogs/CalendarSkillDialogBase.cs
+++ b/skills/csharp/calendarskill/Dialogs/CalendarSkillDialogBase.cs
@@ -2299,19 +2299,6 @@ namespace CalendarSkill.Dialogs
             return dateTimeResults;
         }
 
-        protected Task SendActionEnded(ITurnContext turnContext)
-        {
-            if (turnContext.IsSkill())
-            {
-                return Task.CompletedTask;
-            }
-            else
-            {
-                var activity = TemplateEngine.GenerateActivityForLocale(CalendarSharedResponses.ActionEnded);
-                return turnContext.SendActivityAsync(activity);
-            }
-        }
-
         private async Task<List<object>> GetMeetingCardListAsync(DialogContext dc, List<EventModel> events)
         {
             var state = await Accessor.GetAsync(dc.Context);

--- a/skills/csharp/calendarskill/Dialogs/CreateEventDialog.cs
+++ b/skills/csharp/calendarskill/Dialogs/CreateEventDialog.cs
@@ -692,7 +692,6 @@ namespace CalendarSkill.Dialogs
                     switch (recreateState.Value)
                     {
                         case RecreateEventState.Cancel:
-                            await SendActionEnded(sc.Context);
                             state.Clear();
                             return await sc.EndDialogAsync(true, cancellationToken);
                         case RecreateEventState.Time:

--- a/skills/csharp/calendarskill/Dialogs/MainDialog.cs
+++ b/skills/csharp/calendarskill/Dialogs/MainDialog.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using CalendarSkill.Models;

--- a/skills/csharp/calendarskill/Dialogs/UpdateEventDialog.cs
+++ b/skills/csharp/calendarskill/Dialogs/UpdateEventDialog.cs
@@ -175,7 +175,6 @@ namespace CalendarSkill.Dialogs
                 }
                 else
                 {
-                    await SendActionEnded(sc.Context);
                     if (options.SubFlowMode)
                     {
                         state.UpdateMeetingInfo.Clear();

--- a/skills/csharp/experimental/hospitalityskill/Dialogs/MainDialog.cs
+++ b/skills/csharp/experimental/hospitalityskill/Dialogs/MainDialog.cs
@@ -310,7 +310,7 @@ namespace HospitalitySkill.Dialogs
             }
             else
             {
-                return await stepContext.ReplaceDialogAsync(this.Id, _responseManager.GetResponse(MainResponses.WelcomeMessage), cancellationToken);
+                return await stepContext.ReplaceDialogAsync(this.Id, _responseManager.GetResponse(SharedResponses.ActionEnded), cancellationToken);
             }
         }
 

--- a/skills/csharp/experimental/itsmskill/Dialogs/MainDialog.cs
+++ b/skills/csharp/experimental/itsmskill/Dialogs/MainDialog.cs
@@ -304,7 +304,7 @@ namespace ITSMSkill.Dialogs
             }
             else
             {
-                return await stepContext.ReplaceDialogAsync(this.Id, _responseManager.GetResponse(MainResponses.WelcomeMessage), cancellationToken);
+                return await stepContext.ReplaceDialogAsync(this.Id, _responseManager.GetResponse(SharedResponses.ActionEnded), cancellationToken);
             }
         }
 

--- a/skills/csharp/experimental/itsmskill/Dialogs/ShowKnowledgeDialog.cs
+++ b/skills/csharp/experimental/itsmskill/Dialogs/ShowKnowledgeDialog.cs
@@ -95,7 +95,6 @@ namespace ITSMSkill.Dialogs
             }
             else
             {
-                await SendActionEnded(sc.Context);
                 return await sc.CancelAllDialogsAsync();
             }
         }

--- a/skills/csharp/experimental/itsmskill/Dialogs/ShowTicketDialog.cs
+++ b/skills/csharp/experimental/itsmskill/Dialogs/ShowTicketDialog.cs
@@ -279,7 +279,6 @@ namespace ITSMSkill.Dialogs
             var intent = (GeneralLuis.Intent)sc.Result;
             if (intent == GeneralLuis.Intent.Reject)
             {
-                await SendActionEnded(sc.Context);
                 return await sc.CancelAllDialogsAsync();
             }
             else if (intent == GeneralLuis.Intent.Confirm)

--- a/skills/csharp/experimental/itsmskill/Dialogs/SkillDialogBase.cs
+++ b/skills/csharp/experimental/itsmskill/Dialogs/SkillDialogBase.cs
@@ -885,7 +885,6 @@ namespace ITSMSkill.Dialogs
             var intent = (GeneralLuis.Intent)sc.Result;
             if (intent == GeneralLuis.Intent.Confirm)
             {
-                await SendActionEnded(sc.Context);
                 return await sc.CancelAllDialogsAsync();
             }
             else if (intent == GeneralLuis.Intent.Reject)
@@ -1109,18 +1108,6 @@ namespace ITSMSkill.Dialogs
             else
             {
                 return card;
-            }
-        }
-
-        protected Task SendActionEnded(ITurnContext turnContext)
-        {
-            if (turnContext.IsSkill())
-            {
-                return Task.CompletedTask;
-            }
-            else
-            {
-                return turnContext.SendActivityAsync(ResponseManager.GetResponse(SharedResponses.ActionEnded));
             }
         }
 

--- a/skills/csharp/tests/hospitalityskill.tests/Flow/GeneralFlowTests.cs
+++ b/skills/csharp/tests/hospitalityskill.tests/Flow/GeneralFlowTests.cs
@@ -21,7 +21,7 @@ namespace HospitalitySkill.Tests.Flow
                 .AssertReply(AssertContains(MainResponses.WelcomeMessage))
                 .Send(GeneralTestUtterances.Help)
                 .AssertReply(AssertContains(MainResponses.HelpMessage))
-                .AssertReply(ActionEndMessage())
+                .AssertReply(AssertContains(MainResponses.WelcomeMessage))
                 .StartTestAsync();
         }
 
@@ -33,7 +33,7 @@ namespace HospitalitySkill.Tests.Flow
                 .AssertReply(AssertContains(MainResponses.WelcomeMessage))
                 .Send(GeneralTestUtterances.Cancel)
                 .AssertReply(AssertContains(MainResponses.CancelMessage))
-                .AssertReply(ActionEndMessage())
+                .AssertReply(AssertContains(MainResponses.WelcomeMessage))
                 .StartTestAsync();
         }
 

--- a/skills/csharp/tests/hospitalityskill.tests/Flow/HospitalitySkillTestBase.cs
+++ b/skills/csharp/tests/hospitalityskill.tests/Flow/HospitalitySkillTestBase.cs
@@ -178,7 +178,7 @@ namespace HospitalitySkill.Tests.Flow
 
         protected Action<IActivity> ActionEndMessage()
         {
-            return AssertContains(MainResponses.WelcomeMessage);
+            return AssertContains(SharedResponses.ActionEnded);
         }
 
         protected Action<IActivity> SkillActionEndMessage()

--- a/skills/csharp/tests/hospitalityskill.tests/Flow/LateCheckOutFlowTests.cs
+++ b/skills/csharp/tests/hospitalityskill.tests/Flow/LateCheckOutFlowTests.cs
@@ -103,7 +103,7 @@ namespace HospitalitySkill.Tests.Flow
                 .AssertReply(AssertStartsWith(LateCheckOutResponses.MoveCheckOutPrompt, tokens))
                 .Send(GeneralTestUtterances.Cancel)
                 .AssertReply(AssertContains(MainResponses.CancelMessage))
-                .AssertReply(ActionEndMessage())
+                .AssertReply(AssertContains(MainResponses.WelcomeMessage))
                 .StartTestAsync();
         }
     }

--- a/skills/csharp/tests/itsmskill.tests/Flow/GeneralFlowTests.cs
+++ b/skills/csharp/tests/itsmskill.tests/Flow/GeneralFlowTests.cs
@@ -20,7 +20,7 @@ namespace ITSMSkill.Tests.Flow
                 .AssertReply(AssertContains(MainResponses.WelcomeMessage))
                 .Send(GeneralTestUtterances.Help)
                 .AssertReply(AssertContains(MainResponses.HelpMessage))
-                .AssertReply(ActionEndMessage())
+                .AssertReply(AssertContains(MainResponses.WelcomeMessage))
                 .StartTestAsync();
         }
 
@@ -32,7 +32,7 @@ namespace ITSMSkill.Tests.Flow
                 .AssertReply(AssertContains(MainResponses.WelcomeMessage))
                 .Send(GeneralTestUtterances.Cancel)
                 .AssertReply(AssertContains(MainResponses.CancelMessage))
-                .AssertReply(ActionEndMessage())
+                .AssertReply(AssertContains(MainResponses.WelcomeMessage))
                 .StartTestAsync();
         }
 

--- a/skills/csharp/tests/itsmskill.tests/Flow/KnowledgeShowTests.cs
+++ b/skills/csharp/tests/itsmskill.tests/Flow/KnowledgeShowTests.cs
@@ -38,7 +38,6 @@ namespace ITSMSkill.Tests.Flow
                 .AssertReply(AssertContains(SharedResponses.ResultIndicator, null, CardStrings.Knowledge))
                 .AssertReply(AssertStartsWith(KnowledgeResponses.IfFindWanted, navigate))
                 .Send(GeneralTestUtterances.Confirm)
-                .AssertReply(AssertContains(SharedResponses.ActionEnded))
                 .AssertReply(ActionEndMessage())
                 .StartTestAsync();
         }
@@ -65,7 +64,6 @@ namespace ITSMSkill.Tests.Flow
                 .AssertReply(AssertContains(MainResponses.HelpMessage))
                 .AssertReply(AssertStartsWith(KnowledgeResponses.IfFindWanted, navigate))
                 .Send(GeneralTestUtterances.Confirm)
-                .AssertReply(AssertContains(SharedResponses.ActionEnded))
                 .AssertReply(ActionEndMessage())
                 .StartTestAsync();
         }
@@ -90,7 +88,7 @@ namespace ITSMSkill.Tests.Flow
                 .AssertReply(AssertStartsWith(KnowledgeResponses.IfFindWanted, navigate))
                 .Send(GeneralTestUtterances.Cancel)
                 .AssertReply(AssertContains(MainResponses.CancelMessage))
-                .AssertReply(ActionEndMessage())
+                .AssertReply(AssertContains(MainResponses.WelcomeMessage))
                 .StartTestAsync();
         }
 

--- a/skills/csharp/tests/itsmskill.tests/Flow/SkillTestBase.cs
+++ b/skills/csharp/tests/itsmskill.tests/Flow/SkillTestBase.cs
@@ -186,7 +186,7 @@ namespace ITSMSkill.Tests.Flow
 
         protected Action<IActivity> ActionEndMessage()
         {
-            return AssertContains(MainResponses.WelcomeMessage);
+            return AssertContains(SharedResponses.ActionEnded);
         }
 
         protected Action<IActivity> SkillActionEndMessage()

--- a/skills/csharp/tests/itsmskill.tests/Flow/TicketCreateFlowTests.cs
+++ b/skills/csharp/tests/itsmskill.tests/Flow/TicketCreateFlowTests.cs
@@ -68,7 +68,6 @@ namespace ITSMSkill.Tests.Flow
                 .AssertReply(AssertContains(SharedResponses.ResultIndicator, null, CardStrings.Knowledge))
                 .AssertReply(AssertStartsWith(KnowledgeResponses.IfExistingSolve, navigate))
                 .Send(GeneralTestUtterances.Confirm)
-                .AssertReply(AssertContains(SharedResponses.ActionEnded))
                 .AssertReply(ActionEndMessage())
                 .StartTestAsync();
         }

--- a/skills/csharp/tests/itsmskill.tests/Flow/TicketShowFlowTests.cs
+++ b/skills/csharp/tests/itsmskill.tests/Flow/TicketShowFlowTests.cs
@@ -55,7 +55,6 @@ namespace ITSMSkill.Tests.Flow
                 .AssertReply(AssertContains(SharedResponses.ResultIndicator, null, CardStrings.TicketUpdateClose))
                 .AssertReply(AssertStartsWith(TicketResponses.TicketShow, navigate))
                 .Send(GeneralTestUtterances.Reject)
-                .AssertReply(AssertContains(SharedResponses.ActionEnded))
                 .AssertReply(ActionEndMessage())
                 .StartTestAsync();
         }
@@ -83,7 +82,6 @@ namespace ITSMSkill.Tests.Flow
                 .AssertReply(AssertContains(SharedResponses.ResultIndicator, null, CardStrings.TicketUpdateClose))
                 .AssertReply(AssertStartsWith(TicketResponses.TicketShow, navigate))
                 .Send(GeneralTestUtterances.Reject)
-                .AssertReply(AssertContains(SharedResponses.ActionEnded))
                 .AssertReply(ActionEndMessage())
                 .StartTestAsync();
         }

--- a/skills/csharp/tests/todoskill.tests/Flow/AddToDoFlowTests.cs
+++ b/skills/csharp/tests/todoskill.tests/Flow/AddToDoFlowTests.cs
@@ -200,10 +200,5 @@ namespace ToDoSkill.Tests.Flow
         {
             return GetTemplates(AddToDoResponses.AfterTaskAdded, data);
         }
-
-        private string[] ActionEndMessage()
-        {
-            return GetTemplates(ToDoSharedResponses.ActionEnded);
-        }
     }
 }

--- a/skills/csharp/tests/todoskill.tests/Flow/DeleteToDoFlowTests.cs
+++ b/skills/csharp/tests/todoskill.tests/Flow/DeleteToDoFlowTests.cs
@@ -151,11 +151,6 @@ namespace ToDoSkill.Tests.Flow
             return GetTemplates(DeleteToDoResponses.DeleteAnotherTaskPrompt);
         }
 
-        private string[] ActionEndMessage()
-        {
-            return GetTemplates(ToDoSharedResponses.ActionEnded);
-        }
-
         private string[] CollectListType()
         {
             return GetTemplates(DeleteToDoResponses.ListTypePromptForDelete);

--- a/skills/csharp/tests/todoskill.tests/Flow/ShowToDoFlowTests.cs
+++ b/skills/csharp/tests/todoskill.tests/Flow/ShowToDoFlowTests.cs
@@ -212,12 +212,7 @@ namespace ToDoSkill.Tests.Flow
 
         private string[] FirstReadMoreRefused()
         {
-            return GetTemplates(ToDoSharedResponses.ActionEnded);
-        }
-
-        private string[] ActionEndMessage()
-        {
-            return GetTemplates(ToDoSharedResponses.ActionEnded);
+            return GetTemplates(ToDoMainResponses.CompletedMessage);
         }
     }
 }

--- a/skills/csharp/tests/todoskill.tests/Flow/ToDoSkillTestBase.cs
+++ b/skills/csharp/tests/todoskill.tests/Flow/ToDoSkillTestBase.cs
@@ -24,6 +24,7 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using ToDoSkill.Bots;
 using ToDoSkill.Dialogs;
+using ToDoSkill.Responses.Main;
 using ToDoSkill.Services;
 using ToDoSkill.Tests.Flow.Fakes;
 using ToDoSkill.Tests.Flow.Utterances;
@@ -188,6 +189,11 @@ namespace ToDoSkill.Tests.Flow
             });
 
             return testFlow;
+        }
+
+        protected string[] ActionEndMessage()
+        {
+            return GetTemplates(ToDoMainResponses.CompletedMessage);
         }
     }
 }

--- a/skills/csharp/todoskill/Dialogs/AddToDoItemDialog.cs
+++ b/skills/csharp/todoskill/Dialogs/AddToDoItemDialog.cs
@@ -136,7 +136,6 @@ namespace ToDoSkill.Dialogs
                 }
                 else
                 {
-                    await SendActionEnded(sc.Context);
                     return await sc.EndDialogAsync(true);
                 }
             }
@@ -428,7 +427,6 @@ namespace ToDoSkill.Dialogs
                 }
                 else
                 {
-                    await SendActionEnded(sc.Context);
                     return await sc.EndDialogAsync(true);
                 }
             }

--- a/skills/csharp/todoskill/Dialogs/DeleteToDoItemDialog.cs
+++ b/skills/csharp/todoskill/Dialogs/DeleteToDoItemDialog.cs
@@ -484,7 +484,6 @@ namespace ToDoSkill.Dialogs
                 }
                 else
                 {
-                    await SendActionEnded(sc.Context);
                     return await sc.EndDialogAsync(true);
                 }
             }

--- a/skills/csharp/todoskill/Dialogs/MarkToDoItemDialog.cs
+++ b/skills/csharp/todoskill/Dialogs/MarkToDoItemDialog.cs
@@ -387,7 +387,6 @@ namespace ToDoSkill.Dialogs
                 }
                 else
                 {
-                    await SendActionEnded(sc.Context);
                     return await sc.EndDialogAsync(true);
                 }
             }

--- a/skills/csharp/todoskill/Dialogs/ShowToDoItemDialog.cs
+++ b/skills/csharp/todoskill/Dialogs/ShowToDoItemDialog.cs
@@ -284,7 +284,6 @@ namespace ToDoSkill.Dialogs
                 }
                 else
                 {
-                    await SendActionEnded(sc.Context);
                     return await sc.CancelAllDialogsAsync();
                 }
             }
@@ -374,7 +373,6 @@ namespace ToDoSkill.Dialogs
                 }
                 else
                 {
-                    await SendActionEnded(sc.Context);
                     return await sc.CancelAllDialogsAsync();
                 }
             }
@@ -485,7 +483,6 @@ namespace ToDoSkill.Dialogs
             else
             {
                 state.GoBackToStart = false;
-                await SendActionEnded(sc.Context);
                 return await sc.EndDialogAsync(true);
             }
         }
@@ -529,7 +526,6 @@ namespace ToDoSkill.Dialogs
             else
             {
                 state.GoBackToStart = false;
-                await SendActionEnded(sc.Context);
                 return await sc.EndDialogAsync(true);
             }
         }

--- a/skills/csharp/todoskill/Dialogs/ToDoSkillDialogBase.cs
+++ b/skills/csharp/todoskill/Dialogs/ToDoSkillDialogBase.cs
@@ -647,19 +647,6 @@ namespace ToDoSkill.Dialogs
             }
         }
 
-        protected Task SendActionEnded(ITurnContext turnContext)
-        {
-            if (turnContext.IsSkill())
-            {
-                return Task.CompletedTask;
-            }
-            else
-            {
-                var activity = TemplateEngine.GenerateActivityForLocale(ToDoSharedResponses.ActionEnded);
-                return turnContext.SendActivityAsync(activity);
-            }
-        }
-
         private async Task<bool> RecoverListTypeIdsAsync(DialogContext dc)
         {
             var userState = await UserStateAccessor.GetAsync(dc.Context, () => new ToDoSkillUserState());


### PR DESCRIPTION
<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
### Purpose
*What is the context of this pull request? Why is it being done?*

Remove ActionEnded since in FinalStepAsync it responses CompletedMessage

Current:
![image](https://user-images.githubusercontent.com/2876650/75406838-74315c80-594c-11ea-8d87-5fc3845bea7f.png)

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*

### Tests
*Is this covered by existing tests or new ones? If no, why not?*

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation

#### Bots
- [ ] I have validated that new and updated responses use appropriate [Speak](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-text-to-speech?view=azure-bot-service-3.0) and [InputHint](https://docs.microsoft.com/en-us/azure/bot-service/dotnet/bot-builder-dotnet-add-input-hints?view=azure-bot-service-3.0) properties to ensure a high-quality speech-first experience
- [ ] I have replicated language model changes across the English, French, Italian, German, Spanish, and Chinese `.lu` files and validated that deployment is successful

#### Deployment Scripts
- [ ] I have replicated my changes in the **Virtual Assistant Template** and **Sample** projects
- [ ] I have replicated my changes in the **Skill Template** and **Sample** projects
