### PR TITLE
Generator support for custom package references

### DIFF
--- a/experimental/generator-adaptive-bot/generators/app/index.js
+++ b/experimental/generator-adaptive-bot/generators/app/index.js
@@ -88,7 +88,7 @@ module.exports = class extends Generator {
         const packageReferences = this._formatPackageReferences();
 
         this.fs.copyTpl(
-            this.templatePath(path.join(platform, integration, '**')),
+            this.templatePath(path.join(platform, integration)),
             this.destinationPath(botName),
             {
                 botName,
@@ -137,7 +137,7 @@ module.exports = class extends Generator {
         const botName = this.options.botName;
 
         this.fs.copyTpl(
-            this.templatePath(path.join('assets', '**')),
+            this.templatePath(path.join('assets')),
             this.destinationPath(botName),
             {
                 botName

--- a/experimental/generator-adaptive-bot/generators/app/index.js
+++ b/experimental/generator-adaptive-bot/generators/app/index.js
@@ -40,16 +40,31 @@ module.exports = class extends Generator {
         });
 
         this._verifyOptions();
+        this.packageReferences = this._validatePackageReferences(opts.packageReferences);
     }
 
     _verifyOptions() {
-        if (this.options.integration.toLowerCase() != INTEGRATION_WEBAPP && this.options.integration.toLowerCase() != INTEGRATION_FUNCTIONS) {
-            throw new Error(`--integration must be: ${INTEGRATION_WEBAPP} or ${INTEGRATION_FUNCTIONS}`);
+        if (this.options.integration.toLowerCase() != INTEGRATION_WEBAPP &&
+            this.options.integration.toLowerCase() != INTEGRATION_FUNCTIONS) {
+            this.env.error(`--integration must be: ${INTEGRATION_WEBAPP} or ${INTEGRATION_FUNCTIONS}`);
         }
 
         if (this.options.platform !== PLATFORM_DOTNET) {
-            throw new Error(`--platform must be: ${PLATFORM_DOTNET}`);
+            this.env.error(`--platform must be: ${PLATFORM_DOTNET}`);
         }
+    }
+
+    _validatePackageReferences(packageReferences) {
+        let result = [];
+        if (Array.isArray(packageReferences)) {
+            packageReferences.forEach((reference) => {
+                if (typeof reference == 'object' && reference.name && reference.version) {
+                    result.push(reference);
+                }
+            });
+        }
+
+        return result;
     }
 
     // 1. initializing - Your initialization methods (checking current project state, getting configs, etc)
@@ -70,12 +85,14 @@ module.exports = class extends Generator {
         const botName = this.options.botName;
         const integration = this.options.integration;
         const platform = this.options.platform;
+        const packageReferences = this._formatPackageReferences();
 
         this.fs.copyTpl(
-            this.templatePath(path.join(platform, integration,'**')),
+            this.templatePath(path.join(platform, integration, '**')),
             this.destinationPath(botName),
             {
-                botName
+                botName,
+                packageReferences
             }
         );
 
@@ -85,6 +102,15 @@ module.exports = class extends Generator {
         );
 
         this._copyDotnetSolutionFile();
+    }
+
+    _formatPackageReferences() {
+        let result = '';
+        this.packageReferences.forEach((reference) => {
+            result = result.concat(`\n    <PackageReference Include="${reference.name}" Version="${reference.version}" />`);
+        });
+
+        return result;
     }
 
     _copyDotnetSolutionFile() {
@@ -111,7 +137,7 @@ module.exports = class extends Generator {
         const botName = this.options.botName;
 
         this.fs.copyTpl(
-            this.templatePath(path.join('assets','**')),
+            this.templatePath(path.join('assets', '**')),
             this.destinationPath(botName),
             {
                 botName

--- a/experimental/generator-adaptive-bot/generators/app/templates/dotnet/functions/botName.csproj
+++ b/experimental/generator-adaptive-bot/generators/app/templates/dotnet/functions/botName.csproj
@@ -27,7 +27,7 @@
     <PackageReference Include="Microsoft.AspNetCore.OData" Version="7.5.2" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
     <PackageReference Include="Microsoft.Bot.Builder.Runtime" Version="4.12.0-daily.preview.20201218.196720.6ea9b09" />
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.7" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.7" /><%- packageReferences %>
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">

--- a/experimental/generator-adaptive-bot/generators/app/templates/dotnet/webapp/botName.csproj
+++ b/experimental/generator-adaptive-bot/generators/app/templates/dotnet/webapp/botName.csproj
@@ -11,6 +11,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.8" />
-    <PackageReference Include="Microsoft.Bot.Builder.Runtime" Version="4.12.0-daily.preview.20201218.196720.6ea9b09" />
+    <PackageReference Include="Microsoft.Bot.Builder.Runtime" Version="4.12.0-daily.preview.20201218.196720.6ea9b09" /><%- packageReferences %>
   </ItemGroup>
 </Project>

--- a/experimental/generator-adaptive-bot/package-lock.json
+++ b/experimental/generator-adaptive-bot/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "generator-botframework",
-  "version": "0.1.0",
+  "name": "generator-adaptive-bot",
+  "version": "1.0.0-preview.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/experimental/generator-adaptive-bot/package.json
+++ b/experimental/generator-adaptive-bot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-adaptive-bot",
-  "version": "1.0.0-preview.3",
+  "version": "1.0.0-preview.4",
   "description": "Yeoman generator for creating an Adaptive Bot application built on top of the Microsoft Bot Framework SDK and runtime.",
   "files": [
     "generators"

--- a/experimental/generator-adaptive-bot/package.json
+++ b/experimental/generator-adaptive-bot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-adaptive-bot",
-  "version": "1.0.0-preview.2",
+  "version": "1.0.0-preview.3",
   "description": "Yeoman generator for creating an Adaptive Bot application built on top of the Microsoft Bot Framework SDK and runtime.",
   "files": [
     "generators"
@@ -9,7 +9,7 @@
     "microsoft",
     "bot",
     "framework",
-	"adaptive",
+    "adaptive",
     "yeoman-generator"
   ],
   "dependencies": {


### PR DESCRIPTION
### Purpose
Our custom template generators will have the need to include additional package references on top of the base references added by generator-adaptive-bot. However, we do not want to add the ability to add package references to the adaptive-bot generator via CLI as it is complex.

This change enables other generators which use generator-adaptive-bot as a sub-generator to optionally supply additional package references which will be included in the generated .csproj, without exposing it as a CLI parameter.

### Changes
- Read and store packageReferences on generator instance from opts parameter supplied to generator constructor.
- Add templating token for packageReferences to both .csproj files for web app and Functions.
- Include formatted package reference string in generation of .csproj files.
- Changing error throwing to use this.env.error instead to enable better handling of errors by CLI when generator is invoked as a sub-generator.

### Tests
Manually tested.