### PR TITLE
Remove defaultRootDialog from generator appsettings.json

### DIFF
--- a/experimental/generator-adaptive-bot/generators/app/templates/assets/appsettings.json
+++ b/experimental/generator-adaptive-bot/generators/app/templates/assets/appsettings.json
@@ -1,7 +1,6 @@
 {
   "MicrosoftAppPassword": "",
   "MicrosoftAppId": "",
-  "defaultRootDialog": "",
   "applicationInsights": {
     "InstrumentationKey": ""
   }

--- a/experimental/generator-adaptive-bot/package.json
+++ b/experimental/generator-adaptive-bot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-adaptive-bot",
-  "version": "1.0.0-preview.4",
+  "version": "1.0.0-preview.5",
   "description": "Yeoman generator for creating an Adaptive Bot application built on top of the Microsoft Bot Framework SDK and runtime.",
   "files": [
     "generators"


### PR DESCRIPTION
<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
### Purpose
*What is the context of this pull request? Why is it being done?*

The presence of defaultRootDialog in appsettings.json causes the computed root dialog value (first .dialog file in the project directory root) to be overwritten with an empty string, causing the runtime to be unable to load the root dialog.

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*

- Removing 'defautlRootDialog' property from appsettings.json in the generator.

### Tests
*Is this covered by existing tests or new ones? If no, why not?*

N/A

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation
