### PR TITLE
bug: Fix Microsoft.Bot.Components.Calendar version in calendar generator

### DIFF
--- a/generators/generator-preview-calendar-skill/generators/app/index.js
+++ b/generators/generator-preview-calendar-skill/generators/app/index.js
@@ -16,7 +16,7 @@ module.exports = class extends Generator {
         arguments: this.args,
         packageReferences: [{
           name: 'Microsoft.Bot.Components.Calendar',
-          version: '1.0.0-alpha.20210219.eefbca8'
+          version: '1.0.0-preview1'
           }],
         pluginDefinitions : [
           {


### PR DESCRIPTION
### Purpose
Need to update to latest package version for Calendar component.

### Changes
- Update Microsoft.Bot.Components.Calendar package version to 1.0.0-preview1 in generator-preview-calendar-skill.

### Tests
I like to live dangerously.