### PR TITLE
feat: Add Orchestrator Recognizer plugin component

### DIFF
--- a/build/yaml/pipelines/recognizers-orchestrator.yml
+++ b/build/yaml/pipelines/recognizers-orchestrator.yml
@@ -1,0 +1,30 @@
+name: $(Build.DefinitionName)-$(SourceBranchName)-$(Date:yyyyMMdd)$(Rev:.r)
+
+trigger:
+  batch: true
+  branches:
+    include:
+      - main
+  paths:
+    include:
+      - packages/Recognizers.Orchestrator
+
+pr:
+  branches:
+    include:
+      - main
+  paths:
+    include:
+      - packages/Recognizers.Orchestrator
+
+pool: 
+  vmImage: 'windows-2019'
+
+extends:
+  template: ../templates/component-template.yml
+  parameters:
+      componentType: codeExtension
+
+variables:
+  WorkingDirectory: 'packages/Recognizers.Orchestrator'
+  BuildConfiguration: 'Release'

--- a/packages/Microsoft.Bot.Components.sln
+++ b/packages/Microsoft.Bot.Components.sln
@@ -7,6 +7,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Component.Cal
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Component.MsGraph", "MsGraph\Microsoft.Bot.Component.MsGraph.csproj", "{415A7327-9FA1-4354-8104-5900A8882582}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.Bot.Components.Recognizers.Orchestrator", "Recognizers.Orchestrator\Microsoft.Bot.Components.Recognizers.Orchestrator.csproj", "{96DBF818-1B13-479A-B3D8-8932E4215F76}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -21,6 +23,10 @@ Global
 		{415A7327-9FA1-4354-8104-5900A8882582}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{415A7327-9FA1-4354-8104-5900A8882582}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{415A7327-9FA1-4354-8104-5900A8882582}.Release|Any CPU.Build.0 = Release|Any CPU
+		{96DBF818-1B13-479A-B3D8-8932E4215F76}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{96DBF818-1B13-479A-B3D8-8932E4215F76}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{96DBF818-1B13-479A-B3D8-8932E4215F76}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{96DBF818-1B13-479A-B3D8-8932E4215F76}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/packages/Recognizers.Orchestrator/BotPlugin.cs
+++ b/packages/Recognizers.Orchestrator/BotPlugin.cs
@@ -1,0 +1,17 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Bot.Builder;
+using Microsoft.Bot.Builder.AI.Orchestrator;
+using Microsoft.Bot.Builder.Runtime.Plugins;
+
+namespace Microsoft.Bot.Components.Recognizers.Orchestrator
+{
+    public class BotPlugin : IBotPlugin
+    {
+        public void Load(IBotPluginLoadContext context)
+        {
+            ComponentRegistration.Add(new OrchestratorComponentRegistration());
+        }
+    }
+}

--- a/packages/Recognizers.Orchestrator/Microsoft.Bot.Components.Recognizers.Orchestrator.csproj
+++ b/packages/Recognizers.Orchestrator/Microsoft.Bot.Components.Recognizers.Orchestrator.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <PackageId>Microsoft.Bot.Components.Recognizers.Orchestrator</PackageId>
+    <VersionPrefix>1.0.0</VersionPrefix>
+    <VersionSuffix>preview.4</VersionSuffix>
+    <Description>Plugin component for Microsoft.Bot.Builder.Runtime to register Orchestrator adaptive recognizer.</Description>
+    <Summary>Plugin component for Microsoft.Bot.Builder.Runtime to register Orchestrator adaptive recognizer.</Summary>
+    <Company>Microsoft</Company>
+    <Authors>Microsoft</Authors>
+    <Product>Microsoft Bot Builder SDK</Product>
+    <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Bot.Builder.AI.Orchestrator" Version="4.12.0-daily.preview.20210208.211224.35d8ba0" />
+    <PackageReference Include="Microsoft.Bot.Builder.Runtime.Plugins" Version="4.12.0-daily.preview.20210208.211224.35d8ba0" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
### Purpose
Adding the Orchestrator recognizer plugin to the official components solution as part of completing #492.

### Changes
- Add Microsoft.Bot.Components.Recognizers.Orchestrator project to packages/Microsoft.Bot.Components solution.
- Add build pipeline yaml files for Orchestrator pacakge.

### Tests
Manually verified through integration testing in Composer.
