### PR TITLE
feat: Runtime Generator integration updates

### DIFF
--- a/experimental/generator-adaptive-bot/generators/app/index.js
+++ b/experimental/generator-adaptive-bot/generators/app/index.js
@@ -40,6 +40,8 @@ module.exports = class extends Generator {
         });
 
         this._verifyOptions();
+        this.applicationSettingsDirectory = this._validateApplicationSettingsDirectory(opts);
+        this.includeApplicationSettings = this._validateIncludeApplicationSettings(opts);
         this.packageReferences = this._validatePackageReferences(opts.packageReferences);
     }
 
@@ -52,6 +54,28 @@ module.exports = class extends Generator {
         if (this.options.platform !== PLATFORM_DOTNET) {
             this.env.error(`--platform must be: ${PLATFORM_DOTNET}`);
         }
+    }
+
+    _validateApplicationSettingsDirectory(opts) {
+        let result = null;
+        if ('applicationSettingsDirectory' in opts) {
+            if (opts.applicationSettingsDirectory &&
+                typeof(opts.applicationSettingsDirectory) === 'string') {
+                result = opts.applicationSettingsDirectory;
+            }
+        }
+
+        return result;
+    }
+
+    _validateIncludeApplicationSettings(opts) {
+        let result = true;
+        if ('includeApplicationSettings' in opts &&
+            typeof(opts.includeApplicationSettings) === 'boolean') {
+            result = opts.includeApplicationSettings;
+        }
+
+        return result;
     }
 
     _validatePackageReferences(packageReferences) {
@@ -86,13 +110,17 @@ module.exports = class extends Generator {
         const integration = this.options.integration;
         const platform = this.options.platform;
         const packageReferences = this._formatPackageReferences();
+        const settingsDirectory = this.applicationSettingsDirectory === null
+            ? 'null'
+            : `"${this.applicationSettingsDirectory}"`;
 
         this.fs.copyTpl(
             this.templatePath(path.join(platform, integration)),
             this.destinationPath(botName),
             {
                 botName,
-                packageReferences
+                packageReferences,
+                settingsDirectory
             }
         );
 
@@ -136,12 +164,19 @@ module.exports = class extends Generator {
     _copyAssets() {
         const botName = this.options.botName;
 
-        this.fs.copyTpl(
-            this.templatePath(path.join('assets')),
-            this.destinationPath(botName),
-            {
-                botName
-            }
-        );
+        const assetFileNames = ['NuGet.config', 'runtime.json'];
+        if (this.includeApplicationSettings) {
+            assetFileNames.push('appsettings.json');
+        }
+
+        for (const assetFileName of assetFileNames) {
+            this.fs.copyTpl(
+                this.templatePath(path.join('assets', assetFileName)),
+                this.destinationPath(botName),
+                {
+                    botName
+                }
+            );
+        }
     }
 };

--- a/experimental/generator-adaptive-bot/generators/app/index.js
+++ b/experimental/generator-adaptive-bot/generators/app/index.js
@@ -116,7 +116,7 @@ module.exports = class extends Generator {
 
         this.fs.copyTpl(
             this.templatePath(path.join(platform, integration)),
-            this.destinationPath(path.join(botName)),
+            this.destinationPath(botName),
             {
                 botName,
                 packageReferences,

--- a/experimental/generator-adaptive-bot/generators/app/index.js
+++ b/experimental/generator-adaptive-bot/generators/app/index.js
@@ -116,7 +116,7 @@ module.exports = class extends Generator {
 
         this.fs.copyTpl(
             this.templatePath(path.join(platform, integration)),
-            this.destinationPath(botName),
+            this.destinationPath(path.join(botName)),
             {
                 botName,
                 packageReferences,
@@ -172,7 +172,7 @@ module.exports = class extends Generator {
         for (const assetFileName of assetFileNames) {
             this.fs.copyTpl(
                 this.templatePath(path.join('assets', assetFileName)),
-                this.destinationPath(botName),
+                this.destinationPath(path.join(botName, assetFileName)),
                 {
                     botName
                 }

--- a/experimental/generator-adaptive-bot/generators/app/templates/assets/NuGet.config
+++ b/experimental/generator-adaptive-bot/generators/app/templates/assets/NuGet.config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="botbuilder-v4-dotnet-daily" value="https://botbuilder.myget.org/F/botbuilder-v4-dotnet-daily/api/v3/index.json" protocolVersion="3" />
+  </packageSources>
+</configuration>

--- a/experimental/generator-adaptive-bot/generators/app/templates/dotnet/functions/Startup.cs
+++ b/experimental/generator-adaptive-bot/generators/app/templates/dotnet/functions/Startup.cs
@@ -15,10 +15,17 @@ namespace <%= botName %>
 
         public override void ConfigureAppConfiguration(IFunctionsConfigurationBuilder configurationBuilder)
         {
-            var isDevelopment = string.Equals(configurationBuilder.GetContext().EnvironmentName, Microsoft.Extensions.Hosting.Environments.Development, StringComparison.OrdinalIgnoreCase);
-            var applicationRoot = configurationBuilder.GetContext().ApplicationRootPath;
+            string applicationRoot = configurationBuilder.GetContext().ApplicationRootPath;
+            string settingsDirectory = <%- settingsDirectory %>;
+            bool isDevelopment = string.Equals(
+                configurationBuilder.GetContext().EnvironmentName,
+                Microsoft.Extensions.Hosting.Environments.Development,
+                StringComparison.OrdinalIgnoreCase);
 
-            configurationBuilder.ConfigurationBuilder.AddBotRuntimeConfiguration(applicationRoot, isDevelopment);
+            configurationBuilder.ConfigurationBuilder.AddBotRuntimeConfiguration(
+                applicationRoot,
+                settingsDirectory,
+                isDevelopment);
         }
     }
 }

--- a/experimental/generator-adaptive-bot/generators/app/templates/dotnet/functions/botName.csproj
+++ b/experimental/generator-adaptive-bot/generators/app/templates/dotnet/functions/botName.csproj
@@ -26,7 +26,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.10" />
     <PackageReference Include="Microsoft.AspNetCore.OData" Version="7.5.2" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
-    <PackageReference Include="Microsoft.Bot.Builder.Runtime" Version="4.12.0-daily.preview.20201218.196720.6ea9b09" />
+    <PackageReference Include="Microsoft.Bot.Builder.Runtime" Version="4.12.0-daily.preview.20210126.206273.e467c25" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.7" /><%- packageReferences %>
   </ItemGroup>
   <ItemGroup>

--- a/experimental/generator-adaptive-bot/generators/app/templates/dotnet/functions/botName.csproj
+++ b/experimental/generator-adaptive-bot/generators/app/templates/dotnet/functions/botName.csproj
@@ -18,7 +18,7 @@
       <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
     </Content>
-    <Content Include="**/*.dialog;**/*.lg;**/*.lu;**/*.qna" Exclude="$(BaseOutputPath)/**;$(BaseIntermediateOutputPath)/**">
+    <Content Include="**/*.blu;**/*.dialog;**/*.lg;**/*.lu;**/*.qna" Exclude="$(BaseOutputPath)/**;$(BaseIntermediateOutputPath)/**">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>

--- a/experimental/generator-adaptive-bot/generators/app/templates/dotnet/webapp/Program.cs
+++ b/experimental/generator-adaptive-bot/generators/app/templates/dotnet/webapp/Program.cs
@@ -25,6 +25,8 @@ namespace <%= botName %>
                         applicationRoot,
                         settingsDirectory,
                         env.IsDevelopment());
+
+                    builder.AddCommandLine(args);
                 })
                 .ConfigureWebHostDefaults(webBuilder =>
                 {

--- a/experimental/generator-adaptive-bot/generators/app/templates/dotnet/webapp/Program.cs
+++ b/experimental/generator-adaptive-bot/generators/app/templates/dotnet/webapp/Program.cs
@@ -15,17 +15,20 @@ namespace <%= botName %>
 
         public static IHostBuilder CreateHostBuilder(string[] args) =>
             Host.CreateDefaultBuilder(args)
-            .ConfigureAppConfiguration((hostingContext, builder) =>
-            {
-                IHostEnvironment env = hostingContext.HostingEnvironment;
-                var applicationRoot = AppDomain.CurrentDomain.BaseDirectory;
+                .ConfigureAppConfiguration((hostingContext, builder) =>
+                {
+                    IHostEnvironment env = hostingContext.HostingEnvironment;
+                    string applicationRoot = AppDomain.CurrentDomain.BaseDirectory;
+                    string settingsDirectory = <%- settingsDirectory %>;
 
-                builder.AddBotRuntimeConfiguration(applicationRoot, env.IsDevelopment());
-                builder.AddCommandLine(args);
-            })
-            .ConfigureWebHostDefaults(webBuilder =>
-            {
-                webBuilder.UseStartup<Startup>();
-            });
+                    builder.AddBotRuntimeConfiguration(
+                        applicationRoot,
+                        settingsDirectory,
+                        env.IsDevelopment());
+                })
+                .ConfigureWebHostDefaults(webBuilder =>
+                {
+                    webBuilder.UseStartup<Startup>();
+                });
     }
 }

--- a/experimental/generator-adaptive-bot/generators/app/templates/dotnet/webapp/botName.csproj
+++ b/experimental/generator-adaptive-bot/generators/app/templates/dotnet/webapp/botName.csproj
@@ -11,6 +11,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.8" />
-    <PackageReference Include="Microsoft.Bot.Builder.Runtime" Version="4.12.0-daily.preview.20201218.196720.6ea9b09" /><%- packageReferences %>
+    <PackageReference Include="Microsoft.Bot.Builder.Runtime" Version="4.12.0-daily.preview.20210126.206273.e467c25" /><%- packageReferences %>
   </ItemGroup>
 </Project>

--- a/experimental/generator-adaptive-bot/generators/app/templates/dotnet/webapp/botName.csproj
+++ b/experimental/generator-adaptive-bot/generators/app/templates/dotnet/webapp/botName.csproj
@@ -5,7 +5,7 @@
     <AspNetCoreHostingModel>OutOfProcess</AspNetCoreHostingModel>
   </PropertyGroup>
   <ItemGroup>
-    <Content Include="**/*.dialog;**/*.lg;**/*.lu;**/*.qna" Exclude="$(BaseOutputPath)/**;$(BaseIntermediateOutputPath)/**">
+    <Content Include="**/*.blu;**/*.dialog;**/*.lg;**/*.lu;**/*.qna" Exclude="$(BaseOutputPath)/**;$(BaseIntermediateOutputPath)/**">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>

--- a/experimental/generator-adaptive-bot/package-lock.json
+++ b/experimental/generator-adaptive-bot/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-adaptive-bot",
-  "version": "1.0.0-preview.3",
+  "version": "1.0.0-preview.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/experimental/generator-adaptive-bot/package.json
+++ b/experimental/generator-adaptive-bot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-adaptive-bot",
-  "version": "1.0.0-preview.5",
+  "version": "1.0.0-preview.6",
   "description": "Yeoman generator for creating an Adaptive Bot application built on top of the Microsoft Bot Framework SDK and runtime.",
   "files": [
     "generators"


### PR DESCRIPTION
### Purpose
Following validation of the runtime generator integration in Composer, making a few adjustments to ensure we can fully build, run and publish end-to-end out of the box.

### Changes
- Enable specifying of the appsettings.json directory to be used by invoking generators through the 'applicationSettingsDirectory' option.
- Enable exclusion of the default appsettings.json file through the 'includeApplicationSettings' option.
- Include NuGet.config as part of app generation with addition of Bot Framework SDK daily package source.
- Update to .csproj files to include .blu files in build output to support Orchestrator recognizer.

### Tests
Manual validation required following update to Microsoft.Bot.Builder.Runtime package once it is available from daily builds.
