### PR TITLE
feat: generator-microsoft-bot-adaptive plugin support

### DIFF
--- a/generators/generator-microsoft-bot-adaptive/generators/app/templates/assets/runtime.json
+++ b/generators/generator-microsoft-bot-adaptive/generators/app/templates/assets/runtime.json
@@ -2,8 +2,7 @@
   "adapter":
   {
     "$kind": "Microsoft.BotCoreAdapter",
-    "middleware": [
-    ]
+    "middleware": []
   },
   "channel": {
     "$kind": "Microsoft.DeclarativeChannelProvider",

--- a/generators/generator-microsoft-bot-adaptive/generators/app/templates/dotnet/functions/Startup.cs
+++ b/generators/generator-microsoft-bot-adaptive/generators/app/templates/dotnet/functions/Startup.cs
@@ -17,15 +17,10 @@ namespace <%= botName %>
         {
             string applicationRoot = configurationBuilder.GetContext().ApplicationRootPath;
             string settingsDirectory = <%- settingsDirectory %>;
-            bool isDevelopment = string.Equals(
-                configurationBuilder.GetContext().EnvironmentName,
-                Microsoft.Extensions.Hosting.Environments.Development,
-                StringComparison.OrdinalIgnoreCase);
 
             configurationBuilder.ConfigurationBuilder.AddBotRuntimeConfiguration(
                 applicationRoot,
-                settingsDirectory,
-                isDevelopment);
+                settingsDirectory);
         }
     }
 }

--- a/generators/generator-microsoft-bot-adaptive/generators/app/templates/dotnet/functions/botName.csproj
+++ b/generators/generator-microsoft-bot-adaptive/generators/app/templates/dotnet/functions/botName.csproj
@@ -26,7 +26,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.10" />
     <PackageReference Include="Microsoft.AspNetCore.OData" Version="7.5.2" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
-    <PackageReference Include="Microsoft.Bot.Builder.Runtime" Version="4.12.0-daily.preview.20210126.206273.e467c25" />
+    <PackageReference Include="Microsoft.Bot.Builder.Runtime" Version="4.12.0-daily.preview.20210208.211224.35d8ba0" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.7" /><%- packageReferences %>
   </ItemGroup>
   <ItemGroup>

--- a/generators/generator-microsoft-bot-adaptive/generators/app/templates/dotnet/webapp/Program.cs
+++ b/generators/generator-microsoft-bot-adaptive/generators/app/templates/dotnet/webapp/Program.cs
@@ -17,14 +17,12 @@ namespace <%= botName %>
             Host.CreateDefaultBuilder(args)
                 .ConfigureAppConfiguration((hostingContext, builder) =>
                 {
-                    IHostEnvironment env = hostingContext.HostingEnvironment;
                     string applicationRoot = AppDomain.CurrentDomain.BaseDirectory;
                     string settingsDirectory = <%- settingsDirectory %>;
 
                     builder.AddBotRuntimeConfiguration(
                         applicationRoot,
-                        settingsDirectory,
-                        env.IsDevelopment());
+                        settingsDirectory);
 
                     builder.AddCommandLine(args);
                 })

--- a/generators/generator-microsoft-bot-adaptive/generators/app/templates/dotnet/webapp/botName.csproj
+++ b/generators/generator-microsoft-bot-adaptive/generators/app/templates/dotnet/webapp/botName.csproj
@@ -11,6 +11,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.8" />
-    <PackageReference Include="Microsoft.Bot.Builder.Runtime" Version="4.12.0-daily.preview.20210126.206273.e467c25" /><%- packageReferences %>
+    <PackageReference Include="Microsoft.Bot.Builder.Runtime" Version="4.12.0-daily.preview.20210208.211224.35d8ba0" /><%- packageReferences %>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
### Purpose
Merging in latest changes to generator-adaptive-bot to support plugins.

### Changes
- Adding support for pluginDefinitions to generator options to enable other generators to add one or more plugins out of the box when scaffolding the bot.
- Due to package publishing constraints being enforced for security, removing multiple package sources from template NuGet.config.

### Tests
Manually verified with Composer integration and validation.
