### PR TITLE
DevOps: Stop triggering all builds on any PR

### DIFF
--- a/build/yaml/pipelines/calendar.yml
+++ b/build/yaml/pipelines/calendar.yml
@@ -10,6 +10,14 @@ trigger:
     include:
       - packages/CalendarSkill
 
+pr:
+  branches:
+    include:
+      - main
+  paths:
+    include:
+      - packages/CalendarSkill
+
 pool: 
   vmImage: 'windows-2019'
   

--- a/build/yaml/pipelines/calendar.yml
+++ b/build/yaml/pipelines/calendar.yml
@@ -5,7 +5,6 @@ trigger:
   branches:
     include:
       - main
-      - preview/*
   paths:
     include:
       - packages/CalendarSkill

--- a/build/yaml/pipelines/generator-adaptive-bot.yml
+++ b/build/yaml/pipelines/generator-adaptive-bot.yml
@@ -5,7 +5,14 @@ trigger:
   branches:
     include:
       - main
-      - preview/*
+  paths:
+    include:
+      - generators/generator-adaptive-bot
+
+pr:
+  branches:
+    include:
+      - main
   paths:
     include:
       - generators/generator-adaptive-bot

--- a/build/yaml/pipelines/generator-conversational-core.yml
+++ b/build/yaml/pipelines/generator-conversational-core.yml
@@ -5,11 +5,18 @@ trigger:
   branches:
     include:
       - main
-      - preview/*
   paths:
     include:
       - generators/generator-conversational-core
 
+pr:
+  branches:
+    include:
+      - main
+  paths:
+    include:
+      - generators/generator-conversational-core
+ 
 pool: 
   vmImage: 'windows-2019'
   

--- a/build/yaml/pipelines/generator-empty-bot.yml
+++ b/build/yaml/pipelines/generator-empty-bot.yml
@@ -1,0 +1,29 @@
+name: $(Build.DefinitionName)-$(SourceBranchName)-$(Date:yyyyMMdd)$(Rev:.r)
+
+trigger:
+  batch: true
+  branches:
+    include:
+      - main
+  paths:
+    include:
+      - generators/generator-empty-bot
+
+pr:
+  branches:
+    include:
+      - main
+  paths:
+    include:
+      - generators/generator-empty-bot
+
+pool: 
+  vmImage: 'windows-2019'
+
+extends:
+  template: ../templates/component-template.yml
+  parameters:
+      componentType: generator
+
+variables:
+  WorkingDirectory: 'generators/generator-empty-bot'

--- a/build/yaml/pipelines/helpandcancel.yml
+++ b/build/yaml/pipelines/helpandcancel.yml
@@ -5,7 +5,14 @@ trigger:
   branches:
     include:
       - main
-      - preview/*
+  paths:
+    include:
+      - packages/HelpAndCancel
+
+pr:
+  branches:
+    include:
+      - main
   paths:
     include:
       - packages/HelpAndCancel

--- a/build/yaml/pipelines/msgraph.yml
+++ b/build/yaml/pipelines/msgraph.yml
@@ -5,7 +5,14 @@ trigger:
   branches:
     include:
       - main
-      - preview/*
+  paths:
+    include:
+      - packages/MsGraph
+
+pr:
+  branches:
+    include:
+      - main
   paths:
     include:
       - packages/MsGraph

--- a/build/yaml/pipelines/starter-pipeline.yml
+++ b/build/yaml/pipelines/starter-pipeline.yml
@@ -5,7 +5,14 @@ trigger:
   branches:
     include:
       - main
-      - preview/*
+  paths:
+    include:
+      - {YOUR_WORKING_DIRECTORY}
+
+pr:
+  branches:
+    include:
+      - main
   paths:
     include:
       - {YOUR_WORKING_DIRECTORY}

--- a/build/yaml/pipelines/welcome.yml
+++ b/build/yaml/pipelines/welcome.yml
@@ -5,7 +5,14 @@ trigger:
   branches:
     include:
       - main
-      - preview/*
+  paths:
+    include:
+      - packages/Welcome
+
+pr:
+  branches:
+    include:
+      - main
   paths:
     include:
       - packages/Welcome


### PR DESCRIPTION
<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
### Purpose
*What is the context of this pull request? Why is it being done?*
#480 

All builds are running on any PR, this will explicitly only run buils scoped down to component paths in PRs against the main branch

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*
- Add PR trigger for all pipelines
- Add generator-empty-bot pipeline
- Remove CI rule on updating `preview/*` branches
