### PR TITLE
feat: generator-adaptive-bot plugin support

### DIFF
--- a/generators/generator-adaptive-bot/generators/app/templates/assets/NuGet.config
+++ b/generators/generator-adaptive-bot/generators/app/templates/assets/NuGet.config
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
-    <clear/>
-    <add key="BotBuilder.myget.org" value="https://botbuilder.myget.org/F/botbuilder-v4-dotnet-daily/api/v3/index.json" protocolVersion="3" />
+    <add key="botbuilder-v4-dotnet-daily" value="https://botbuilder.myget.org/F/botbuilder-v4-dotnet-daily/api/v3/index.json" protocolVersion="3" />
+    <add key="botpackages" value="https://fuselabs.pkgs.visualstudio.com/566d503b-55c0-46b5-9e83-8a4efa7f9efa/_packaging/botpackages/nuget/v3/index.json" />
   </packageSources>
 </configuration>

--- a/generators/generator-adaptive-bot/generators/app/templates/assets/NuGet.config
+++ b/generators/generator-adaptive-bot/generators/app/templates/assets/NuGet.config
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
-    <add key="botbuilder-v4-dotnet-daily" value="https://botbuilder.myget.org/F/botbuilder-v4-dotnet-daily/api/v3/index.json" protocolVersion="3" />
-    <add key="botpackages" value="https://fuselabs.pkgs.visualstudio.com/566d503b-55c0-46b5-9e83-8a4efa7f9efa/_packaging/botpackages/nuget/v3/index.json" />
+    <clear/>
+    <add key="BotBuilder.myget.org" value="https://botbuilder.myget.org/F/botbuilder-v4-dotnet-daily/api/v3/index.json" protocolVersion="3" />
   </packageSources>
 </configuration>

--- a/generators/generator-adaptive-bot/generators/app/templates/assets/runtime.json
+++ b/generators/generator-adaptive-bot/generators/app/templates/assets/runtime.json
@@ -2,8 +2,7 @@
   "adapter":
   {
     "$kind": "Microsoft.BotCoreAdapter",
-    "middleware": [
-    ]
+    "middleware": []
   },
   "channel": {
     "$kind": "Microsoft.DeclarativeChannelProvider",
@@ -15,6 +14,7 @@
     "applicationPassword": "=MicrosoftAppPassword"
   },
   "defaultLocale": "en-US",
+  "plugins": [],
   "rootDialog": "=defaultRootDialog",
   "storage": {
     "$kind": "Microsoft.MemoryStorage"

--- a/generators/generator-adaptive-bot/generators/app/templates/dotnet/functions/Startup.cs
+++ b/generators/generator-adaptive-bot/generators/app/templates/dotnet/functions/Startup.cs
@@ -17,15 +17,10 @@ namespace <%= botName %>
         {
             string applicationRoot = configurationBuilder.GetContext().ApplicationRootPath;
             string settingsDirectory = <%- settingsDirectory %>;
-            bool isDevelopment = string.Equals(
-                configurationBuilder.GetContext().EnvironmentName,
-                Microsoft.Extensions.Hosting.Environments.Development,
-                StringComparison.OrdinalIgnoreCase);
 
             configurationBuilder.ConfigurationBuilder.AddBotRuntimeConfiguration(
                 applicationRoot,
-                settingsDirectory,
-                isDevelopment);
+                settingsDirectory);
         }
     }
 }

--- a/generators/generator-adaptive-bot/generators/app/templates/dotnet/functions/botName.csproj
+++ b/generators/generator-adaptive-bot/generators/app/templates/dotnet/functions/botName.csproj
@@ -26,7 +26,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.10" />
     <PackageReference Include="Microsoft.AspNetCore.OData" Version="7.5.2" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
-    <PackageReference Include="Microsoft.Bot.Builder.Runtime" Version="4.12.0-daily.preview.20210126.206273.e467c25" />
+    <PackageReference Include="Microsoft.Bot.Builder.Runtime" Version="4.12.0-daily.preview.20210208.211224.35d8ba0" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.7" /><%- packageReferences %>
   </ItemGroup>
   <ItemGroup>

--- a/generators/generator-adaptive-bot/generators/app/templates/dotnet/webapp/Program.cs
+++ b/generators/generator-adaptive-bot/generators/app/templates/dotnet/webapp/Program.cs
@@ -17,14 +17,12 @@ namespace <%= botName %>
             Host.CreateDefaultBuilder(args)
                 .ConfigureAppConfiguration((hostingContext, builder) =>
                 {
-                    IHostEnvironment env = hostingContext.HostingEnvironment;
                     string applicationRoot = AppDomain.CurrentDomain.BaseDirectory;
                     string settingsDirectory = <%- settingsDirectory %>;
 
                     builder.AddBotRuntimeConfiguration(
                         applicationRoot,
-                        settingsDirectory,
-                        env.IsDevelopment());
+                        settingsDirectory);
 
                     builder.AddCommandLine(args);
                 })

--- a/generators/generator-adaptive-bot/generators/app/templates/dotnet/webapp/botName.csproj
+++ b/generators/generator-adaptive-bot/generators/app/templates/dotnet/webapp/botName.csproj
@@ -11,6 +11,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.8" />
-    <PackageReference Include="Microsoft.Bot.Builder.Runtime" Version="4.12.0-daily.preview.20210126.206273.e467c25" /><%- packageReferences %>
+    <PackageReference Include="Microsoft.Bot.Builder.Runtime" Version="4.12.0-daily.preview.20210208.211224.35d8ba0" /><%- packageReferences %>
   </ItemGroup>
 </Project>

--- a/generators/generator-adaptive-bot/package-lock.json
+++ b/generators/generator-adaptive-bot/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-adaptive-bot",
-  "version": "1.0.0-preview.6",
+  "version": "1.0.0-preview.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/generators/generator-adaptive-bot/package.json
+++ b/generators/generator-adaptive-bot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-adaptive-bot",
-  "version": "1.0.0-preview.9",
+  "version": "1.0.0-preview.10",
   "description": "Yeoman generator for creating an Adaptive Bot application built on top of the Microsoft Bot Framework SDK and runtime.",
   "files": [
     "generators"
@@ -17,5 +17,9 @@
     "yeoman-generator": "^1.1.1"
   },
   "author": "Bot Framework",
-  "license": "ISC"
+  "license": "ISC",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Microsoft/botframework-components.git"
+  }
 }

--- a/generators/generator-adaptive-bot/package.json
+++ b/generators/generator-adaptive-bot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-adaptive-bot",
-  "version": "1.0.0-preview.6",
+  "version": "1.0.0-preview.9",
   "description": "Yeoman generator for creating an Adaptive Bot application built on top of the Microsoft Bot Framework SDK and runtime.",
   "files": [
     "generators"
@@ -17,9 +17,5 @@
     "yeoman-generator": "^1.1.1"
   },
   "author": "Bot Framework",
-  "license": "ISC",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/Microsoft/botframework-components.git"
-  }
+  "license": "ISC"
 }


### PR DESCRIPTION
### Purpose
Merging in latest changes to generator-adaptive-bot to support plugins.

### Changes
- Adding support for pluginDefinitions to generator options to enable other generators to add one or more plugins out of the box when scaffolding the bot.
- Due to package publishing constraints being enforced for security, removing multiple package sources from template NuGet.config.

### Tests
Manually verified with Composer integration and validation.
