### PR TITLE
updating read me for templates to more favorable format for Composer

### DIFF
--- a/docs/qnaTemplateReadMe.md
+++ b/docs/qnaTemplateReadMe.md
@@ -1,6 +1,12 @@
-# QNA Empty Bot Template
-Yeoman generator for instantiating a bot template using the generator-empty-bot npm package.
+## QNA Template
 
-When used in Composer this template will instantiate an instance of the empty bot template and then route the user to add the QNA knowledge base through the Composer client.
+Instantiates a Bot Framework bot using the [component model](https://aka.ms/ComponentTemplateDocumentation). This template instantiates an empty bot with the option to configure a QNA source during creation time. Following qna configuration you are left with an empty bot that can handle answering questions that are specified in your qna source.
 
-The resulting bot template will have an empty bot implementation with a QNA intent configured that routes to the users uploaded QNA knowledge base. 
+### Packages
+No packages. 
+
+### Languages
+English.
+
+### Azure Resource Deployment
+This template does not rely on any additional Azure Resources.

--- a/generators/generator-conversational-core/README.md
+++ b/generators/generator-conversational-core/README.md
@@ -1,12 +1,11 @@
-# Generator-conversational-core
-Yeoman generator for instantiating a bot template using the Conversational Core components.
+## Conversational Core
 
-Bot framework Composer is configured to consume and instantiate a bot template using this Yeomen generator. 
+Instantiates a Bot Framework bot using the [component model](https://aka.ms/ComponentTemplateDocumentation) that includes the following packages and respective functionality.
+### Packages
+[General intent handling](https://www.nuget.org/packages/Preview.Bot.Component.GeneralIntent/), [Greeting dialog](https://www.nuget.org/packages/Preview.Bot.Component.GreetingDialog/), [Onboarding dialog](https://www.nuget.org/packages/Preview.Bot.Component.OnboardingDialog/), [Unknown intent dialog](https://www.nuget.org/packages/Preview.Bot.Component.UnknownIntentDialog/).
 
-The resulting bot template will have the following packages + routing logic to these packages.
+### Languages
+English.
 
-# packages
-- Preview.Bot.Component.GeneralIntent
-- Preview.Bot.Component.GreetingDialog
-- Preview.Bot.Component.OnboardingDialog
-- Preview.Bot.Component.UnknownIntentDialog
+### Azure Resource Deployment
+This template does not rely on any additional Azure Resources.

--- a/generators/generator-conversational-core/package.json
+++ b/generators/generator-conversational-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-conversational-core",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "description": "Preview conversational core package for TESTING ONLY",
   "main": "./generators/app/templates/ConversationalCore/index.js",
   "dependencies": {

--- a/generators/generator-empty-bot/README.md
+++ b/generators/generator-empty-bot/README.md
@@ -1,10 +1,12 @@
-# generator-empty-bot
-Yeoman generator for instantiating a bot template using the generator-empty-bot components.
+## Empty Bot
 
-Bot framework Composer is configured to consume and instantiate a bot template using this Yeomen generator. 
+Instantiates a Bot Framework bot using the [component model](https://aka.ms/ComponentTemplateDocumentation). This template instantiates an empty bot with no dependent packages.
 
-The resulting bot template will have the following packages + routing logic to these packages.
+### Packages
+No packages. 
 
-# packages
+### Languages
+English.
 
-This empty bot template has no dependent component packages
+### Azure Resource Deployment
+This template does not rely on any additional Azure Resources.

--- a/generators/generator-empty-bot/package.json
+++ b/generators/generator-empty-bot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-empty-bot",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "",
   "main": "./generators/app/templates/index.js",
   "dependencies": {


### PR DESCRIPTION

<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
### Purpose
*What is the context of this pull request? Why is it being done?*

This PR updates the read me for the three templates that will be shipped in R12 (Conversational core, empty bot and qna template). 

These new read mes are in a more favorable format for rendering within Composer's 'select template' view
