### PR TITLE
bug: Re-enable Calendar tests

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -30,3 +30,8 @@ jobs:
       - name: Build solution
         run:  dotnet build
         working-directory: ./skills/declarative/tests
+
+      # Run the tests
+      - name: Run tests
+        run: dotnet test
+        working-directory: ./skills/declarative/tests


### PR DESCRIPTION
### Purpose
Had to temporarily disable Calendar tests to unblock check-in of updates to component packages. Re-enabling.

### Changes
Re-enabling Calendar unit tests.

### Tests
Automated test coverage.