### PR TITLE
fix: wrong id format in 'todoskill' bot

### DIFF
--- a/skills/declarative/todoskill/dialogs/AddToDo/AddToDo.dialog
+++ b/skills/declarative/todoskill/dialogs/AddToDo/AddToDo.dialog
@@ -6,7 +6,7 @@
   },
   "autoEndDialog": "true",
   "defaultResultProperty": "dialog.result",
-  "recognizer": "AddToDo.lu",
+  "recognizer": "AddToDo.lu.qna",
   "triggers": [
     {
       "$kind": "Microsoft.OnBeginDialog",
@@ -18,7 +18,7 @@
         {
           "$kind": "Microsoft.BeginDialog",
           "$designer": {
-            "id": "Jk-nXo"
+            "id": "Jk_nXo"
           },
           "dialog": "SetListTypePage"
         },
@@ -186,7 +186,7 @@
             {
               "$kind": "Microsoft.EndDialog",
               "$designer": {
-                "id": "-fYnxb"
+                "id": "_fYnxb"
               }
             }
           ],
@@ -205,7 +205,7 @@
             {
               "$kind": "Microsoft.ReplaceDialog",
               "$designer": {
-                "id": "8nNkT-"
+                "id": "8nNkT_"
               },
               "dialog": "ShowToDo",
               "options": {
@@ -252,5 +252,6 @@
       ]
     }
   ],
-  "generator": "AddToDo.lg"
+  "generator": "AddToDo.lg",
+  "id": "AddToDo"
 }

--- a/skills/declarative/todoskill/dialogs/AddToDo/AddToDo.dialog
+++ b/skills/declarative/todoskill/dialogs/AddToDo/AddToDo.dialog
@@ -6,7 +6,7 @@
   },
   "autoEndDialog": "true",
   "defaultResultProperty": "dialog.result",
-  "recognizer": "AddToDo.lu.qna",
+  "recognizer": "AddToDo.lu",
   "triggers": [
     {
       "$kind": "Microsoft.OnBeginDialog",
@@ -252,6 +252,5 @@
       ]
     }
   ],
-  "generator": "AddToDo.lg",
-  "id": "AddToDo"
+  "generator": "AddToDo.lg"
 }

