### PR TITLE
Upgrading package name and removing path '**' bug

### DIFF
--- a/experimental/generator-adaptive-bot/generators/app/index.js
+++ b/experimental/generator-adaptive-bot/generators/app/index.js
@@ -88,7 +88,7 @@ module.exports = class extends Generator {
         const packageReferences = this._formatPackageReferences();
 
         this.fs.copyTpl(
-            this.templatePath(path.join(platform, integration, '**')),
+            this.templatePath(path.join(platform, integration)),
             this.destinationPath(botName),
             {
                 botName,
@@ -137,7 +137,7 @@ module.exports = class extends Generator {
         const botName = this.options.botName;
 
         this.fs.copyTpl(
-            this.templatePath(path.join('assets', '**')),
+            this.templatePath(path.join('assets')),
             this.destinationPath(botName),
             {
                 botName

--- a/experimental/generator-adaptive-bot/package.json
+++ b/experimental/generator-adaptive-bot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-adaptive-bot",
-  "version": "1.0.0-preview.3",
+  "version": "1.0.0-preview.4",
   "description": "Yeoman generator for creating an Adaptive Bot application built on top of the Microsoft Bot Framework SDK and runtime.",
   "files": [
     "generators"


### PR DESCRIPTION
<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
### Purpose
Fix template path declaration that has unneeded '\*\*' path declaration. Yeomen does not need '\*\*' to indicate that all contents of the directory need to be copied, instead it looks for a directory called '\*\*' leading to errors.

### Changes
- removed unneeded path symbols
- updated package version to prep for publish

### Tests
Manually tested fix in Composer and validated that removal of '**' leads to successful generator instantiation 
