### PR TITLE
Declarative file includes in yeoman generator templates

### DIFF
--- a/experimental/generator-adaptive-bot/generators/app/templates/dotnet/functions/botName.csproj
+++ b/experimental/generator-adaptive-bot/generators/app/templates/dotnet/functions/botName.csproj
@@ -18,9 +18,9 @@
       <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
     </Content>
-    <None Include="Dialogs\**">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
+    <Content Include="**/*.dialog;**/*.lg;**/*.lu;**/*.qna" Exclude="$(BaseOutputPath)/**;$(BaseIntermediateOutputPath)/**">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.10" />

--- a/experimental/generator-adaptive-bot/generators/app/templates/dotnet/webapp/botName.csproj
+++ b/experimental/generator-adaptive-bot/generators/app/templates/dotnet/webapp/botName.csproj
@@ -5,10 +5,11 @@
     <AspNetCoreHostingModel>OutOfProcess</AspNetCoreHostingModel>
   </PropertyGroup>
   <ItemGroup>
-    <None Include="Dialogs\**">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>  <ItemGroup>
+    <Content Include="**/*.dialog;**/*.lg;**/*.lu;**/*.qna" Exclude="$(BaseOutputPath)/**;$(BaseIntermediateOutputPath)/**">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.8" />
     <PackageReference Include="Microsoft.Bot.Builder.Runtime" Version="4.12.0-daily.preview.20201218.196720.6ea9b09" />
   </ItemGroup>

--- a/experimental/generator-adaptive-bot/package.json
+++ b/experimental/generator-adaptive-bot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-adaptive-bot",
-  "version": "1.0.0-preview.1",
+  "version": "1.0.0-preview.2",
   "description": "Yeoman generator for creating an Adaptive Bot application built on top of the Microsoft Bot Framework SDK and runtime.",
   "files": [
     "generators"


### PR DESCRIPTION
### Purpose
As part of the build process for applications generated from the yeoman generator, we need to ensure that all declarative assets are copied to the build output location so that they can be discovered by the runtime host application.

### Changes
- Update the .csrpoj files for both the web app and Functions templates to include all declarative files (.dialog, .lg, .lu, .qna) in the build output directory at their relative locations, ignoring files from the intermediary output (obj/) and output (bin/) directories.

### Tests
Manually tested.