--- a/skills/declarative/todoskill/dialogs/AddToListOutlook/AddToListOutlook.dialog
+++ b/skills/declarative/todoskill/dialogs/AddToListOutlook/AddToListOutlook.dialog
@@ -32,7 +32,7 @@
         {
           "$kind": "Microsoft.SetProperties",
           "$designer": {
-            "id": "bT-rCD"
+            "id": "bT_rCD"
           },
           "assignments": [
             {

--- a/skills/declarative/todoskill/dialogs/CorrectPage/CorrectPage.dialog
+++ b/skills/declarative/todoskill/dialogs/CorrectPage/CorrectPage.dialog
@@ -64,7 +64,7 @@
                 {
                   "$kind": "Microsoft.SetProperties",
                   "$designer": {
-                    "id": "vA-Tkg"
+                    "id": "vA_Tkg"
                   },
                   "assignments": [
                     {

--- a/skills/declarative/todoskill/dialogs/DeleteInListOutlook/DeleteInListOutlook.dialog
+++ b/skills/declarative/todoskill/dialogs/DeleteInListOutlook/DeleteInListOutlook.dialog
@@ -24,7 +24,7 @@
         {
           "$kind": "Microsoft.Foreach",
           "$designer": {
-            "id": "2lh-BU"
+            "id": "2lh_BU"
           },
           "itemsProperty": "dialog.tasks",
           "actions": [

--- a/skills/declarative/todoskill/dialogs/DeleteToDo/DeleteToDo.dialog
+++ b/skills/declarative/todoskill/dialogs/DeleteToDo/DeleteToDo.dialog
@@ -17,7 +17,7 @@
         {
           "$kind": "Microsoft.BeginDialog",
           "$designer": {
-            "id": "--RowA"
+            "id": "__RowA"
           },
           "dialog": "SetListTypePage"
         },
@@ -93,7 +93,7 @@
         {
           "$kind": "Microsoft.SetProperties",
           "$designer": {
-            "id": "K-bSF9"
+            "id": "K_bSF9"
           },
           "assignments": [
             {

--- a/skills/declarative/todoskill/dialogs/GetToDos/GetToDos.dialog
+++ b/skills/declarative/todoskill/dialogs/GetToDos/GetToDos.dialog
@@ -57,7 +57,7 @@
         {
           "$kind": "Microsoft.EndDialog",
           "$designer": {
-            "id": "_utP-l"
+            "id": "_utP_l"
           },
           "value": "=dialog.result"
         }

--- a/skills/declarative/todoskill/dialogs/MarkInListOutlook/MarkInListOutlook.dialog
+++ b/skills/declarative/todoskill/dialogs/MarkInListOutlook/MarkInListOutlook.dialog
@@ -17,7 +17,7 @@
         {
           "$kind": "Microsoft.BeginDialog",
           "$designer": {
-            "id": "-AKi_C"
+            "id": "_AKi_C"
           },
           "dialog": "OAuth"
         },

--- a/skills/declarative/todoskill/dialogs/MarkToDo/MarkToDo.dialog
+++ b/skills/declarative/todoskill/dialogs/MarkToDo/MarkToDo.dialog
@@ -120,7 +120,7 @@
                 {
                   "$kind": "Microsoft.IfCondition",
                   "$designer": {
-                    "id": "x--xlA"
+                    "id": "x__xlA"
                   },
                   "condition": "=dialog.taskContent == null",
                   "actions": [

--- a/skills/declarative/todoskill/dialogs/OAuth/OAuth.dialog
+++ b/skills/declarative/todoskill/dialogs/OAuth/OAuth.dialog
@@ -52,7 +52,7 @@
         {
           "$kind": "Microsoft.EndDialog",
           "$designer": {
-            "id": "cz-kXr"
+            "id": "cz_kXr"
           },
           "value": "=turn.token"
         }

--- a/skills/declarative/todoskill/dialogs/OutlookGetOrCreateTaskFolderAsync/OutlookGetOrCreateTaskFolderAsync.dialog
+++ b/skills/declarative/todoskill/dialogs/OutlookGetOrCreateTaskFolderAsync/OutlookGetOrCreateTaskFolderAsync.dialog
@@ -40,7 +40,7 @@
             {
               "$kind": "Microsoft.EditArray",
               "$designer": {
-                "id": "DXIBQ-"
+                "id": "DXIBQ_"
               },
               "changeType": "push",
               "itemsProperty": "turn.listToId",
@@ -51,7 +51,7 @@
         {
           "$kind": "Microsoft.EndDialog",
           "$designer": {
-            "id": "cfZNG-"
+            "id": "cfZNG_"
           },
           "value": "=dialog.id"
         }

--- a/skills/declarative/todoskill/dialogs/OutlookGetTaskFoldersAsync/OutlookGetTaskFoldersAsync.dialog
+++ b/skills/declarative/todoskill/dialogs/OutlookGetTaskFoldersAsync/OutlookGetTaskFoldersAsync.dialog
@@ -1,7 +1,7 @@
 {
   "$kind": "Microsoft.AdaptiveDialog",
   "$designer": {
-    "id": "-E55SX",
+    "id": "_E55SX",
     "name": "OutlookGetTaskFoldersAsync"
   },
   "autoEndDialog": "true",

--- a/skills/declarative/todoskill/dialogs/PostAsync/PostAsync.dialog
+++ b/skills/declarative/todoskill/dialogs/PostAsync/PostAsync.dialog
@@ -11,7 +11,7 @@
       "$kind": "Microsoft.OnBeginDialog",
       "$designer": {
         "name": "BeginDialog",
-        "id": "DBpVA-"
+        "id": "DBpVA_"
       },
       "actions": [
         {
@@ -33,7 +33,7 @@
         {
           "$kind": "Microsoft.TraceActivity",
           "$designer": {
-            "id": "g37gp-"
+            "id": "g37gp_"
           }
         },
         {

--- a/skills/declarative/todoskill/dialogs/ShowNextPrev/ShowNextPrev.dialog
+++ b/skills/declarative/todoskill/dialogs/ShowNextPrev/ShowNextPrev.dialog
@@ -45,7 +45,7 @@
                 {
                   "$kind": "Microsoft.SetProperties",
                   "$designer": {
-                    "id": "mlvo2-"
+                    "id": "mlvo2_"
                   },
                   "assignments": [
                     {


### PR DESCRIPTION
<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
### Purpose
*What is the context of this pull request? Why is it being done?*
Wrong id format in old bots could lead to unhappy experience in Composer.
Refs: https://github.com/microsoft/BotFramework-Composer/issues/5421
### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*

`-` -> `_`
### Tests
*Is this covered by existing tests or new ones? If no, why not?*

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation
