### PR TITLE
Provision correct resources + allow endpoint override

### DIFF
--- a/skills/csharp/experimental/newsskill/Deployment/Resources/template.json
+++ b/skills/csharp/experimental/newsskill/Deployment/Resources/template.json
@@ -106,9 +106,17 @@
       "type": "string",
       "defaultValue": "[concat(parameters('name'), '-bing')]"
     },
+    "bingServiceSku": {
+      "type": "string",
+      "defaultValue": "S1"
+    },
     "azureMapsServiceName": {
       "type": "string",
       "defaultValue": "[concat(parameters('name'), '-maps')]"
+    },
+    "azureMapServiceSku": {
+      "type": "string",
+      "defaultValue": "S1"
     },
     "resourceTagName": {
       "type": "string",
@@ -303,6 +311,29 @@
         "[resourceId('Microsoft.CognitiveServices/accounts', parameters('luisRuntimeName'))]"
       ],
       "condition": "[parameters('useLuisAuthoring')]"
+    },
+    {
+      "apiVersion": "2020-06-10",
+      "name": "[parameters('bingServiceName')]",
+      "location": "global",
+      "type": "Microsoft.Bing/accounts",
+      "kind": "Bing.Search.v7",
+      "sku": {
+          "name": "[parameters('bingServiceSku')]"
+      },
+      "properties": {
+          "statisticsEnabled": false
+      }
+    },
+    {
+      "name": "[parameters('azureMapsServiceName')]",
+      "type": "Microsoft.Maps/accounts",
+      "apiVersion": "2018-05-01",
+      "location": "global",
+      "tags": {},
+      "sku": {
+        "name": "[parameters('azureMapServiceSku')]"
+      }
     }
   ],
   "outputs": {
@@ -349,7 +380,7 @@
     },
     "BingNewsKey": {
       "type": "string",
-      "value": "[listKeys(resourceId('Microsoft.CognitiveServices/accounts', parameters('bingServiceName')),'2017-04-18').key1]"
+      "value": "[listKeys(resourceId('Microsoft.Bing/accounts', parameters('bingServiceName')),'2020-06-10').key1]"
     },
     "AzureMapsKey": {
       "type": "string",

--- a/skills/csharp/experimental/newsskill/Dialogs/FavoriteTopicsDialog.cs
+++ b/skills/csharp/experimental/newsskill/Dialogs/FavoriteTopicsDialog.cs
@@ -26,7 +26,7 @@ namespace NewsSkill.Dialogs
         {
             var newsKey = Settings.BingNewsKey ?? throw new Exception("The BingNewsKey must be provided to use this dialog. Please provide this key in your Skill Configuration.");
 
-            _client = new NewsClient(newsKey);
+            _client = new NewsClient(Settings.BingNewsEndPoint, newsKey);
 
             var favoriteTopics = new WaterfallStep[]
             {

--- a/skills/csharp/experimental/newsskill/Dialogs/FindArticlesDialog.cs
+++ b/skills/csharp/experimental/newsskill/Dialogs/FindArticlesDialog.cs
@@ -24,7 +24,7 @@ namespace NewsSkill.Dialogs
         {
             var newsKey = Settings.BingNewsKey ?? throw new Exception("The BingNewsKey must be provided to use this dialog. Please provide this key in your Skill Configuration.");
 
-            _client = new NewsClient(newsKey);
+            _client = new NewsClient(Settings.BingNewsEndPoint, newsKey);
 
             var findArticles = new WaterfallStep[]
             {

--- a/skills/csharp/experimental/newsskill/Dialogs/TrendingArticlesDialog.cs
+++ b/skills/csharp/experimental/newsskill/Dialogs/TrendingArticlesDialog.cs
@@ -23,7 +23,7 @@ namespace NewsSkill.Dialogs
         {
             var key = Settings.BingNewsKey ?? throw new Exception("The BingNewsKey must be provided to use this dialog. Please provide this key in your Skill Configuration.");
 
-            _client = new NewsClient(key);
+            _client = new NewsClient(Settings.BingNewsEndPoint, key);
 
             var trendingArticles = new WaterfallStep[]
             {

--- a/skills/csharp/experimental/newsskill/Dialogs/TrendingArticlesDialog.cs
+++ b/skills/csharp/experimental/newsskill/Dialogs/TrendingArticlesDialog.cs
@@ -15,15 +15,13 @@ namespace NewsSkill.Dialogs
 {
     public class TrendingArticlesDialog : NewsDialogBase
     {
-        private NewsClient _client;
+        private string _newsKey;
 
         public TrendingArticlesDialog(
             IServiceProvider serviceProvider)
             : base(nameof(TrendingArticlesDialog), serviceProvider)
         {
-            var key = Settings.BingNewsKey ?? throw new Exception("The BingNewsKey must be provided to use this dialog. Please provide this key in your Skill Configuration.");
-
-            _client = new NewsClient(Settings.BingNewsEndPoint, key);
+            _newsKey = Settings.BingNewsKey ?? throw new Exception("The BingNewsKey must be provided to use this dialog. Please provide this key in your Skill Configuration.");
 
             var trendingArticles = new WaterfallStep[]
             {
@@ -40,16 +38,19 @@ namespace NewsSkill.Dialogs
         {
             var userState = await UserAccessor.GetAsync(sc.Context, () => new NewsSkillUserState(), cancellationToken: cancellationToken);
 
-            var articles = await _client.GetTrendingNewsAsync(userState.Market);
-            await sc.Context.SendActivityAsync(HeroCardResponses.ShowTrendingCards(sc.Context, TemplateManager, articles), cancellationToken);
-
-            var state = await ConvAccessor.GetAsync(sc.Context, () => new NewsSkillState(), cancellationToken: cancellationToken);
-            if (state.IsAction)
+            using (var client = new NewsClient(Settings.BingNewsEndPoint, _newsKey))
             {
-                return await sc.EndDialogAsync(GenerateNewsActionResult(articles, true), cancellationToken);
-            }
+                var articles = await client.GetTrendingNewsAsync(userState.Market);
+                await sc.Context.SendActivityAsync(HeroCardResponses.ShowTrendingCards(sc.Context, TemplateManager, articles), cancellationToken);
 
-            return await sc.EndDialogAsync(cancellationToken: cancellationToken);
+                var state = await ConvAccessor.GetAsync(sc.Context, () => new NewsSkillState(), cancellationToken: cancellationToken);
+                if (state.IsAction)
+                {
+                    return await sc.EndDialogAsync(GenerateNewsActionResult(articles, true), cancellationToken);
+                }
+
+                return await sc.EndDialogAsync(cancellationToken: cancellationToken);
+            }
         }
     }
 }

--- a/skills/csharp/experimental/newsskill/Services/BotSettings.cs
+++ b/skills/csharp/experimental/newsskill/Services/BotSettings.cs
@@ -9,6 +9,8 @@ namespace NewsSkill.Services
     {
         public string BingNewsKey { get; set; }
 
+        public string BingNewsEndPoint { get; set; }
+
         public string AzureMapsKey { get; set; }
     }
 }

--- a/skills/csharp/experimental/newsskill/Services/NewsClient.cs
+++ b/skills/csharp/experimental/newsskill/Services/NewsClient.cs
@@ -1,20 +1,48 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System;
 using System.Collections.Generic;
+using System.Net.Http;
 using System.Threading.Tasks;
 using Microsoft.Azure.CognitiveServices.Search.NewsSearch;
 using Microsoft.Azure.CognitiveServices.Search.NewsSearch.Models;
 
 namespace NewsSkill.Services
 {
-    public class NewsClient
+    public class HttpUrlRewriteHandler : DelegatingHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, System.Threading.CancellationToken cancellationToken)
+        {
+            // Rewriting the URI because for the V7 version of the API there is a
+            // migration from Cognitive Service to Bing API URL. However, the relative path
+            // is not the same. So while we can set the EndPoint in the NewsClient we cannot
+            // set the relative path for the REST calls. Doing this to effectively hijack
+            // the request and rewrite the URI to get to the right place.
+            if (request.RequestUri.Host.Contains("api.bing.microsoft.com") &&
+                request.RequestUri.AbsolutePath.Contains("bing/v7.0/news"))
+            {
+                Uri newUri = new Uri(request.RequestUri.AbsoluteUri.Replace("bing/v7.0/news", "v7.0/news"));
+
+                request.RequestUri = newUri;
+            }
+
+            return base.SendAsync(request, cancellationToken);
+        }
+    }
+
+    public class NewsClient : IDisposable
     {
         private NewsSearchClient _client;
 
-        public NewsClient(string key)
+        public NewsClient(string endPoint, string key)
         {
-            _client = new NewsSearchClient(new ApiKeyServiceClientCredentials(key));
+            _client = new NewsSearchClient(new ApiKeyServiceClientCredentials(key), new HttpUrlRewriteHandler());
+
+            if (!string.IsNullOrEmpty(endPoint))
+            {
+                _client.Endpoint = endPoint;
+            }
         }
 
         public async Task<IList<NewsArticle>> GetNewsForTopicAsync(string query, string mkt)
@@ -37,6 +65,14 @@ namespace NewsSkill.Services
             // general search by category
             var results = await _client.News.CategoryAsync(category: topic, market: mkt, count: 10);
             return results.Value;
+        }
+
+        /// <summary>
+        /// Dispose of the news http client and all the objects underneath
+        /// </summary>
+        public void Dispose()
+        {
+            this._client.Dispose();
         }
     }
 }


### PR DESCRIPTION
### Purpose
This is to fix issues with our experimental C# news skills to account for the migration of the news API from Azure Cognitive Service to Bing Service. 

It also fixes issue with resource provisioning which misses the Azure Maps and the Bing API provision.

Lastly it makes sure the news clients are properly disposing the httpclient underneath.

### Changes
We added a DelegatingHandler to intercept the HttpRequest and re-write the URL on the fly to account for the fact that the new Bing Service API URI does not have /bing in its relative path.

### Tests
Tested manually using Azure Bot Service + Bot Emulator. Issue appears unblocked.

### Feature Plan
None, but we should probably fix documentations.

### Checklist

#### General
- [x] I have commented my code, particularly in hard-to-understand areas	
- [x] I have added or updated the appropriate tests	
- [x] I have updated related documentation
