### PR TITLE
feat: Add schemas to generator-microsoft-bot-adaptive

### DIFF
--- a/generators/generator-microsoft-bot-adaptive/generators/app/index.js
+++ b/generators/generator-microsoft-bot-adaptive/generators/app/index.js
@@ -210,12 +210,12 @@ module.exports = class extends Generator {
     _copyAssets() {
         const botName = this.options.botName;
 
-        const assetFileNames = ['NuGet.config'];
+        const assetNames = ['NuGet.config', 'schemas'];
 
-        for (const assetFileName of assetFileNames) {
+        for (const assetName of assetNames) {
             this.fs.copyTpl(
-                this.templatePath(path.join('assets', assetFileName)),
-                this.destinationPath(path.join(botName, assetFileName)),
+                this.templatePath(path.join('assets', assetName)),
+                this.destinationPath(path.join(botName, assetName)),
                 {
                     botName
                 }
@@ -235,7 +235,7 @@ module.exports = class extends Generator {
 
         this.fs.writeJSON(
             this.destinationPath(path.join(botName, fileName)),
-            runtime
+            appSettings
         );
     }
 };

--- a/generators/generator-microsoft-bot-adaptive/generators/app/templates/assets/schemas/readme.md
+++ b/generators/generator-microsoft-bot-adaptive/generators/app/templates/assets/schemas/readme.md
@@ -1,0 +1,124 @@
+# How to update the schema file
+
+Once the bot has been setup with Composer and we wish to make changes to the schema, the first step in this process is to eject the runtime through the `Runtime Config` in Composer. The ejected runtime folder will broadly have the following structure
+
+```
+bot
+  /bot.dialog
+  /language-generation
+  /language-understanding
+  /dialogs
+     /customized-dialogs
+  /runtime
+     /azurewebapp
+     /azurefunctions
+  /schemas
+     sdk.schema
+```
+
+##### Prequisites
+
+Botframework CLI > 4.10
+
+```
+npm i -g @microsoft/botframework-cli
+```
+
+> NOTE: Previous versions of botframework-cli required you to install @microsoft/bf-plugin. You will need to uninstall for 4.10 and above.
+>
+> ```
+> bf plugins:uninstall @microsoft/bf-dialog
+> ```
+
+## Adding Custom Actions to your Composer bot
+
+**NOTE: These steps assume you are using azurewebapp as your deployment solution. Replicating it on azurefunctions would be similar
+**
+
+- In this tutorial, we will be going over the steps to include a custom action `MultiplyDialog` that multiplies two numbers passed as inputs. Note that the ejected runtime should contain a `customaction` folder that has this sample.
+
+- Navigate to the csproj file inside the `runtime` folder (bot/runtime/azurewebapp/Microsoft.BotFramework.Composer.WebApp.csproj) and include a project reference to the customaction project like `<ProjectReference Include="..\customaction\Microsoft.BotFramework.Composer.CustomAction.csproj" />`.
+
+- Then Uncomment line 28 and 139 in azurewebapp/Startup.cs file so as to register this action.
+
+```
+
+using Microsoft.BotFramework.Composer.CustomAction;
+// This is for custom action component registration.
+ComponentRegistration.Add(new CustomActionComponentRegistration());
+
+```
+
+- Run the command `dotnet build` on the azurewebapp project to verify if it passes build after adding custom actions to it.
+
+- Navigate to to the `schemas (bot/schemas)` folder. This folder contains a Powershell script and a bash script. Run either of these scripts `./update-schema.ps1 -runtime azurewebapp` or `sh ./update-schema.sh -runtime azurewebapp`. The runtime `azurewebapp` is chosen by default if no argument is passed.
+
+- Validate that the partial schema (MultiplyDialog.schema inside customaction/Schema) has been appended to the default sdk.schema file to generate one single consolidated sdk.schema file.
+
+The above steps should have generated a new sdk.schema file inside `schemas` folder for Composer to use. Reload the bot and you should be able to include your new custom action!
+
+## Customizing Composer using the UI Schema
+
+Composer's UI can be customized using the UI Schema. You can either customize one of your custom actions or override Composer defaults.
+
+There are 2 ways to do this.
+
+1. **Component UI Schema File**
+
+To customize a specific component, simply create a `.uischema` file inside of the `/schemas` directory with the same name as the component, These files will be merged into a single `.uischema` file when running the `update-schema` script.
+
+Example:
+
+```json
+// Microsoft.SendActivity.uischema
+{
+  "$schema": "https://schemas.botframework.com/schemas/ui/v1.0/ui.schema",
+  "form": {
+    "label": "A custom label"
+  }
+}
+```
+
+2. **UI Schema Override File**
+
+This approach allows you to co-locate all of your UI customizations into a single file. This will not be merged into the `sdk.uischema`, instead it will be loaded by Composer and applied as overrides.
+
+Example:
+
+```json
+{
+  "$schema": "https://schemas.botframework.com/schemas/ui/v1.0/ui.schema",
+  "Microsoft.SendActivity": {
+    "form": {
+      "label": "A custom label"
+    }
+  }
+}
+```
+
+#### UI Customization Options
+
+##### Form
+
+| **Property** | **Description**                                                                        | **Type**            | **Default**          |
+| ------------ | -------------------------------------------------------------------------------------- | ------------------- | -------------------- |
+| description  | Text used in tooltips.                                                                 | `string`            | `schema.description` |
+| helpLink     | URI to component or property documentation. Used in tooltips.                          | `string`            |                      |
+| hidden       | An array of property names to hide in the UI.                                          | `string[]`          |                      |
+| label        | Label override. Can either be a string or false to hide the label.                     | `string` \| `false` | `schema.title`       |
+| order        | Set the order of fields. Use "\_" for all other fields. ex. ["foo", "_", "bar"]        | `string[]`          | `[*]`                |
+| placeholder  | Placeholder override.                                                                  | `string`            | `schema.examples`    |
+| properties   | A map of component property names to UI options with customizations for each property. | `object`            |                      |
+| subtitle     | Subtitle rendered in form title.                                                       | `string`            | `schema.$kind`       |
+| widget       | Override default field widget. See list of widgets below.                              | `enum`              |                      |
+
+###### Widgets
+
+- checkbox
+- date
+- datetime
+- input
+- number
+- radio
+- select
+- textarea

--- a/generators/generator-microsoft-bot-adaptive/generators/app/templates/assets/schemas/sdk.schema
+++ b/generators/generator-microsoft-bot-adaptive/generators/app/templates/assets/schemas/sdk.schema
@@ -1,0 +1,9873 @@
+{
+  "$schema": "https://schemas.botframework.com/schemas/component/v1.0/component.schema",
+  "type": "object",
+  "title": "Component kinds",
+  "description": "These are all of the kinds that can be created by the loader.",
+  "oneOf": [
+    {
+      "$ref": "#/definitions/Microsoft.ActivityTemplate"
+    },
+    {
+      "$ref": "#/definitions/Microsoft.AdaptiveDialog"
+    },
+    {
+      "$ref": "#/definitions/Microsoft.AgeEntityRecognizer"
+    },
+    {
+      "$ref": "#/definitions/Microsoft.Ask"
+    },
+    {
+      "$ref": "#/definitions/Microsoft.AttachmentInput"
+    },
+    {
+      "$ref": "#/definitions/Microsoft.BeginDialog"
+    },
+    {
+      "$ref": "#/definitions/Microsoft.BeginSkill"
+    },
+    {
+      "$ref": "#/definitions/Microsoft.BreakLoop"
+    },
+    {
+      "$ref": "#/definitions/Microsoft.CancelAllDialogs"
+    },
+    {
+      "$ref": "#/definitions/Microsoft.CancelDialog"
+    },
+    {
+      "$ref": "#/definitions/Microsoft.ChannelMentionEntityRecognizer"
+    },
+    {
+      "$ref": "#/definitions/Microsoft.ChoiceInput"
+    },
+    {
+      "$ref": "#/definitions/Microsoft.ConditionalSelector"
+    },
+    {
+      "$ref": "#/definitions/Microsoft.ConfirmInput"
+    },
+    {
+      "$ref": "#/definitions/Microsoft.ConfirmationEntityRecognizer"
+    },
+    {
+      "$ref": "#/definitions/Microsoft.ContinueConversationLater"
+    },
+    {
+      "$ref": "#/definitions/Microsoft.ContinueLoop"
+    },
+    {
+      "$ref": "#/definitions/Microsoft.CrossTrainedRecognizerSet"
+    },
+    {
+      "$ref": "#/definitions/Microsoft.CurrencyEntityRecognizer"
+    },
+    {
+      "$ref": "#/definitions/Microsoft.DateTimeEntityRecognizer"
+    },
+    {
+      "$ref": "#/definitions/Microsoft.DateTimeInput"
+    },
+    {
+      "$ref": "#/definitions/Microsoft.DebugBreak"
+    },
+    {
+      "$ref": "#/definitions/Microsoft.DeleteActivity"
+    },
+    {
+      "$ref": "#/definitions/Microsoft.DeleteProperties"
+    },
+    {
+      "$ref": "#/definitions/Microsoft.DeleteProperty"
+    },
+    {
+      "$ref": "#/definitions/Microsoft.DimensionEntityRecognizer"
+    },
+    {
+      "$ref": "#/definitions/Microsoft.EditActions"
+    },
+    {
+      "$ref": "#/definitions/Microsoft.EditArray"
+    },
+    {
+      "$ref": "#/definitions/Microsoft.EmailEntityRecognizer"
+    },
+    {
+      "$ref": "#/definitions/Microsoft.EmitEvent"
+    },
+    {
+      "$ref": "#/definitions/Microsoft.EndDialog"
+    },
+    {
+      "$ref": "#/definitions/Microsoft.EndTurn"
+    },
+    {
+      "$ref": "#/definitions/Microsoft.FirstSelector"
+    },
+    {
+      "$ref": "#/definitions/Microsoft.Foreach"
+    },
+    {
+      "$ref": "#/definitions/Microsoft.ForeachPage"
+    },
+    {
+      "$ref": "#/definitions/Microsoft.GetActivityMembers"
+    },
+    {
+      "$ref": "#/definitions/Microsoft.GetConversationMembers"
+    },
+    {
+      "$ref": "#/definitions/Microsoft.GotoAction"
+    },
+    {
+      "$ref": "#/definitions/Microsoft.GuidEntityRecognizer"
+    },
+    {
+      "$ref": "#/definitions/Microsoft.HashtagEntityRecognizer"
+    },
+    {
+      "$ref": "#/definitions/Microsoft.HttpRequest"
+    },
+    {
+      "$ref": "#/definitions/Microsoft.IfCondition"
+    },
+    {
+      "$ref": "#/definitions/Microsoft.IpEntityRecognizer"
+    },
+    {
+      "$ref": "#/definitions/Microsoft.LogAction"
+    },
+    {
+      "$ref": "#/definitions/Microsoft.LuisRecognizer"
+    },
+    {
+      "$ref": "#/definitions/Microsoft.MentionEntityRecognizer"
+    },
+    {
+      "$ref": "#/definitions/Microsoft.MostSpecificSelector"
+    },
+    {
+      "$ref": "#/definitions/Microsoft.MultiLanguageRecognizer"
+    },
+    {
+      "$ref": "#/definitions/Microsoft.NumberEntityRecognizer"
+    },
+    {
+      "$ref": "#/definitions/Microsoft.NumberInput"
+    },
+    {
+      "$ref": "#/definitions/Microsoft.NumberRangeEntityRecognizer"
+    },
+    {
+      "$ref": "#/definitions/Microsoft.OAuthInput"
+    },
+    {
+      "$ref": "#/definitions/Microsoft.OnActivity"
+    },
+    {
+      "$ref": "#/definitions/Microsoft.OnAssignEntity"
+    },
+    {
+      "$ref": "#/definitions/Microsoft.OnBeginDialog"
+    },
+    {
+      "$ref": "#/definitions/Microsoft.OnCancelDialog"
+    },
+    {
+      "$ref": "#/definitions/Microsoft.OnChooseEntity"
+    },
+    {
+      "$ref": "#/definitions/Microsoft.OnChooseIntent"
+    },
+    {
+      "$ref": "#/definitions/Microsoft.OnChooseProperty"
+    },
+    {
+      "$ref": "#/definitions/Microsoft.OnCondition"
+    },
+    {
+      "$ref": "#/definitions/Microsoft.OnContinueConversation"
+    },
+    {
+      "$ref": "#/definitions/Microsoft.OnConversationUpdateActivity"
+    },
+    {
+      "$ref": "#/definitions/Microsoft.OnDialogEvent"
+    },
+    {
+      "$ref": "#/definitions/Microsoft.OnEndOfActions"
+    },
+    {
+      "$ref": "#/definitions/Microsoft.OnEndOfConversationActivity"
+    },
+    {
+      "$ref": "#/definitions/Microsoft.OnError"
+    },
+    {
+      "$ref": "#/definitions/Microsoft.OnEventActivity"
+    },
+    {
+      "$ref": "#/definitions/Microsoft.OnHandoffActivity"
+    },
+    {
+      "$ref": "#/definitions/Microsoft.OnInstallationUpdateActivity"
+    },
+    {
+      "$ref": "#/definitions/Microsoft.OnIntent"
+    },
+    {
+      "$ref": "#/definitions/Microsoft.OnInvokeActivity"
+    },
+    {
+      "$ref": "#/definitions/Microsoft.OnMessageActivity"
+    },
+    {
+      "$ref": "#/definitions/Microsoft.OnMessageDeleteActivity"
+    },
+    {
+      "$ref": "#/definitions/Microsoft.OnMessageReactionActivity"
+    },
+    {
+      "$ref": "#/definitions/Microsoft.OnMessageUpdateActivity"
+    },
+    {
+      "$ref": "#/definitions/Microsoft.OnQnAMatch"
+    },
+    {
+      "$ref": "#/definitions/Microsoft.OnRepromptDialog"
+    },
+    {
+      "$ref": "#/definitions/Microsoft.OnTypingActivity"
+    },
+    {
+      "$ref": "#/definitions/Microsoft.OnUnknownIntent"
+    },
+    {
+      "$ref": "#/definitions/Microsoft.OrdinalEntityRecognizer"
+    },
+    {
+      "$ref": "#/definitions/Microsoft.PercentageEntityRecognizer"
+    },
+    {
+      "$ref": "#/definitions/Microsoft.PhoneNumberEntityRecognizer"
+    },
+    {
+      "$ref": "#/definitions/Microsoft.QnAMakerDialog"
+    },
+    {
+      "$ref": "#/definitions/Microsoft.QnAMakerRecognizer"
+    },
+    {
+      "$ref": "#/definitions/Microsoft.RandomSelector"
+    },
+    {
+      "$ref": "#/definitions/Microsoft.RecognizerSet"
+    },
+    {
+      "$ref": "#/definitions/Microsoft.RegexEntityRecognizer"
+    },
+    {
+      "$ref": "#/definitions/Microsoft.RegexRecognizer"
+    },
+    {
+      "$ref": "#/definitions/Microsoft.RepeatDialog"
+    },
+    {
+      "$ref": "#/definitions/Microsoft.ReplaceDialog"
+    },
+    {
+      "$ref": "#/definitions/Microsoft.ResourceMultiLanguageGenerator"
+    },
+    {
+      "$ref": "#/definitions/Microsoft.SendActivity"
+    },
+    {
+      "$ref": "#/definitions/Microsoft.SetProperties"
+    },
+    {
+      "$ref": "#/definitions/Microsoft.SetProperty"
+    },
+    {
+      "$ref": "#/definitions/Microsoft.SignOutUser"
+    },
+    {
+      "$ref": "#/definitions/Microsoft.StaticActivityTemplate"
+    },
+    {
+      "$ref": "#/definitions/Microsoft.SwitchCondition"
+    },
+    {
+      "$ref": "#/definitions/Microsoft.TelemetryTrackEvent"
+    },
+    {
+      "$ref": "#/definitions/Microsoft.TemperatureEntityRecognizer"
+    },
+    {
+      "$ref": "#/definitions/Microsoft.TemplateEngineLanguageGenerator"
+    },
+    {
+      "$ref": "#/definitions/Microsoft.TextInput"
+    },
+    {
+      "$ref": "#/definitions/Microsoft.TextTemplate"
+    },
+    {
+      "$ref": "#/definitions/Microsoft.ThrowException"
+    },
+    {
+      "$ref": "#/definitions/Microsoft.TraceActivity"
+    },
+    {
+      "$ref": "#/definitions/Microsoft.TrueSelector"
+    },
+    {
+      "$ref": "#/definitions/Microsoft.UpdateActivity"
+    },
+    {
+      "$ref": "#/definitions/Microsoft.UrlEntityRecognizer"
+    }
+  ],
+  "definitions": {
+    "Microsoft.ActivityTemplate": {
+      "$role": "implements(Microsoft.IActivityTemplate)",
+      "title": "Microsoft activity template",
+      "type": "object",
+      "required": [
+        "template",
+        "$kind"
+      ],
+      "$package": {
+        "name": "Microsoft.Bot.Builder.Dialogs.Adaptive",
+        "version": "4.11.0"
+      },
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\$": {
+          "title": "Tooling property",
+          "description": "Open ended property for tooling."
+        }
+      },
+      "properties": {
+        "template": {
+          "title": "Template",
+          "description": "Language Generator template to use to create the activity",
+          "type": "string"
+        },
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.ActivityTemplate"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
+        }
+      }
+    },
+    "Microsoft.AdaptiveDialog": {
+      "$role": "implements(Microsoft.IDialog)",
+      "title": "Adaptive dialog",
+      "description": "Flexible, data driven dialog that can adapt to the conversation.",
+      "type": "object",
+      "$package": {
+        "name": "Microsoft.Bot.Builder.Dialogs.Adaptive",
+        "version": "4.11.0"
+      },
+      "required": [
+        "$kind"
+      ],
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\$": {
+          "title": "Tooling property",
+          "description": "Open ended property for tooling."
+        }
+      },
+      "properties": {
+        "id": {
+          "type": "string",
+          "title": "Id",
+          "description": "Optional dialog ID."
+        },
+        "autoEndDialog": {
+          "$ref": "#/definitions/booleanExpression",
+          "title": "Auto end dialog",
+          "description": "If set to true the dialog will automatically end when there are no further actions.  If set to false, remember to manually end the dialog using EndDialog action.",
+          "default": true
+        },
+        "defaultResultProperty": {
+          "type": "string",
+          "title": "Default result property",
+          "description": "Value that will be passed back to the parent dialog.",
+          "default": "dialog.result"
+        },
+        "recognizer": {
+          "$kind": "Microsoft.IRecognizer",
+          "title": "Recognizer",
+          "description": "Input recognizer that interprets user input into intent and entities.",
+          "$ref": "#/definitions/Microsoft.IRecognizer"
+        },
+        "generator": {
+          "$kind": "Microsoft.ILanguageGenerator",
+          "title": "Language generator",
+          "description": "Language generator that generates bot responses.",
+          "$ref": "#/definitions/Microsoft.ILanguageGenerator"
+        },
+        "selector": {
+          "$kind": "Microsoft.ITriggerSelector",
+          "title": "Selector",
+          "description": "Policy to determine which trigger is executed. Defaults to a 'best match' selector (optional).",
+          "$ref": "#/definitions/Microsoft.ITriggerSelector"
+        },
+        "triggers": {
+          "type": "array",
+          "description": "List of triggers defined for this dialog.",
+          "title": "Triggers",
+          "items": {
+            "$kind": "Microsoft.ITrigger",
+            "title": "Event triggers",
+            "description": "Event triggers for handling events.",
+            "$ref": "#/definitions/Microsoft.ITrigger"
+          }
+        },
+        "schema": {
+          "title": "Schema",
+          "description": "Schema to fill in.",
+          "anyOf": [
+            {
+              "$schema": "http://json-schema.org/draft-07/schema#",
+              "title": "Core schema meta-schema",
+              "definitions": {
+                "schemaArray": {
+                  "type": "array",
+                  "minItems": 1,
+                  "items": {
+                    "$ref": "#/definitions/Microsoft.AdaptiveDialog/properties/schema/anyOf/0"
+                  }
+                },
+                "nonNegativeInteger": {
+                  "type": "integer",
+                  "minimum": 0
+                },
+                "nonNegativeIntegerDefault0": {
+                  "type": "integer",
+                  "minimum": 0,
+                  "default": 0
+                },
+                "simpleTypes": {
+                  "enum": [
+                    "array",
+                    "boolean",
+                    "integer",
+                    "null",
+                    "number",
+                    "object",
+                    "string"
+                  ]
+                },
+                "stringArray": {
+                  "type": "array",
+                  "uniqueItems": true,
+                  "default": [],
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
+              "type": [
+                "object",
+                "boolean"
+              ],
+              "properties": {
+                "$schema": {
+                  "type": "string",
+                  "format": "uri"
+                },
+                "$ref": {
+                  "type": "string",
+                  "format": "uri-reference"
+                },
+                "$comment": {
+                  "type": "string"
+                },
+                "title": {
+                  "type": "string"
+                },
+                "description": {
+                  "type": "string"
+                },
+                "default": true,
+                "readOnly": {
+                  "type": "boolean",
+                  "default": false
+                },
+                "writeOnly": {
+                  "type": "boolean",
+                  "default": false
+                },
+                "examples": {
+                  "type": "array",
+                  "items": true
+                },
+                "multipleOf": {
+                  "type": "number",
+                  "exclusiveMinimum": 0
+                },
+                "maximum": {
+                  "type": "number"
+                },
+                "exclusiveMaximum": {
+                  "type": "number"
+                },
+                "minimum": {
+                  "type": "number"
+                },
+                "exclusiveMinimum": {
+                  "type": "number"
+                },
+                "maxLength": {
+                  "$ref": "#/definitions/Microsoft.AdaptiveDialog/properties/schema/anyOf/0/definitions/nonNegativeInteger"
+                },
+                "minLength": {
+                  "$ref": "#/definitions/Microsoft.AdaptiveDialog/properties/schema/anyOf/0/definitions/nonNegativeIntegerDefault0"
+                },
+                "pattern": {
+                  "type": "string",
+                  "format": "regex"
+                },
+                "additionalItems": {
+                  "$ref": "#/definitions/Microsoft.AdaptiveDialog/properties/schema/anyOf/0"
+                },
+                "items": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/definitions/Microsoft.AdaptiveDialog/properties/schema/anyOf/0"
+                    },
+                    {
+                      "$ref": "#/definitions/Microsoft.AdaptiveDialog/properties/schema/anyOf/0/definitions/schemaArray"
+                    }
+                  ],
+                  "default": true
+                },
+                "maxItems": {
+                  "$ref": "#/definitions/Microsoft.AdaptiveDialog/properties/schema/anyOf/0/definitions/nonNegativeInteger"
+                },
+                "minItems": {
+                  "$ref": "#/definitions/Microsoft.AdaptiveDialog/properties/schema/anyOf/0/definitions/nonNegativeIntegerDefault0"
+                },
+                "uniqueItems": {
+                  "type": "boolean",
+                  "default": false
+                },
+                "contains": {
+                  "$ref": "#/definitions/Microsoft.AdaptiveDialog/properties/schema/anyOf/0"
+                },
+                "maxProperties": {
+                  "$ref": "#/definitions/Microsoft.AdaptiveDialog/properties/schema/anyOf/0/definitions/nonNegativeInteger"
+                },
+                "minProperties": {
+                  "$ref": "#/definitions/Microsoft.AdaptiveDialog/properties/schema/anyOf/0/definitions/nonNegativeIntegerDefault0"
+                },
+                "required": {
+                  "$ref": "#/definitions/Microsoft.AdaptiveDialog/properties/schema/anyOf/0/definitions/stringArray"
+                },
+                "additionalProperties": {
+                  "$ref": "#/definitions/Microsoft.AdaptiveDialog/properties/schema/anyOf/0"
+                },
+                "definitions": {
+                  "type": "object",
+                  "default": {},
+                  "additionalProperties": {
+                    "$ref": "#/definitions/Microsoft.AdaptiveDialog/properties/schema/anyOf/0"
+                  }
+                },
+                "properties": {
+                  "type": "object",
+                  "default": {},
+                  "additionalProperties": {
+                    "$ref": "#/definitions/Microsoft.AdaptiveDialog/properties/schema/anyOf/0"
+                  }
+                },
+                "patternProperties": {
+                  "type": "object",
+                  "propertyNames": {
+                    "format": "regex"
+                  },
+                  "default": {},
+                  "additionalProperties": {
+                    "$ref": "#/definitions/Microsoft.AdaptiveDialog/properties/schema/anyOf/0"
+                  }
+                },
+                "dependencies": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "anyOf": [
+                      {
+                        "$ref": "#/definitions/Microsoft.AdaptiveDialog/properties/schema/anyOf/0"
+                      },
+                      {
+                        "$ref": "#/definitions/Microsoft.AdaptiveDialog/properties/schema/anyOf/0/definitions/stringArray"
+                      }
+                    ]
+                  }
+                },
+                "propertyNames": {
+                  "$ref": "#/definitions/Microsoft.AdaptiveDialog/properties/schema/anyOf/0"
+                },
+                "const": true,
+                "enum": {
+                  "type": "array",
+                  "minItems": 1,
+                  "uniqueItems": true,
+                  "items": true
+                },
+                "type": {
+                  "anyOf": [
+                    {
+                      "$ref": "#/definitions/Microsoft.AdaptiveDialog/properties/schema/anyOf/0/definitions/simpleTypes"
+                    },
+                    {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/definitions/Microsoft.AdaptiveDialog/properties/schema/anyOf/0/definitions/simpleTypes"
+                      },
+                      "minItems": 1,
+                      "uniqueItems": true
+                    }
+                  ]
+                },
+                "format": {
+                  "type": "string"
+                },
+                "contentMediaType": {
+                  "type": "string"
+                },
+                "contentEncoding": {
+                  "type": "string"
+                },
+                "if": {
+                  "$ref": "#/definitions/Microsoft.AdaptiveDialog/properties/schema/anyOf/0"
+                },
+                "then": {
+                  "$ref": "#/definitions/Microsoft.AdaptiveDialog/properties/schema/anyOf/0"
+                },
+                "else": {
+                  "$ref": "#/definitions/Microsoft.AdaptiveDialog/properties/schema/anyOf/0"
+                },
+                "allOf": {
+                  "$ref": "#/definitions/Microsoft.AdaptiveDialog/properties/schema/anyOf/0/definitions/schemaArray"
+                },
+                "anyOf": {
+                  "$ref": "#/definitions/Microsoft.AdaptiveDialog/properties/schema/anyOf/0/definitions/schemaArray"
+                },
+                "oneOf": {
+                  "$ref": "#/definitions/Microsoft.AdaptiveDialog/properties/schema/anyOf/0/definitions/schemaArray"
+                },
+                "not": {
+                  "$ref": "#/definitions/Microsoft.AdaptiveDialog/properties/schema/anyOf/0"
+                }
+              },
+              "default": true
+            },
+            {
+              "type": "string",
+              "title": "Reference to JSON schema",
+              "description": "Reference to JSON schema .dialog file."
+            }
+          ]
+        },
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.AdaptiveDialog"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
+        }
+      }
+    },
+    "Microsoft.AgeEntityRecognizer": {
+      "$role": [
+        "implements(Microsoft.IRecognizer)",
+        "implements(Microsoft.IEntityRecognizer)"
+      ],
+      "title": "Age entity recognizer",
+      "description": "Recognizer which recognizes age.",
+      "type": "object",
+      "$package": {
+        "name": "Microsoft.Bot.Builder.Dialogs.Adaptive",
+        "version": "4.11.0"
+      },
+      "required": [
+        "$kind"
+      ],
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\$": {
+          "title": "Tooling property",
+          "description": "Open ended property for tooling."
+        }
+      },
+      "properties": {
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.AgeEntityRecognizer"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
+        }
+      }
+    },
+    "Microsoft.Ask": {
+      "$role": [
+        "implements(Microsoft.IDialog)",
+        "extends(Microsoft.SendActivity)"
+      ],
+      "title": "Send activity to ask a question",
+      "description": "This is an action which sends an activity to the user when a response is expected",
+      "type": "object",
+      "$package": {
+        "name": "Microsoft.Bot.Builder.Dialogs.Adaptive",
+        "version": "4.11.0"
+      },
+      "required": [
+        "$kind"
+      ],
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\$": {
+          "title": "Tooling property",
+          "description": "Open ended property for tooling."
+        }
+      },
+      "properties": {
+        "expectedProperties": {
+          "$ref": "#/definitions/arrayExpression",
+          "title": "Expected properties",
+          "description": "Properties expected from the user.",
+          "examples": [
+            [
+              "age",
+              "name"
+            ]
+          ],
+          "items": {
+            "type": "string",
+            "title": "Name",
+            "description": "Name of the property"
+          }
+        },
+        "defaultOperation": {
+          "$ref": "#/definitions/stringExpression",
+          "title": "Default operation",
+          "description": "Sets the default operation that will be used when no operation is recognized in the response to this Ask.",
+          "examples": [
+            "Add()",
+            "Remove()"
+          ]
+        },
+        "id": {
+          "type": "string",
+          "title": "Id",
+          "description": "Optional id for the dialog"
+        },
+        "disabled": {
+          "$ref": "#/definitions/booleanExpression",
+          "title": "Disabled",
+          "description": "Optional condition which if true will disable this action."
+        },
+        "activity": {
+          "$kind": "Microsoft.IActivityTemplate",
+          "title": "Activity",
+          "description": "Activity to send.",
+          "$ref": "#/definitions/Microsoft.IActivityTemplate"
+        },
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.Ask"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
+        }
+      }
+    },
+    "Microsoft.AttachmentInput": {
+      "$role": [
+        "implements(Microsoft.IDialog)",
+        "extends(Microsoft.InputDialog)"
+      ],
+      "title": "Attachment input dialog",
+      "description": "Collect information - Ask for a file or image.",
+      "$package": {
+        "name": "Microsoft.Bot.Builder.Dialogs.Adaptive",
+        "version": "4.11.0"
+      },
+      "type": "object",
+      "required": [
+        "$kind"
+      ],
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\$": {
+          "title": "Tooling property",
+          "description": "Open ended property for tooling."
+        }
+      },
+      "properties": {
+        "defaultValue": {
+          "$role": "expression",
+          "title": "Default value",
+          "description": "'Property' will be set to the object or the result of this expression when max turn count is exceeded.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/Microsoft.IActivityTemplate/oneOf/1/properties/attachments/items",
+              "title": "Object",
+              "description": "Attachment object."
+            },
+            {
+              "$ref": "#/definitions/equalsExpression"
+            }
+          ]
+        },
+        "value": {
+          "$role": "expression",
+          "title": "Value",
+          "description": "'Property' will be set to the object or the result of this expression unless it evaluates to null.",
+          "oneOf": [
+            {
+              "$ref": "#/definitions/Microsoft.IActivityTemplate/oneOf/1/properties/attachments/items",
+              "title": "Object",
+              "description": "Attachment object."
+            },
+            {
+              "$ref": "#/definitions/equalsExpression"
+            }
+          ]
+        },
+        "outputFormat": {
+          "$role": "expression",
+          "title": "Output format",
+          "description": "Attachment output format.",
+          "oneOf": [
+            {
+              "type": "string",
+              "title": "Standard format",
+              "description": "Standard output formats.",
+              "enum": [
+                "all",
+                "first"
+              ],
+              "default": "first"
+            },
+            {
+              "$ref": "#/definitions/equalsExpression"
+            }
+          ]
+        },
+        "id": {
+          "type": "string",
+          "title": "Id",
+          "description": "Optional id for the dialog"
+        },
+        "disabled": {
+          "$ref": "#/definitions/booleanExpression",
+          "title": "Disabled",
+          "description": "Optional condition which if true will disable this action.",
+          "default": false,
+          "examples": [
+            false,
+            "=user.isVip"
+          ]
+        },
+        "prompt": {
+          "$kind": "Microsoft.IActivityTemplate",
+          "title": "Initial prompt",
+          "description": "Message to send to collect information.",
+          "examples": [
+            "What is your birth date?"
+          ],
+          "$ref": "#/definitions/Microsoft.IActivityTemplate"
+        },
+        "unrecognizedPrompt": {
+          "$kind": "Microsoft.IActivityTemplate",
+          "title": "Unrecognized prompt",
+          "description": "Message to send when max turn count (if specified) has been exceeded and the default value is selected as the value.",
+          "examples": [
+            "Sorry, I'm having trouble understanding you. I will just use {this.options.defaultValue} for now. You can say 'I'm 36 years old' to change it."
+          ],
+          "$ref": "#/definitions/Microsoft.IActivityTemplate"
+        },
+        "invalidPrompt": {
+          "$kind": "Microsoft.IActivityTemplate",
+          "title": "Invalid prompt",
+          "description": "Message to send when the user input does not meet any validation expression.",
+          "examples": [
+            "Sorry, '{this.value}' does not work. I need a number between 1-150. What is your age?"
+          ],
+          "$ref": "#/definitions/Microsoft.IActivityTemplate"
+        },
+        "defaultValueResponse": {
+          "$kind": "Microsoft.IActivityTemplate",
+          "title": "Default value response",
+          "description": "Message to send when max turn count (if specified) has been exceeded and the default value is selected as the value.",
+          "examples": [
+            "Sorry, I'm having trouble understanding you. I will just use {this.options.defaultValue} for now. You can say 'I'm 36 years old' to change it."
+          ],
+          "$ref": "#/definitions/Microsoft.IActivityTemplate"
+        },
+        "maxTurnCount": {
+          "$ref": "#/definitions/integerExpression",
+          "title": "Max turn count",
+          "description": "Maximum number of re-prompt attempts to collect information.",
+          "default": 3,
+          "examples": [
+            3,
+            "=settings.xyz"
+          ]
+        },
+        "validations": {
+          "type": "array",
+          "title": "Validation expressions",
+          "description": "Expression to validate user input.",
+          "items": {
+            "$ref": "#/definitions/condition",
+            "title": "Condition",
+            "description": "Expression which needs to met for the input to be considered valid",
+            "examples": [
+              "int(this.value) > 1 && int(this.value) <= 150",
+              "count(this.value) < 300"
+            ]
+          }
+        },
+        "property": {
+          "$ref": "#/definitions/stringExpression",
+          "title": "Property",
+          "description": "Property to store collected information. Input will be skipped if property has value (unless 'Always prompt' is true).",
+          "examples": [
+            "$birthday",
+            "dialog.${user.name}",
+            "=f(x)"
+          ]
+        },
+        "alwaysPrompt": {
+          "$ref": "#/definitions/booleanExpression",
+          "title": "Always prompt",
+          "description": "Collect information even if the specified 'property' is not empty.",
+          "default": false,
+          "examples": [
+            false,
+            "=$val"
+          ]
+        },
+        "allowInterruptions": {
+          "$ref": "#/definitions/booleanExpression",
+          "title": "Allow Interruptions",
+          "description": "A boolean expression that determines whether the parent should be allowed to interrupt the input.",
+          "default": true,
+          "examples": [
+            true,
+            "=user.xyz"
+          ]
+        },
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.AttachmentInput"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
+        }
+      }
+    },
+    "Microsoft.BeginDialog": {
+      "$role": "implements(Microsoft.IDialog)",
+      "title": "Begin a dialog",
+      "description": "Begin another dialog.",
+      "type": "object",
+      "$package": {
+        "name": "Microsoft.Bot.Builder.Dialogs.Adaptive",
+        "version": "4.11.0"
+      },
+      "required": [
+        "$kind"
+      ],
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\$": {
+          "title": "Tooling property",
+          "description": "Open ended property for tooling."
+        }
+      },
+      "properties": {
+        "id": {
+          "type": "string",
+          "title": "Id",
+          "description": "Optional id for the dialog"
+        },
+        "disabled": {
+          "$ref": "#/definitions/booleanExpression",
+          "title": "Disabled",
+          "description": "Optional condition which if true will disable this action.",
+          "examples": [
+            "user.age > 3"
+          ]
+        },
+        "dialog": {
+          "oneOf": [
+            {
+              "$kind": "Microsoft.IDialog",
+              "pattern": "^(?!(=)).*",
+              "title": "Dialog",
+              "$ref": "#/definitions/Microsoft.IDialog"
+            },
+            {
+              "$ref": "#/definitions/equalsExpression",
+              "examples": [
+                "=settings.dialogId"
+              ]
+            }
+          ],
+          "title": "Dialog name",
+          "description": "Name of the dialog to call."
+        },
+        "options": {
+          "$ref": "#/definitions/objectExpression",
+          "title": "Options",
+          "description": "One or more options that are passed to the dialog that is called.",
+          "examples": [
+            {
+              "arg1": "=expression"
+            }
+          ],
+          "additionalProperties": {
+            "type": "string",
+            "title": "Options",
+            "description": "Options for dialog."
+          }
+        },
+        "activityProcessed": {
+          "$ref": "#/definitions/booleanExpression",
+          "title": "Activity processed",
+          "description": "When set to false, the dialog that is called can process the current activity.",
+          "default": true
+        },
+        "resultProperty": {
+          "$ref": "#/definitions/stringExpression",
+          "title": "Property",
+          "description": "Property to store any value returned by the dialog that is called.",
+          "examples": [
+            "dialog.userName"
+          ]
+        },
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.BeginDialog"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
+        }
+      }
+    },
+    "Microsoft.BeginSkill": {
+      "$role": "implements(Microsoft.IDialog)",
+      "title": "Begin a skill",
+      "description": "Begin a remote skill.",
+      "type": "object",
+      "$package": {
+        "name": "Microsoft.Bot.Builder.Dialogs.Adaptive",
+        "version": "4.11.0"
+      },
+      "required": [
+        "$kind"
+      ],
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\$": {
+          "title": "Tooling property",
+          "description": "Open ended property for tooling."
+        }
+      },
+      "properties": {
+        "id": {
+          "type": "string",
+          "title": "Id",
+          "description": "Optional id for the skill dialog"
+        },
+        "disabled": {
+          "$ref": "#/definitions/booleanExpression",
+          "title": "Disabled",
+          "description": "Optional condition which if true will disable this action.",
+          "examples": [
+            true,
+            "=f(x)"
+          ]
+        },
+        "activityProcessed": {
+          "$ref": "#/definitions/booleanExpression",
+          "title": "Activity processed",
+          "description": "When set to false, the skill will be started using the activity in the current turn context instead of the activity in the Activity property.",
+          "default": true,
+          "examples": [
+            true,
+            "=f(x)"
+          ]
+        },
+        "resultProperty": {
+          "$ref": "#/definitions/stringExpression",
+          "title": "Property",
+          "description": "Property to store any value returned by the dialog that is called.",
+          "examples": [
+            "dialog.userName"
+          ]
+        },
+        "botId": {
+          "$ref": "#/definitions/stringExpression",
+          "title": "Skill host bot ID",
+          "description": "The Microsoft App ID that will be calling the skill.",
+          "default": "=settings.MicrosoftAppId"
+        },
+        "skillHostEndpoint": {
+          "$ref": "#/definitions/stringExpression",
+          "title": "Skill host",
+          "description": "The callback Url for the skill host.",
+          "default": "=settings.skillHostEndpoint",
+          "examples": [
+            "https://mybot.contoso.com/api/skills/"
+          ]
+        },
+        "connectionName": {
+          "$ref": "#/definitions/stringExpression",
+          "title": "OAuth connection name (SSO)",
+          "description": "The OAuth Connection Name, that would be used to perform Single SignOn with a skill.",
+          "default": "=settings.connectionName"
+        },
+        "skillAppId": {
+          "$ref": "#/definitions/stringExpression",
+          "title": "Skill App Id",
+          "description": "The Microsoft App ID for the skill."
+        },
+        "skillEndpoint": {
+          "$ref": "#/definitions/stringExpression",
+          "title": "Skill endpoint ",
+          "description": "The /api/messages endpoint for the skill.",
+          "examples": [
+            "https://myskill.contoso.com/api/messages/"
+          ]
+        },
+        "activity": {
+          "$kind": "Microsoft.IActivityTemplate",
+          "title": "Activity",
+          "description": "The activity to send to the skill.",
+          "$ref": "#/definitions/Microsoft.IActivityTemplate"
+        },
+        "allowInterruptions": {
+          "$ref": "#/definitions/booleanExpression",
+          "title": "Allow interruptions",
+          "description": "A boolean expression that determines whether the parent should be allowed to interrupt the skill.",
+          "default": true,
+          "examples": [
+            true,
+            "=user.xyz"
+          ]
+        },
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.BeginSkill"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
+        }
+      }
+    },
+    "Microsoft.BreakLoop": {
+      "$role": "implements(Microsoft.IDialog)",
+      "title": "Break loop",
+      "description": "Stop executing this loop",
+      "type": "object",
+      "required": [
+        "$kind"
+      ],
+      "$package": {
+        "name": "Microsoft.Bot.Builder.Dialogs.Adaptive",
+        "version": "4.11.0"
+      },
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\$": {
+          "title": "Tooling property",
+          "description": "Open ended property for tooling."
+        }
+      },
+      "properties": {
+        "id": {
+          "type": "string",
+          "title": "Id",
+          "description": "Optional id for the dialog"
+        },
+        "disabled": {
+          "$ref": "#/definitions/booleanExpression",
+          "title": "Disabled",
+          "description": "Optional condition which if true will disable this action.",
+          "examples": [
+            "user.age > 3"
+          ]
+        },
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.BreakLoop"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
+        }
+      }
+    },
+    "Microsoft.CancelAllDialogs": {
+      "$role": "implements(Microsoft.IDialog)",
+      "title": "Cancel all dialogs",
+      "description": "Cancel all active dialogs. All dialogs in the dialog chain will need a trigger to capture the event configured in this action.",
+      "type": "object",
+      "$package": {
+        "name": "Microsoft.Bot.Builder.Dialogs.Adaptive",
+        "version": "4.11.0"
+      },
+      "required": [
+        "$kind"
+      ],
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\$": {
+          "title": "Tooling property",
+          "description": "Open ended property for tooling."
+        }
+      },
+      "properties": {
+        "id": {
+          "type": "string",
+          "title": "Id",
+          "description": "Optional id for the dialog"
+        },
+        "disabled": {
+          "$ref": "#/definitions/booleanExpression",
+          "title": "Disabled",
+          "description": "Optional condition which if true will disable this action.",
+          "examples": [
+            "user.age > 3"
+          ]
+        },
+        "activityProcessed": {
+          "$ref": "#/definitions/booleanExpression",
+          "title": "Activity processed",
+          "description": "When set to false, the caller dialog is told it should process the current activity.",
+          "default": true
+        },
+        "eventName": {
+          "$ref": "#/definitions/stringExpression",
+          "title": "Event name",
+          "description": "Name of the event to emit."
+        },
+        "eventValue": {
+          "$ref": "#/definitions/valueExpression",
+          "title": "Event value",
+          "description": "Value to emit with the event (optional).",
+          "additionalProperties": true
+        },
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.CancelAllDialogs"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
+        }
+      }
+    },
+    "Microsoft.CancelDialog": {
+      "$role": "implements(Microsoft.IDialog)",
+      "title": "Cancel all dialogs",
+      "description": "Cancel all active dialogs. All dialogs in the dialog chain will need a trigger to capture the event configured in this action.",
+      "type": "object",
+      "$package": {
+        "name": "Microsoft.Bot.Builder.Dialogs.Adaptive",
+        "version": "4.11.0"
+      },
+      "required": [
+        "$kind"
+      ],
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\$": {
+          "title": "Tooling property",
+          "description": "Open ended property for tooling."
+        }
+      },
+      "properties": {
+        "id": {
+          "type": "string",
+          "title": "Id",
+          "description": "Optional id for the dialog"
+        },
+        "disabled": {
+          "$ref": "#/definitions/booleanExpression",
+          "title": "Disabled",
+          "description": "Optional condition which if true will disable this action.",
+          "examples": [
+            "user.age > 3"
+          ]
+        },
+        "activityProcessed": {
+          "$ref": "#/definitions/booleanExpression",
+          "title": "Activity processed",
+          "description": "When set to false, the caller dialog is told it should process the current activity.",
+          "default": true
+        },
+        "eventName": {
+          "$ref": "#/definitions/stringExpression",
+          "title": "Event name",
+          "description": "Name of the event to emit."
+        },
+        "eventValue": {
+          "$ref": "#/definitions/valueExpression",
+          "title": "Event value",
+          "description": "Value to emit with the event (optional).",
+          "additionalProperties": true
+        },
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.CancelDialog"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
+        }
+      }
+    },
+    "Microsoft.ChannelMentionEntityRecognizer": {
+      "$role": [
+        "implements(Microsoft.IRecognizer)"
+      ],
+      "title": "Channel mention entity recognizer",
+      "description": "Promotes mention entities passed by a channel via the activity.entities into recognizer result.",
+      "type": "object",
+      "$package": {
+        "name": "Microsoft.Bot.Builder.Dialogs.Adaptive",
+        "version": "4.11.0"
+      },
+      "required": [
+        "$kind"
+      ],
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\$": {
+          "title": "Tooling property",
+          "description": "Open ended property for tooling."
+        }
+      },
+      "properties": {
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.ChannelMentionEntityRecognizer"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
+        }
+      }
+    },
+    "Microsoft.ChoiceInput": {
+      "$role": [
+        "implements(Microsoft.IDialog)",
+        "extends(Microsoft.InputDialog)"
+      ],
+      "title": "Choice input dialog",
+      "description": "Collect information - Pick from a list of choices",
+      "type": "object",
+      "$package": {
+        "name": "Microsoft.Bot.Builder.Dialogs.Adaptive",
+        "version": "4.11.0"
+      },
+      "required": [
+        "$kind"
+      ],
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\$": {
+          "title": "Tooling property",
+          "description": "Open ended property for tooling."
+        }
+      },
+      "properties": {
+        "defaultValue": {
+          "$ref": "#/definitions/stringExpression",
+          "title": "Default value",
+          "description": "'Property' will be set to the value of this expression when max turn count is exceeded.",
+          "examples": [
+            "hello world",
+            "Hello ${user.name}",
+            "=concat(user.firstname, user.lastName)"
+          ]
+        },
+        "value": {
+          "$ref": "#/definitions/stringExpression",
+          "title": "Value",
+          "description": "'Property' will be set to the value of this expression unless it evaluates to null.",
+          "examples": [
+            "hello world",
+            "Hello ${user.name}",
+            "=concat(user.firstname, user.lastName)"
+          ]
+        },
+        "outputFormat": {
+          "$role": "expression",
+          "title": "Output format",
+          "description": "Sets the desired choice output format (either value or index into choices).",
+          "oneOf": [
+            {
+              "type": "string",
+              "title": "Standard",
+              "description": "Standard output format.",
+              "enum": [
+                "value",
+                "index"
+              ],
+              "default": "value"
+            },
+            {
+              "$ref": "#/definitions/equalsExpression"
+            }
+          ]
+        },
+        "choices": {
+          "$role": "expression",
+          "title": "Array of choices",
+          "description": "Choices to choose from.",
+          "oneOf": [
+            {
+              "type": "array",
+              "title": "Simple choices",
+              "description": "Simple choices to choose from.",
+              "items": [
+                {
+                  "type": "string",
+                  "title": "Simple choice",
+                  "description": "One choice for choice input."
+                }
+              ]
+            },
+            {
+              "type": "array",
+              "title": "Structured choices",
+              "description": "Choices that allow full control.",
+              "items": [
+                {
+                  "type": "object",
+                  "title": "Structured choice",
+                  "description": "Structured choice to choose from.",
+                  "properties": {
+                    "value": {
+                      "type": "string",
+                      "title": "Value",
+                      "description": "Value to return when this choice is selected."
+                    },
+                    "action": {
+                      "$ref": "#/definitions/Microsoft.IActivityTemplate/oneOf/1/properties/suggestedActions/properties/actions/items",
+                      "title": "Action",
+                      "description": "Card action for the choice."
+                    },
+                    "synonyms": {
+                      "type": "array",
+                      "title": "Synonyms",
+                      "description": "List of synonyms to recognize in addition to the value (optional).",
+                      "items": {
+                        "type": "string",
+                        "title": "Synonym",
+                        "description": "Synonym for value."
+                      }
+                    }
+                  }
+                }
+              ]
+            },
+            {
+              "$ref": "#/definitions/equalsExpression"
+            }
+          ]
+        },
+        "defaultLocale": {
+          "$ref": "#/definitions/stringExpression",
+          "title": "Default locale",
+          "description": "The default locale to use to parse confirmation choices if there is not one passed by the caller.",
+          "default": "en-us",
+          "examples": [
+            "en-us"
+          ]
+        },
+        "style": {
+          "$role": "expression",
+          "title": "List style",
+          "description": "Sets the ListStyle to control how choices are rendered.",
+          "oneOf": [
+            {
+              "type": "string",
+              "title": "List style",
+              "description": "Standard list style.",
+              "enum": [
+                "none",
+                "auto",
+                "inline",
+                "list",
+                "suggestedAction",
+                "heroCard"
+              ],
+              "default": "auto"
+            },
+            {
+              "$ref": "#/definitions/equalsExpression"
+            }
+          ]
+        },
+        "choiceOptions": {
+          "title": "Choice options",
+          "description": "Sets the choice options used for controlling how choices are combined.",
+          "oneOf": [
+            {
+              "type": "object",
+              "title": "Object",
+              "description": "Choice options object.",
+              "properties": {
+                "inlineSeparator": {
+                  "type": "string",
+                  "title": "Inline separator",
+                  "description": "Character used to separate individual choices when there are more than 2 choices",
+                  "default": ", "
+                },
+                "inlineOr": {
+                  "type": "string",
+                  "title": "Inline or",
+                  "description": "Separator inserted between the choices when there are only 2 choices",
+                  "default": " or "
+                },
+                "inlineOrMore": {
+                  "type": "string",
+                  "title": "Inline or more",
+                  "description": "Separator inserted between the last 2 choices when their are more than 2 choices.",
+                  "default": ", or "
+                },
+                "includeNumbers": {
+                  "type": "boolean",
+                  "title": "Include numbers",
+                  "description": "If true, 'inline' and 'list' list style will be prefixed with the index of the choice.",
+                  "default": true
+                }
+              }
+            },
+            {
+              "$ref": "#/definitions/equalsExpression"
+            }
+          ]
+        },
+        "recognizerOptions": {
+          "title": "Recognizer options",
+          "description": "Sets how to recognize choices in the response",
+          "oneOf": [
+            {
+              "type": "object",
+              "title": "Object",
+              "description": "Options for recognizer.",
+              "properties": {
+                "noValue": {
+                  "type": "boolean",
+                  "title": "No value",
+                  "description": "If true, the choices value field will NOT be search over",
+                  "default": false
+                },
+                "noAction": {
+                  "type": "boolean",
+                  "title": "No action",
+                  "description": "If true, the choices action.title field will NOT be searched over",
+                  "default": false
+                },
+                "recognizeNumbers": {
+                  "type": "boolean",
+                  "title": "Recognize numbers",
+                  "description": "If true, the number recognizer will be used to recognize an index response (1,2,3...) to the prompt.",
+                  "default": true
+                },
+                "recognizeOrdinals": {
+                  "type": "boolean",
+                  "title": "Recognize ordinals",
+                  "description": "If true, the ordinal recognizer will be used to recognize ordinal response (first/second/...) to the prompt.",
+                  "default": true
+                }
+              }
+            },
+            {
+              "$ref": "#/definitions/equalsExpression"
+            }
+          ]
+        },
+        "id": {
+          "type": "string",
+          "title": "Id",
+          "description": "Optional id for the dialog"
+        },
+        "disabled": {
+          "$ref": "#/definitions/booleanExpression",
+          "title": "Disabled",
+          "description": "Optional condition which if true will disable this action.",
+          "default": false,
+          "examples": [
+            false,
+            "=user.isVip"
+          ]
+        },
+        "prompt": {
+          "$kind": "Microsoft.IActivityTemplate",
+          "title": "Initial prompt",
+          "description": "Message to send to collect information.",
+          "examples": [
+            "What is your birth date?"
+          ],
+          "$ref": "#/definitions/Microsoft.IActivityTemplate"
+        },
+        "unrecognizedPrompt": {
+          "$kind": "Microsoft.IActivityTemplate",
+          "title": "Unrecognized prompt",
+          "description": "Message to send when max turn count (if specified) has been exceeded and the default value is selected as the value.",
+          "examples": [
+            "Sorry, I'm having trouble understanding you. I will just use {this.options.defaultValue} for now. You can say 'I'm 36 years old' to change it."
+          ],
+          "$ref": "#/definitions/Microsoft.IActivityTemplate"
+        },
+        "invalidPrompt": {
+          "$kind": "Microsoft.IActivityTemplate",
+          "title": "Invalid prompt",
+          "description": "Message to send when the user input does not meet any validation expression.",
+          "examples": [
+            "Sorry, '{this.value}' does not work. I need a number between 1-150. What is your age?"
+          ],
+          "$ref": "#/definitions/Microsoft.IActivityTemplate"
+        },
+        "defaultValueResponse": {
+          "$kind": "Microsoft.IActivityTemplate",
+          "title": "Default value response",
+          "description": "Message to send when max turn count (if specified) has been exceeded and the default value is selected as the value.",
+          "examples": [
+            "Sorry, I'm having trouble understanding you. I will just use {this.options.defaultValue} for now. You can say 'I'm 36 years old' to change it."
+          ],
+          "$ref": "#/definitions/Microsoft.IActivityTemplate"
+        },
+        "maxTurnCount": {
+          "$ref": "#/definitions/integerExpression",
+          "title": "Max turn count",
+          "description": "Maximum number of re-prompt attempts to collect information.",
+          "default": 3,
+          "examples": [
+            3,
+            "=settings.xyz"
+          ]
+        },
+        "validations": {
+          "type": "array",
+          "title": "Validation expressions",
+          "description": "Expression to validate user input.",
+          "items": {
+            "$ref": "#/definitions/condition",
+            "title": "Condition",
+            "description": "Expression which needs to met for the input to be considered valid",
+            "examples": [
+              "int(this.value) > 1 && int(this.value) <= 150",
+              "count(this.value) < 300"
+            ]
+          }
+        },
+        "property": {
+          "$ref": "#/definitions/stringExpression",
+          "title": "Property",
+          "description": "Property to store collected information. Input will be skipped if property has value (unless 'Always prompt' is true).",
+          "examples": [
+            "$birthday",
+            "dialog.${user.name}",
+            "=f(x)"
+          ]
+        },
+        "alwaysPrompt": {
+          "$ref": "#/definitions/booleanExpression",
+          "title": "Always prompt",
+          "description": "Collect information even if the specified 'property' is not empty.",
+          "default": false,
+          "examples": [
+            false,
+            "=$val"
+          ]
+        },
+        "allowInterruptions": {
+          "$ref": "#/definitions/booleanExpression",
+          "title": "Allow Interruptions",
+          "description": "A boolean expression that determines whether the parent should be allowed to interrupt the input.",
+          "default": true,
+          "examples": [
+            true,
+            "=user.xyz"
+          ]
+        },
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.ChoiceInput"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
+        }
+      }
+    },
+    "Microsoft.ConditionalSelector": {
+      "$role": "implements(Microsoft.ITriggerSelector)",
+      "title": "Conditional trigger selector",
+      "description": "Use a rule selector based on a condition",
+      "type": "object",
+      "required": [
+        "condition",
+        "ifTrue",
+        "ifFalse",
+        "$kind"
+      ],
+      "$package": {
+        "name": "Microsoft.Bot.Builder.Dialogs.Adaptive",
+        "version": "4.11.0"
+      },
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\$": {
+          "title": "Tooling property",
+          "description": "Open ended property for tooling."
+        }
+      },
+      "properties": {
+        "condition": {
+          "$ref": "#/definitions/condition",
+          "title": "Condition",
+          "description": "Expression to evaluate"
+        },
+        "ifTrue": {
+          "$kind": "Microsoft.ITriggerSelector",
+          "$ref": "#/definitions/Microsoft.ITriggerSelector"
+        },
+        "ifFalse": {
+          "$kind": "Microsoft.ITriggerSelector",
+          "$ref": "#/definitions/Microsoft.ITriggerSelector"
+        },
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.ConditionalSelector"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
+        }
+      }
+    },
+    "Microsoft.ConfirmInput": {
+      "$role": [
+        "implements(Microsoft.IDialog)",
+        "extends(Microsoft.InputDialog)"
+      ],
+      "title": "Confirm input dialog",
+      "description": "Collect information - Ask for confirmation (yes or no).",
+      "type": "object",
+      "$package": {
+        "name": "Microsoft.Bot.Builder.Dialogs.Adaptive",
+        "version": "4.11.0"
+      },
+      "required": [
+        "$kind"
+      ],
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\$": {
+          "title": "Tooling property",
+          "description": "Open ended property for tooling."
+        }
+      },
+      "properties": {
+        "outputFormat": {
+          "$ref": "#/definitions/valueExpression",
+          "title": "Output format",
+          "description": "Optional expression to use to format the output.",
+          "examples": [
+            "=concat('confirmation:', this.value)"
+          ]
+        },
+        "defaultLocale": {
+          "$ref": "#/definitions/stringExpression",
+          "title": "Default locale",
+          "description": "The Default locale or an expression which provides the default locale to use as default if not found in the activity.",
+          "default": "en-us",
+          "examples": [
+            "en-us"
+          ]
+        },
+        "style": {
+          "$role": "expression",
+          "title": "List style",
+          "description": "Sets the ListStyle to control how choices are rendered.",
+          "oneOf": [
+            {
+              "type": "string",
+              "title": "Standard style",
+              "description": "Standard style for rendering choices.",
+              "enum": [
+                "none",
+                "auto",
+                "inline",
+                "list",
+                "suggestedAction",
+                "heroCard"
+              ],
+              "default": "auto"
+            },
+            {
+              "$ref": "#/definitions/equalsExpression"
+            }
+          ]
+        },
+        "choiceOptions": {
+          "title": "Choice options",
+          "description": "Choice Options or expression which provides Choice Options to control display choices to the user.",
+          "oneOf": [
+            {
+              "type": "object",
+              "title": "Choice options",
+              "description": "Choice options.",
+              "properties": {
+                "inlineSeparator": {
+                  "type": "string",
+                  "title": "Inline separator",
+                  "description": "Text to separate individual choices when there are more than 2 choices",
+                  "default": ", "
+                },
+                "inlineOr": {
+                  "type": "string",
+                  "title": "Inline or",
+                  "description": "Text to be inserted between the choices when their are only 2 choices",
+                  "default": " or "
+                },
+                "inlineOrMore": {
+                  "type": "string",
+                  "title": "Inline or more",
+                  "description": "Text to be inserted between the last 2 choices when their are more than 2 choices.",
+                  "default": ", or "
+                },
+                "includeNumbers": {
+                  "type": "boolean",
+                  "title": "Include numbers",
+                  "description": "If true, inline and list style choices will be prefixed with the index of the choice.",
+                  "default": true
+                }
+              }
+            },
+            {
+              "$ref": "#/definitions/equalsExpression"
+            }
+          ]
+        },
+        "defaultValue": {
+          "$ref": "#/definitions/booleanExpression",
+          "title": "Default value",
+          "description": "'Property' will be set to the value of this expression when max turn count is exceeded.",
+          "examples": [
+            true,
+            "=user.age > 3"
+          ]
+        },
+        "value": {
+          "$ref": "#/definitions/booleanExpression",
+          "title": "Value",
+          "description": "'Property' will be set to the value of this expression unless it evaluates to null.",
+          "examples": [
+            true,
+            "=user.isVip"
+          ]
+        },
+        "confirmChoices": {
+          "$role": "expression",
+          "title": "Array of choice objects",
+          "description": "Array of simple or structured choices.",
+          "oneOf": [
+            {
+              "type": "array",
+              "title": "Simple choices",
+              "description": "Simple choices to confirm from.",
+              "items": [
+                {
+                  "type": "string",
+                  "title": "Simple choice",
+                  "description": "Simple choice to confirm."
+                }
+              ]
+            },
+            {
+              "type": "array",
+              "title": "Structured choices",
+              "description": "Structured choices for confirmations.",
+              "items": [
+                {
+                  "type": "object",
+                  "title": "Choice",
+                  "description": "Choice to confirm.",
+                  "properties": {
+                    "value": {
+                      "type": "string",
+                      "title": "Value",
+                      "description": "Value to return when this choice is selected."
+                    },
+                    "action": {
+                      "$ref": "#/definitions/Microsoft.IActivityTemplate/oneOf/1/properties/suggestedActions/properties/actions/items",
+                      "title": "Action",
+                      "description": "Card action for the choice."
+                    },
+                    "synonyms": {
+                      "type": "array",
+                      "title": "Synonyms",
+                      "description": "List of synonyms to recognize in addition to the value (optional).",
+                      "items": {
+                        "type": "string",
+                        "title": "Synonym",
+                        "description": "Synonym for choice."
+                      }
+                    }
+                  }
+                }
+              ]
+            },
+            {
+              "$ref": "#/definitions/equalsExpression"
+            }
+          ]
+        },
+        "id": {
+          "type": "string",
+          "title": "Id",
+          "description": "Optional id for the dialog"
+        },
+        "disabled": {
+          "$ref": "#/definitions/booleanExpression",
+          "title": "Disabled",
+          "description": "Optional condition which if true will disable this action.",
+          "default": false,
+          "examples": [
+            false,
+            "=user.isVip"
+          ]
+        },
+        "prompt": {
+          "$kind": "Microsoft.IActivityTemplate",
+          "title": "Initial prompt",
+          "description": "Message to send to collect information.",
+          "examples": [
+            "What is your birth date?"
+          ],
+          "$ref": "#/definitions/Microsoft.IActivityTemplate"
+        },
+        "unrecognizedPrompt": {
+          "$kind": "Microsoft.IActivityTemplate",
+          "title": "Unrecognized prompt",
+          "description": "Message to send when max turn count (if specified) has been exceeded and the default value is selected as the value.",
+          "examples": [
+            "Sorry, I'm having trouble understanding you. I will just use {this.options.defaultValue} for now. You can say 'I'm 36 years old' to change it."
+          ],
+          "$ref": "#/definitions/Microsoft.IActivityTemplate"
+        },
+        "invalidPrompt": {
+          "$kind": "Microsoft.IActivityTemplate",
+          "title": "Invalid prompt",
+          "description": "Message to send when the user input does not meet any validation expression.",
+          "examples": [
+            "Sorry, '{this.value}' does not work. I need a number between 1-150. What is your age?"
+          ],
+          "$ref": "#/definitions/Microsoft.IActivityTemplate"
+        },
+        "defaultValueResponse": {
+          "$kind": "Microsoft.IActivityTemplate",
+          "title": "Default value response",
+          "description": "Message to send when max turn count (if specified) has been exceeded and the default value is selected as the value.",
+          "examples": [
+            "Sorry, I'm having trouble understanding you. I will just use {this.options.defaultValue} for now. You can say 'I'm 36 years old' to change it."
+          ],
+          "$ref": "#/definitions/Microsoft.IActivityTemplate"
+        },
+        "maxTurnCount": {
+          "$ref": "#/definitions/integerExpression",
+          "title": "Max turn count",
+          "description": "Maximum number of re-prompt attempts to collect information.",
+          "default": 3,
+          "examples": [
+            3,
+            "=settings.xyz"
+          ]
+        },
+        "validations": {
+          "type": "array",
+          "title": "Validation expressions",
+          "description": "Expression to validate user input.",
+          "items": {
+            "$ref": "#/definitions/condition",
+            "title": "Condition",
+            "description": "Expression which needs to met for the input to be considered valid",
+            "examples": [
+              "int(this.value) > 1 && int(this.value) <= 150",
+              "count(this.value) < 300"
+            ]
+          }
+        },
+        "property": {
+          "$ref": "#/definitions/stringExpression",
+          "title": "Property",
+          "description": "Property to store collected information. Input will be skipped if property has value (unless 'Always prompt' is true).",
+          "examples": [
+            "$birthday",
+            "dialog.${user.name}",
+            "=f(x)"
+          ]
+        },
+        "alwaysPrompt": {
+          "$ref": "#/definitions/booleanExpression",
+          "title": "Always prompt",
+          "description": "Collect information even if the specified 'property' is not empty.",
+          "default": false,
+          "examples": [
+            false,
+            "=$val"
+          ]
+        },
+        "allowInterruptions": {
+          "$ref": "#/definitions/booleanExpression",
+          "title": "Allow Interruptions",
+          "description": "A boolean expression that determines whether the parent should be allowed to interrupt the input.",
+          "default": true,
+          "examples": [
+            true,
+            "=user.xyz"
+          ]
+        },
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.ConfirmInput"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
+        }
+      }
+    },
+    "Microsoft.ConfirmationEntityRecognizer": {
+      "$role": [
+        "implements(Microsoft.IRecognizer)",
+        "implements(Microsoft.IEntityRecognizer)"
+      ],
+      "title": "Confirmation entity recognizer",
+      "description": "Recognizer which recognizes confirmation choices (yes/no).",
+      "type": "object",
+      "$package": {
+        "name": "Microsoft.Bot.Builder.Dialogs.Adaptive",
+        "version": "4.11.0"
+      },
+      "required": [
+        "$kind"
+      ],
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\$": {
+          "title": "Tooling property",
+          "description": "Open ended property for tooling."
+        }
+      },
+      "properties": {
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.ConfirmationEntityRecognizer"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
+        }
+      }
+    },
+    "Microsoft.ContinueConversationLater": {
+      "$role": "implements(Microsoft.IDialog)",
+      "title": "Continue conversation later (Queue)",
+      "description": "Continue conversation at later time (via Azure Storage Queue).",
+      "type": "object",
+      "required": [
+        "date",
+        "connectionString",
+        "$kind"
+      ],
+      "$package": {
+        "name": "Microsoft.Bot.Builder.Dialogs.Adaptive",
+        "version": "4.11.0"
+      },
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\$": {
+          "title": "Tooling property",
+          "description": "Open ended property for tooling."
+        }
+      },
+      "properties": {
+        "id": {
+          "type": "string",
+          "title": "Id",
+          "description": "Optional id for the dialog"
+        },
+        "disabled": {
+          "$ref": "#/definitions/booleanExpression",
+          "title": "Disabled",
+          "description": "Optional condition which if true will disable this action.",
+          "examples": [
+            "user.age > 3"
+          ]
+        },
+        "date": {
+          "$ref": "#/definitions/stringExpression",
+          "title": "Date",
+          "description": "Date in the future as a ISO string when the conversation should continue.",
+          "examples": [
+            "=addHours(utcNow(), 1)"
+          ]
+        },
+        "value": {
+          "$ref": "#/definitions/valueExpression",
+          "title": "Value",
+          "description": "Value to send in the activity.value."
+        },
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.ContinueConversationLater"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
+        }
+      }
+    },
+    "Microsoft.ContinueLoop": {
+      "$role": "implements(Microsoft.IDialog)",
+      "title": "Continue loop",
+      "description": "Stop executing this template and continue with the next iteration of the loop.",
+      "type": "object",
+      "required": [
+        "$kind"
+      ],
+      "$package": {
+        "name": "Microsoft.Bot.Builder.Dialogs.Adaptive",
+        "version": "4.11.0"
+      },
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\$": {
+          "title": "Tooling property",
+          "description": "Open ended property for tooling."
+        }
+      },
+      "properties": {
+        "id": {
+          "type": "string",
+          "title": "Id",
+          "description": "Optional id for the dialog"
+        },
+        "disabled": {
+          "$ref": "#/definitions/booleanExpression",
+          "title": "Disabled",
+          "description": "Optional condition which if true will disable this action.",
+          "examples": [
+            "user.age > 3"
+          ]
+        },
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.ContinueLoop"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
+        }
+      }
+    },
+    "Microsoft.CrossTrainedRecognizerSet": {
+      "$role": "implements(Microsoft.IRecognizer)",
+      "title": "Cross-trained recognizer set",
+      "description": "Recognizer for selecting between cross trained recognizers.",
+      "type": "object",
+      "required": [
+        "recognizers",
+        "$kind"
+      ],
+      "$package": {
+        "name": "Microsoft.Bot.Builder.Dialogs.Adaptive",
+        "version": "4.11.0"
+      },
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\$": {
+          "title": "Tooling property",
+          "description": "Open ended property for tooling."
+        }
+      },
+      "properties": {
+        "id": {
+          "type": "string",
+          "title": "Id",
+          "description": "Optional unique id using with RecognizerSet."
+        },
+        "recognizers": {
+          "type": "array",
+          "title": "Recognizers",
+          "description": "List of Recognizers defined for this set.",
+          "items": {
+            "$kind": "Microsoft.IRecognizer",
+            "$ref": "#/definitions/Microsoft.IRecognizer"
+          }
+        },
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.CrossTrainedRecognizerSet"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
+        }
+      }
+    },
+    "Microsoft.CurrencyEntityRecognizer": {
+      "$role": [
+        "implements(Microsoft.IRecognizer)",
+        "implements(Microsoft.IEntityRecognizer)"
+      ],
+      "title": "Currency entity recognizer",
+      "description": "Recognizer which recognizes currency.",
+      "type": "object",
+      "$package": {
+        "name": "Microsoft.Bot.Builder.Dialogs.Adaptive",
+        "version": "4.11.0"
+      },
+      "required": [
+        "$kind"
+      ],
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\$": {
+          "title": "Tooling property",
+          "description": "Open ended property for tooling."
+        }
+      },
+      "properties": {
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.CurrencyEntityRecognizer"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
+        }
+      }
+    },
+    "Microsoft.DateTimeEntityRecognizer": {
+      "$role": [
+        "implements(Microsoft.IRecognizer)",
+        "implements(Microsoft.IEntityRecognizer)"
+      ],
+      "title": "Date and time entity recognizer",
+      "description": "Recognizer which recognizes dates and time fragments.",
+      "type": "object",
+      "$package": {
+        "name": "Microsoft.Bot.Builder.Dialogs.Adaptive",
+        "version": "4.11.0"
+      },
+      "required": [
+        "$kind"
+      ],
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\$": {
+          "title": "Tooling property",
+          "description": "Open ended property for tooling."
+        }
+      },
+      "properties": {
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.DateTimeEntityRecognizer"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
+        }
+      }
+    },
+    "Microsoft.DateTimeInput": {
+      "$role": [
+        "implements(Microsoft.IDialog)",
+        "extends(Microsoft.InputDialog)"
+      ],
+      "title": "Date/time input dialog",
+      "description": "Collect information - Ask for date and/ or time",
+      "type": "object",
+      "defaultLocale": {
+        "$ref": "#/definitions/stringExpression",
+        "title": "Default locale",
+        "description": "Default locale.",
+        "default": "en-us"
+      },
+      "$package": {
+        "name": "Microsoft.Bot.Builder.Dialogs.Adaptive",
+        "version": "4.11.0"
+      },
+      "required": [
+        "$kind"
+      ],
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\$": {
+          "title": "Tooling property",
+          "description": "Open ended property for tooling."
+        }
+      },
+      "properties": {
+        "defaultValue": {
+          "$ref": "#/definitions/stringExpression",
+          "format": "date-time",
+          "title": "Default date",
+          "description": "'Property' will be set to the value or the result of the expression when max turn count is exceeded.",
+          "examples": [
+            "=user.birthday"
+          ]
+        },
+        "value": {
+          "$ref": "#/definitions/stringExpression",
+          "format": "date-time",
+          "title": "Value",
+          "description": "'Property' will be set to the value or the result of the expression unless it evaluates to null.",
+          "examples": [
+            "=user.birthday"
+          ]
+        },
+        "outputFormat": {
+          "$ref": "#/definitions/expression",
+          "title": "Output format",
+          "description": "Expression to use for formatting the output.",
+          "examples": [
+            "=this.value[0].Value"
+          ]
+        },
+        "id": {
+          "type": "string",
+          "title": "Id",
+          "description": "Optional id for the dialog"
+        },
+        "disabled": {
+          "$ref": "#/definitions/booleanExpression",
+          "title": "Disabled",
+          "description": "Optional condition which if true will disable this action.",
+          "default": false,
+          "examples": [
+            false,
+            "=user.isVip"
+          ]
+        },
+        "prompt": {
+          "$kind": "Microsoft.IActivityTemplate",
+          "title": "Initial prompt",
+          "description": "Message to send to collect information.",
+          "examples": [
+            "What is your birth date?"
+          ],
+          "$ref": "#/definitions/Microsoft.IActivityTemplate"
+        },
+        "unrecognizedPrompt": {
+          "$kind": "Microsoft.IActivityTemplate",
+          "title": "Unrecognized prompt",
+          "description": "Message to send when max turn count (if specified) has been exceeded and the default value is selected as the value.",
+          "examples": [
+            "Sorry, I'm having trouble understanding you. I will just use {this.options.defaultValue} for now. You can say 'I'm 36 years old' to change it."
+          ],
+          "$ref": "#/definitions/Microsoft.IActivityTemplate"
+        },
+        "invalidPrompt": {
+          "$kind": "Microsoft.IActivityTemplate",
+          "title": "Invalid prompt",
+          "description": "Message to send when the user input does not meet any validation expression.",
+          "examples": [
+            "Sorry, '{this.value}' does not work. I need a number between 1-150. What is your age?"
+          ],
+          "$ref": "#/definitions/Microsoft.IActivityTemplate"
+        },
+        "defaultValueResponse": {
+          "$kind": "Microsoft.IActivityTemplate",
+          "title": "Default value response",
+          "description": "Message to send when max turn count (if specified) has been exceeded and the default value is selected as the value.",
+          "examples": [
+            "Sorry, I'm having trouble understanding you. I will just use {this.options.defaultValue} for now. You can say 'I'm 36 years old' to change it."
+          ],
+          "$ref": "#/definitions/Microsoft.IActivityTemplate"
+        },
+        "maxTurnCount": {
+          "$ref": "#/definitions/integerExpression",
+          "title": "Max turn count",
+          "description": "Maximum number of re-prompt attempts to collect information.",
+          "default": 3,
+          "examples": [
+            3,
+            "=settings.xyz"
+          ]
+        },
+        "validations": {
+          "type": "array",
+          "title": "Validation expressions",
+          "description": "Expression to validate user input.",
+          "items": {
+            "$ref": "#/definitions/condition",
+            "title": "Condition",
+            "description": "Expression which needs to met for the input to be considered valid",
+            "examples": [
+              "int(this.value) > 1 && int(this.value) <= 150",
+              "count(this.value) < 300"
+            ]
+          }
+        },
+        "property": {
+          "$ref": "#/definitions/stringExpression",
+          "title": "Property",
+          "description": "Property to store collected information. Input will be skipped if property has value (unless 'Always prompt' is true).",
+          "examples": [
+            "$birthday",
+            "dialog.${user.name}",
+            "=f(x)"
+          ]
+        },
+        "alwaysPrompt": {
+          "$ref": "#/definitions/booleanExpression",
+          "title": "Always prompt",
+          "description": "Collect information even if the specified 'property' is not empty.",
+          "default": false,
+          "examples": [
+            false,
+            "=$val"
+          ]
+        },
+        "allowInterruptions": {
+          "$ref": "#/definitions/booleanExpression",
+          "title": "Allow Interruptions",
+          "description": "A boolean expression that determines whether the parent should be allowed to interrupt the input.",
+          "default": true,
+          "examples": [
+            true,
+            "=user.xyz"
+          ]
+        },
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.DateTimeInput"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
+        }
+      }
+    },
+    "Microsoft.DebugBreak": {
+      "$role": "implements(Microsoft.IDialog)",
+      "title": "Debugger break",
+      "description": "If debugger is attached, stop the execution at this point in the conversation.",
+      "type": "object",
+      "$package": {
+        "name": "Microsoft.Bot.Builder.Dialogs.Adaptive",
+        "version": "4.11.0"
+      },
+      "required": [
+        "$kind"
+      ],
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\$": {
+          "title": "Tooling property",
+          "description": "Open ended property for tooling."
+        }
+      },
+      "properties": {
+        "id": {
+          "type": "string",
+          "title": "Id",
+          "description": "Optional id for the dialog"
+        },
+        "disabled": {
+          "$ref": "#/definitions/booleanExpression",
+          "title": "Disabled",
+          "description": "Optional condition which if true will disable this action.",
+          "examples": [
+            "user.age > 3"
+          ]
+        },
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.DebugBreak"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
+        }
+      }
+    },
+    "Microsoft.DeleteActivity": {
+      "$role": "implements(Microsoft.IDialog)",
+      "title": "Delete Activity",
+      "description": "Delete an activity that was previously sent.",
+      "type": "object",
+      "required": [
+        "activityId",
+        "$kind"
+      ],
+      "$package": {
+        "name": "Microsoft.Bot.Builder.Dialogs.Adaptive",
+        "version": "4.11.0"
+      },
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\$": {
+          "title": "Tooling property",
+          "description": "Open ended property for tooling."
+        }
+      },
+      "properties": {
+        "id": {
+          "type": "string",
+          "title": "Id",
+          "description": "Optional id for the dialog"
+        },
+        "activityId": {
+          "$ref": "#/definitions/stringExpression",
+          "title": "ActivityId",
+          "description": "expression to an activityId to delete",
+          "examples": [
+            "=$lastActivity"
+          ]
+        },
+        "disabled": {
+          "$ref": "#/definitions/booleanExpression",
+          "title": "Disabled",
+          "description": "Optional condition which if true will disable this action.",
+          "examples": [
+            "user.age > 3"
+          ]
+        },
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.DeleteActivity"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
+        }
+      }
+    },
+    "Microsoft.DeleteProperties": {
+      "$role": "implements(Microsoft.IDialog)",
+      "title": "Delete Properties",
+      "description": "Delete multiple properties and any value it holds.",
+      "type": "object",
+      "required": [
+        "properties",
+        "$kind"
+      ],
+      "$package": {
+        "name": "Microsoft.Bot.Builder.Dialogs.Adaptive",
+        "version": "4.11.0"
+      },
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\$": {
+          "title": "Tooling property",
+          "description": "Open ended property for tooling."
+        }
+      },
+      "properties": {
+        "id": {
+          "type": "string",
+          "title": "Id",
+          "description": "Optional id for the dialog"
+        },
+        "disabled": {
+          "$ref": "#/definitions/booleanExpression",
+          "title": "Disabled",
+          "description": "Optional condition which if true will disable this action.",
+          "examples": [
+            "user.age > 3"
+          ]
+        },
+        "properties": {
+          "type": "array",
+          "title": "Properties",
+          "description": "Properties to delete.",
+          "items": {
+            "$ref": "#/definitions/stringExpression",
+            "title": "Property",
+            "description": "Property to delete."
+          }
+        },
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.DeleteProperties"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
+        }
+      }
+    },
+    "Microsoft.DeleteProperty": {
+      "$role": "implements(Microsoft.IDialog)",
+      "title": "Delete property",
+      "description": "Delete a property and any value it holds.",
+      "type": "object",
+      "required": [
+        "property",
+        "$kind"
+      ],
+      "$package": {
+        "name": "Microsoft.Bot.Builder.Dialogs.Adaptive",
+        "version": "4.11.0"
+      },
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\$": {
+          "title": "Tooling property",
+          "description": "Open ended property for tooling."
+        }
+      },
+      "properties": {
+        "id": {
+          "type": "string",
+          "title": "Id",
+          "description": "Optional id for the dialog"
+        },
+        "disabled": {
+          "$ref": "#/definitions/booleanExpression",
+          "title": "Disabled",
+          "description": "Optional condition which if true will disable this action.",
+          "examples": [
+            "user.age > 3"
+          ]
+        },
+        "property": {
+          "$ref": "#/definitions/stringExpression",
+          "title": "Property",
+          "description": "Property to delete."
+        },
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.DeleteProperty"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
+        }
+      }
+    },
+    "Microsoft.DimensionEntityRecognizer": {
+      "$role": [
+        "implements(Microsoft.IRecognizer)",
+        "implements(Microsoft.IEntityRecognizer)"
+      ],
+      "title": "Dimension entity recognizer",
+      "description": "Recognizer which recognizes dimension.",
+      "type": "object",
+      "$package": {
+        "name": "Microsoft.Bot.Builder.Dialogs.Adaptive",
+        "version": "4.11.0"
+      },
+      "required": [
+        "$kind"
+      ],
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\$": {
+          "title": "Tooling property",
+          "description": "Open ended property for tooling."
+        }
+      },
+      "properties": {
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.DimensionEntityRecognizer"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
+        }
+      }
+    },
+    "Microsoft.EditActions": {
+      "$role": "implements(Microsoft.IDialog)",
+      "title": "Edit actions.",
+      "description": "Edit the current list of actions.",
+      "type": "object",
+      "required": [
+        "changeType",
+        "actions",
+        "$kind"
+      ],
+      "$package": {
+        "name": "Microsoft.Bot.Builder.Dialogs.Adaptive",
+        "version": "4.11.0"
+      },
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\$": {
+          "title": "Tooling property",
+          "description": "Open ended property for tooling."
+        }
+      },
+      "properties": {
+        "id": {
+          "type": "string",
+          "title": "Id",
+          "description": "Optional id for the dialog"
+        },
+        "disabled": {
+          "$ref": "#/definitions/booleanExpression",
+          "title": "Disabled",
+          "description": "Optional condition which if true will disable this action.",
+          "examples": [
+            "user.age > 3"
+          ]
+        },
+        "changeType": {
+          "title": "Type of change",
+          "description": "Type of change to apply to the current actions.",
+          "oneOf": [
+            {
+              "type": "string",
+              "title": "Standard change",
+              "description": "Standard change types.",
+              "enum": [
+                "insertActions",
+                "insertActionsBeforeTags",
+                "appendActions",
+                "endSequence",
+                "replaceSequence"
+              ]
+            },
+            {
+              "$ref": "#/definitions/equalsExpression"
+            }
+          ]
+        },
+        "actions": {
+          "type": "array",
+          "title": "Actions",
+          "description": "Actions to apply.",
+          "items": {
+            "$kind": "Microsoft.IDialog",
+            "$ref": "#/definitions/Microsoft.IDialog"
+          }
+        },
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.EditActions"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
+        }
+      }
+    },
+    "Microsoft.EditArray": {
+      "$role": "implements(Microsoft.IDialog)",
+      "title": "Edit array",
+      "description": "Modify an array in memory",
+      "type": "object",
+      "required": [
+        "itemsProperty",
+        "$kind"
+      ],
+      "$package": {
+        "name": "Microsoft.Bot.Builder.Dialogs.Adaptive",
+        "version": "4.11.0"
+      },
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\$": {
+          "title": "Tooling property",
+          "description": "Open ended property for tooling."
+        }
+      },
+      "properties": {
+        "id": {
+          "type": "string",
+          "title": "Id",
+          "description": "Optional id for the dialog"
+        },
+        "changeType": {
+          "title": "Type of change",
+          "description": "Type of change to the array in memory.",
+          "oneOf": [
+            {
+              "type": "string",
+              "title": "Change type",
+              "description": "Standard change type.",
+              "enum": [
+                "push",
+                "pop",
+                "take",
+                "remove",
+                "clear"
+              ]
+            },
+            {
+              "$ref": "#/definitions/equalsExpression"
+            }
+          ]
+        },
+        "disabled": {
+          "$ref": "#/definitions/booleanExpression",
+          "title": "Disabled",
+          "description": "Optional condition which if true will disable this action.",
+          "examples": [
+            "user.age > 3"
+          ]
+        },
+        "itemsProperty": {
+          "$ref": "#/definitions/stringExpression",
+          "title": "Items property",
+          "description": "Property that holds the array to update."
+        },
+        "resultProperty": {
+          "$ref": "#/definitions/stringExpression",
+          "title": "Result property",
+          "description": "Property to store the result of this action."
+        },
+        "value": {
+          "$ref": "#/definitions/valueExpression",
+          "title": "Value",
+          "description": "New value or expression.",
+          "examples": [
+            "milk",
+            "=dialog.favColor",
+            "=dialog.favColor == 'red'"
+          ]
+        },
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.EditArray"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
+        }
+      }
+    },
+    "Microsoft.EmailEntityRecognizer": {
+      "$role": [
+        "implements(Microsoft.IRecognizer)",
+        "implements(Microsoft.IEntityRecognizer)"
+      ],
+      "title": "Email entity recognizer",
+      "description": "Recognizer which recognizes email.",
+      "type": "object",
+      "$package": {
+        "name": "Microsoft.Bot.Builder.Dialogs.Adaptive",
+        "version": "4.11.0"
+      },
+      "required": [
+        "$kind"
+      ],
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\$": {
+          "title": "Tooling property",
+          "description": "Open ended property for tooling."
+        }
+      },
+      "properties": {
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.EmailEntityRecognizer"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
+        }
+      }
+    },
+    "Microsoft.EmitEvent": {
+      "$role": "implements(Microsoft.IDialog)",
+      "title": "Emit a custom event",
+      "description": "Emit an event. Capture this event with a trigger.",
+      "type": "object",
+      "required": [
+        "eventName",
+        "$kind"
+      ],
+      "$package": {
+        "name": "Microsoft.Bot.Builder.Dialogs.Adaptive",
+        "version": "4.11.0"
+      },
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\$": {
+          "title": "Tooling property",
+          "description": "Open ended property for tooling."
+        }
+      },
+      "properties": {
+        "id": {
+          "type": "string",
+          "title": "Id",
+          "description": "Optional id for the dialog"
+        },
+        "disabled": {
+          "$ref": "#/definitions/booleanExpression",
+          "title": "Disabled",
+          "description": "Optional condition which if true will disable this action.",
+          "examples": [
+            "user.age > 3"
+          ]
+        },
+        "eventName": {
+          "$role": "expression",
+          "title": "Event name",
+          "description": "Name of the event to emit.",
+          "oneOf": [
+            {
+              "type": "string",
+              "title": "Built-in event",
+              "description": "Standard event type.",
+              "enum": [
+                "beginDialog",
+                "resumeDialog",
+                "repromptDialog",
+                "cancelDialog",
+                "endDialog",
+                "activityReceived",
+                "recognizedIntent",
+                "unknownIntent",
+                "actionsStarted",
+                "actionsSaved",
+                "actionsEnded",
+                "actionsResumed"
+              ]
+            },
+            {
+              "type": "string",
+              "title": "Custom event",
+              "description": "Custom event type",
+              "pattern": "^(?!(beginDialog$|resumeDialog$|repromptDialog$|cancelDialog$|endDialog$|activityReceived$|recognizedIntent$|unknownIntent$|actionsStarted$|actionsSaved$|actionsEnded$|actionsResumed))(\\S){1}.*"
+            },
+            {
+              "$ref": "#/definitions/equalsExpression"
+            }
+          ]
+        },
+        "eventValue": {
+          "$ref": "#/definitions/valueExpression",
+          "title": "Event value",
+          "description": "Value to emit with the event (optional)."
+        },
+        "bubbleEvent": {
+          "$ref": "#/definitions/booleanExpression",
+          "title": "Bubble event",
+          "description": "If true this event is passed on to parent dialogs."
+        },
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.EmitEvent"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
+        }
+      }
+    },
+    "Microsoft.EndDialog": {
+      "$role": "implements(Microsoft.IDialog)",
+      "title": "End dialog",
+      "description": "End this dialog.",
+      "type": "object",
+      "$package": {
+        "name": "Microsoft.Bot.Builder.Dialogs.Adaptive",
+        "version": "4.11.0"
+      },
+      "required": [
+        "$kind"
+      ],
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\$": {
+          "title": "Tooling property",
+          "description": "Open ended property for tooling."
+        }
+      },
+      "properties": {
+        "id": {
+          "type": "string",
+          "title": "Id",
+          "description": "Optional id for the dialog"
+        },
+        "disabled": {
+          "$ref": "#/definitions/booleanExpression",
+          "title": "Disabled",
+          "description": "Optional condition which if true will disable this action.",
+          "examples": [
+            "user.age > 3"
+          ]
+        },
+        "value": {
+          "$ref": "#/definitions/valueExpression",
+          "title": "Value",
+          "description": "Result value returned to the parent dialog.",
+          "examples": [
+            "=dialog.userName",
+            "='tomato'"
+          ]
+        },
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.EndDialog"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
+        }
+      }
+    },
+    "Microsoft.EndTurn": {
+      "$role": "implements(Microsoft.IDialog)",
+      "title": "End turn",
+      "description": "End the current turn without ending the dialog.",
+      "type": "object",
+      "$package": {
+        "name": "Microsoft.Bot.Builder.Dialogs.Adaptive",
+        "version": "4.11.0"
+      },
+      "required": [
+        "$kind"
+      ],
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\$": {
+          "title": "Tooling property",
+          "description": "Open ended property for tooling."
+        }
+      },
+      "properties": {
+        "id": {
+          "type": "string",
+          "title": "Id",
+          "description": "Optional id for the dialog"
+        },
+        "disabled": {
+          "$ref": "#/definitions/booleanExpression",
+          "title": "Disabled",
+          "description": "Optional condition which if true will disable this action.",
+          "examples": [
+            "user.age > 3"
+          ]
+        },
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.EndTurn"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
+        }
+      }
+    },
+    "Microsoft.FirstSelector": {
+      "$role": "implements(Microsoft.ITriggerSelector)",
+      "title": "First trigger selector",
+      "description": "Selector for first true rule",
+      "type": "object",
+      "$package": {
+        "name": "Microsoft.Bot.Builder.Dialogs.Adaptive",
+        "version": "4.11.0"
+      },
+      "required": [
+        "$kind"
+      ],
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\$": {
+          "title": "Tooling property",
+          "description": "Open ended property for tooling."
+        }
+      },
+      "properties": {
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.FirstSelector"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
+        }
+      }
+    },
+    "Microsoft.Foreach": {
+      "$role": "implements(Microsoft.IDialog)",
+      "title": "For each item",
+      "description": "Execute actions on each item in an a collection.",
+      "type": "object",
+      "required": [
+        "itemsProperty",
+        "actions",
+        "$kind"
+      ],
+      "$package": {
+        "name": "Microsoft.Bot.Builder.Dialogs.Adaptive",
+        "version": "4.11.0"
+      },
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\$": {
+          "title": "Tooling property",
+          "description": "Open ended property for tooling."
+        }
+      },
+      "properties": {
+        "id": {
+          "type": "string",
+          "title": "Id",
+          "description": "Optional id for the dialog"
+        },
+        "disabled": {
+          "$ref": "#/definitions/booleanExpression",
+          "title": "Disabled",
+          "description": "Optional condition which if true will disable this action.",
+          "examples": [
+            "user.age > 3"
+          ]
+        },
+        "itemsProperty": {
+          "$ref": "#/definitions/stringExpression",
+          "title": "Items property",
+          "description": "Property that holds the array.",
+          "examples": [
+            "user.todoList"
+          ]
+        },
+        "index": {
+          "$ref": "#/definitions/stringExpression",
+          "title": "Index property",
+          "description": "Property that holds the index of the item.",
+          "default": "dialog.foreach.index"
+        },
+        "value": {
+          "$ref": "#/definitions/stringExpression",
+          "title": "Value property",
+          "description": "Property that holds the value of the item.",
+          "default": "dialog.foreach.value"
+        },
+        "actions": {
+          "type": "array",
+          "title": "Actions",
+          "description": "Actions to execute for each item. Use '$foreach.value' to access the value of each item. Use '$foreach.index' to access the index of each item.",
+          "items": {
+            "$kind": "Microsoft.IDialog",
+            "$ref": "#/definitions/Microsoft.IDialog"
+          }
+        },
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.Foreach"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
+        }
+      }
+    },
+    "Microsoft.ForeachPage": {
+      "$role": "implements(Microsoft.IDialog)",
+      "title": "For each page",
+      "description": "Execute actions on each page (collection of items) in an array.",
+      "type": "object",
+      "required": [
+        "itemsProperty",
+        "actions",
+        "$kind"
+      ],
+      "$package": {
+        "name": "Microsoft.Bot.Builder.Dialogs.Adaptive",
+        "version": "4.11.0"
+      },
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\$": {
+          "title": "Tooling property",
+          "description": "Open ended property for tooling."
+        }
+      },
+      "properties": {
+        "id": {
+          "type": "string",
+          "title": "Id",
+          "description": "Optional id for the dialog"
+        },
+        "disabled": {
+          "$ref": "#/definitions/booleanExpression",
+          "title": "Disabled",
+          "description": "Optional condition which if true will disable this action.",
+          "examples": [
+            "user.age > 3"
+          ]
+        },
+        "itemsProperty": {
+          "$ref": "#/definitions/stringExpression",
+          "title": "Items property",
+          "description": "Property that holds the array.",
+          "examples": [
+            "user.todoList"
+          ]
+        },
+        "actions": {
+          "type": "array",
+          "title": "Actions",
+          "description": "Actions to execute for each page. Use '$foreach.page' to access each page.",
+          "items": {
+            "$kind": "Microsoft.IDialog",
+            "$ref": "#/definitions/Microsoft.IDialog"
+          }
+        },
+        "pageIndex": {
+          "$ref": "#/definitions/stringExpression",
+          "title": "Index property",
+          "description": "Property that holds the index of the page.",
+          "default": "dialog.foreach.pageindex"
+        },
+        "page": {
+          "$ref": "#/definitions/stringExpression",
+          "title": "Page property",
+          "description": "Property that holds the value of the page.",
+          "default": "dialog.foreach.page"
+        },
+        "pageSize": {
+          "$ref": "#/definitions/integerExpression",
+          "title": "Page size",
+          "description": "Number of items in each page.",
+          "default": 10
+        },
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.ForeachPage"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
+        }
+      }
+    },
+    "Microsoft.GetActivityMembers": {
+      "$role": "implements(Microsoft.IDialog)",
+      "title": "Get activity members",
+      "description": "Get the members who are participating in an activity. (BotFrameworkAdapter only)",
+      "type": "object",
+      "$package": {
+        "name": "Microsoft.Bot.Builder.Dialogs.Adaptive",
+        "version": "4.11.0"
+      },
+      "required": [
+        "$kind"
+      ],
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\$": {
+          "title": "Tooling property",
+          "description": "Open ended property for tooling."
+        }
+      },
+      "properties": {
+        "id": {
+          "type": "string",
+          "title": "Id",
+          "description": "Optional id for the dialog"
+        },
+        "property": {
+          "$ref": "#/definitions/stringExpression",
+          "title": "Property",
+          "description": "Property (named location to store information).",
+          "examples": [
+            "user.age"
+          ]
+        },
+        "activityId": {
+          "$ref": "#/definitions/stringExpression",
+          "title": "Activity Id",
+          "description": "Activity ID or expression to an activityId to use to get the members. If none is defined then the current activity id will be used.",
+          "examples": [
+            "$lastActivity"
+          ]
+        },
+        "disabled": {
+          "$ref": "#/definitions/booleanExpression",
+          "title": "Disabled",
+          "description": "Optional condition which if true will disable this action.",
+          "examples": [
+            "user.age > 3"
+          ]
+        },
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.GetActivityMembers"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
+        }
+      }
+    },
+    "Microsoft.GetConversationMembers": {
+      "$role": "implements(Microsoft.IDialog)",
+      "title": "Get conversation members",
+      "description": "Get the members who are participating in an conversation. (BotFrameworkAdapter only)",
+      "type": "object",
+      "$package": {
+        "name": "Microsoft.Bot.Builder.Dialogs.Adaptive",
+        "version": "4.11.0"
+      },
+      "required": [
+        "$kind"
+      ],
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\$": {
+          "title": "Tooling property",
+          "description": "Open ended property for tooling."
+        }
+      },
+      "properties": {
+        "id": {
+          "type": "string",
+          "title": "Id",
+          "description": "Optional id for the dialog"
+        },
+        "property": {
+          "$ref": "#/definitions/stringExpression",
+          "title": "Property",
+          "description": "Property (named location to store information).",
+          "examples": [
+            "user.age"
+          ]
+        },
+        "disabled": {
+          "$ref": "#/definitions/booleanExpression",
+          "title": "Disabled",
+          "description": "Optional condition which if true will disable this action.",
+          "examples": [
+            "user.age > 3"
+          ]
+        },
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.GetConversationMembers"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
+        }
+      }
+    },
+    "Microsoft.GotoAction": {
+      "$role": "implements(Microsoft.IDialog)",
+      "title": "Go to action",
+      "description": "Go to an an action by id.",
+      "type": "object",
+      "required": [
+        "actionId",
+        "$kind"
+      ],
+      "$package": {
+        "name": "Microsoft.Bot.Builder.Dialogs.Adaptive",
+        "version": "4.11.0"
+      },
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\$": {
+          "title": "Tooling property",
+          "description": "Open ended property for tooling."
+        }
+      },
+      "properties": {
+        "id": {
+          "type": "string",
+          "title": "Id",
+          "description": "Optional id for the dialog"
+        },
+        "disabled": {
+          "$ref": "#/definitions/booleanExpression",
+          "title": "Disabled",
+          "description": "Optional condition which if true will disable this action.",
+          "examples": [
+            "user.age > 3"
+          ]
+        },
+        "actionId": {
+          "$ref": "#/definitions/stringExpression",
+          "title": "Action Id",
+          "description": "Action Id to execute next"
+        },
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.GotoAction"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
+        }
+      }
+    },
+    "Microsoft.GuidEntityRecognizer": {
+      "$role": [
+        "implements(Microsoft.IRecognizer)",
+        "implements(Microsoft.IEntityRecognizer)"
+      ],
+      "title": "Guid entity recognizer",
+      "description": "Recognizer which recognizes guids.",
+      "type": "object",
+      "$package": {
+        "name": "Microsoft.Bot.Builder.Dialogs.Adaptive",
+        "version": "4.11.0"
+      },
+      "required": [
+        "$kind"
+      ],
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\$": {
+          "title": "Tooling property",
+          "description": "Open ended property for tooling."
+        }
+      },
+      "properties": {
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.GuidEntityRecognizer"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
+        }
+      }
+    },
+    "Microsoft.HashtagEntityRecognizer": {
+      "$role": [
+        "implements(Microsoft.IRecognizer)",
+        "implements(Microsoft.IEntityRecognizer)"
+      ],
+      "title": "Hashtag entity recognizer",
+      "description": "Recognizer which recognizes Hashtags.",
+      "type": "object",
+      "$package": {
+        "name": "Microsoft.Bot.Builder.Dialogs.Adaptive",
+        "version": "4.11.0"
+      },
+      "required": [
+        "$kind"
+      ],
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\$": {
+          "title": "Tooling property",
+          "description": "Open ended property for tooling."
+        }
+      },
+      "properties": {
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.HashtagEntityRecognizer"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
+        }
+      }
+    },
+    "Microsoft.HttpRequest": {
+      "$role": "implements(Microsoft.IDialog)",
+      "type": "object",
+      "title": "HTTP request",
+      "description": "Make a HTTP request.",
+      "required": [
+        "url",
+        "method",
+        "$kind"
+      ],
+      "$package": {
+        "name": "Microsoft.Bot.Builder.Dialogs.Adaptive",
+        "version": "4.11.0"
+      },
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\$": {
+          "title": "Tooling property",
+          "description": "Open ended property for tooling."
+        }
+      },
+      "properties": {
+        "id": {
+          "type": "string",
+          "title": "Id",
+          "description": "Optional id for the dialog"
+        },
+        "disabled": {
+          "$ref": "#/definitions/booleanExpression",
+          "title": "Disabled",
+          "description": "Optional condition which if true will disable this action.",
+          "examples": [
+            "user.age > 3"
+          ]
+        },
+        "method": {
+          "type": "string",
+          "title": "HTTP method",
+          "description": "HTTP method to use.",
+          "enum": [
+            "GET",
+            "POST",
+            "PATCH",
+            "PUT",
+            "DELETE"
+          ],
+          "examples": [
+            "GET",
+            "POST"
+          ]
+        },
+        "url": {
+          "$ref": "#/definitions/stringExpression",
+          "title": "Url",
+          "description": "URL to call (supports data binding).",
+          "examples": [
+            "https://contoso.com"
+          ]
+        },
+        "body": {
+          "$ref": "#/definitions/valueExpression",
+          "title": "Body",
+          "description": "Body to include in the HTTP call (supports data binding).",
+          "additionalProperties": true
+        },
+        "resultProperty": {
+          "$ref": "#/definitions/stringExpression",
+          "title": "Result property",
+          "description": "A property to store the result of this action. The result can include any of the 4 properties from the HTTP response: statusCode, reasonPhrase, content, and headers. If the content is JSON it will be a deserialized object. The values can be accessed via .content for example.",
+          "examples": [
+            "dialog.contosodata"
+          ]
+        },
+        "contentType": {
+          "$ref": "#/definitions/stringExpression",
+          "title": "Content type",
+          "description": "Content media type for the body.",
+          "examples": [
+            "application/json",
+            "text/plain"
+          ]
+        },
+        "headers": {
+          "type": "object",
+          "title": "Headers",
+          "description": "One or more headers to include in the request (supports data binding).",
+          "additionalProperties": {
+            "$ref": "#/definitions/stringExpression"
+          }
+        },
+        "responseType": {
+          "$ref": "#/definitions/stringExpression",
+          "title": "Response type",
+          "description": "Defines the type of HTTP response. Automatically calls the 'Send a response' action if set to 'Activity' or 'Activities'.",
+          "oneOf": [
+            {
+              "type": "string",
+              "title": "Standard response",
+              "description": "Standard response type.",
+              "enum": [
+                "none",
+                "json",
+                "activity",
+                "activities",
+                "binary"
+              ],
+              "default": "json"
+            },
+            {
+              "$ref": "#/definitions/equalsExpression"
+            }
+          ]
+        },
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.HttpRequest"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
+        }
+      }
+    },
+    "Microsoft.IActivityTemplate": {
+      "title": "Microsoft ActivityTemplates",
+      "description": "Components which are ActivityTemplate, which is string template, an activity, or a implementation of ActivityTemplate",
+      "$role": "interface",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "required": [
+            "type"
+          ],
+          "description": "An Activity is the basic communication type for the Bot Framework 3.0 protocol.",
+          "title": "Activity",
+          "type": "object",
+          "properties": {
+            "type": {
+              "description": "Contains the activity type. Possible values include: 'message', 'contactRelationUpdate',\n'conversationUpdate', 'typing', 'endOfConversation', 'event', 'invoke', 'deleteUserData',\n'messageUpdate', 'messageDelete', 'installationUpdate', 'messageReaction', 'suggestion',\n'trace', 'handoff'",
+              "type": "string",
+              "title": "type"
+            },
+            "id": {
+              "description": "Contains an ID that uniquely identifies the activity on the channel.",
+              "type": "string",
+              "title": "id"
+            },
+            "timestamp": {
+              "description": "Contains the date and time that the message was sent, in UTC, expressed in ISO-8601 format.",
+              "type": "string",
+              "format": "date-time",
+              "title": "timestamp"
+            },
+            "localTimestamp": {
+              "description": "Contains the date and time that the message was sent, in local time, expressed in ISO-8601\nformat.\nFor example, 2016-09-23T13:07:49.4714686-07:00.",
+              "type": "string",
+              "format": "date-time",
+              "title": "localTimestamp"
+            },
+            "localTimezone": {
+              "description": "Contains the name of the timezone in which the message, in local time, expressed in IANA Time\nZone database format.\nFor example, America/Los_Angeles.",
+              "type": "string",
+              "title": "localTimezone"
+            },
+            "serviceUrl": {
+              "description": "Contains the URL that specifies the channel's service endpoint. Set by the channel.",
+              "type": "string",
+              "title": "serviceUrl"
+            },
+            "channelId": {
+              "description": "Contains an ID that uniquely identifies the channel. Set by the channel.",
+              "type": "string",
+              "title": "channelId"
+            },
+            "from": {
+              "$ref": "#/definitions/Microsoft.IActivityTemplate/oneOf/1/properties/membersAdded/items",
+              "description": "Identifies the sender of the message.",
+              "title": "from"
+            },
+            "conversation": {
+              "description": "Identifies the conversation to which the activity belongs.",
+              "title": "conversation",
+              "type": "object",
+              "required": [
+                "conversationType",
+                "id",
+                "isGroup",
+                "name"
+              ],
+              "properties": {
+                "isGroup": {
+                  "description": "Indicates whether the conversation contains more than two participants at the time the\nactivity was generated",
+                  "type": "boolean",
+                  "title": "isGroup"
+                },
+                "conversationType": {
+                  "description": "Indicates the type of the conversation in channels that distinguish between conversation types",
+                  "type": "string",
+                  "title": "conversationType"
+                },
+                "id": {
+                  "description": "Channel id for the user or bot on this channel (Example: joe@smith.com, or @joesmith or\n123456)",
+                  "type": "string",
+                  "title": "id"
+                },
+                "name": {
+                  "description": "Display friendly name",
+                  "type": "string",
+                  "title": "name"
+                },
+                "aadObjectId": {
+                  "description": "This account's object ID within Azure Active Directory (AAD)",
+                  "type": "string",
+                  "title": "aadObjectId"
+                },
+                "role": {
+                  "description": "Role of the entity behind the account (Example: User, Bot, etc.). Possible values include:\n'user', 'bot'",
+                  "enum": [
+                    "bot",
+                    "user"
+                  ],
+                  "type": "string",
+                  "title": "role"
+                }
+              }
+            },
+            "recipient": {
+              "$ref": "#/definitions/Microsoft.IActivityTemplate/oneOf/1/properties/membersAdded/items",
+              "description": "Identifies the recipient of the message.",
+              "title": "recipient"
+            },
+            "textFormat": {
+              "description": "Format of text fields Default:markdown. Possible values include: 'markdown', 'plain', 'xml'",
+              "type": "string",
+              "title": "textFormat"
+            },
+            "attachmentLayout": {
+              "description": "The layout hint for multiple attachments. Default: list. Possible values include: 'list',\n'carousel'",
+              "type": "string",
+              "title": "attachmentLayout"
+            },
+            "membersAdded": {
+              "description": "The collection of members added to the conversation.",
+              "type": "array",
+              "title": "membersAdded",
+              "items": {
+                "description": "Channel account information needed to route a message",
+                "title": "ChannelAccount",
+                "type": "object",
+                "required": [
+                  "id",
+                  "name"
+                ],
+                "properties": {
+                  "id": {
+                    "description": "Channel id for the user or bot on this channel (Example: joe@smith.com, or @joesmith or\n123456)",
+                    "type": "string",
+                    "title": "id"
+                  },
+                  "name": {
+                    "description": "Display friendly name",
+                    "type": "string",
+                    "title": "name"
+                  },
+                  "aadObjectId": {
+                    "description": "This account's object ID within Azure Active Directory (AAD)",
+                    "type": "string",
+                    "title": "aadObjectId"
+                  },
+                  "role": {
+                    "description": "Role of the entity behind the account (Example: User, Bot, etc.). Possible values include:\n'user', 'bot'",
+                    "type": "string",
+                    "title": "role"
+                  }
+                }
+              }
+            },
+            "membersRemoved": {
+              "description": "The collection of members removed from the conversation.",
+              "type": "array",
+              "title": "membersRemoved",
+              "items": {
+                "$ref": "#/definitions/Microsoft.IActivityTemplate/oneOf/1/properties/membersAdded/items"
+              }
+            },
+            "reactionsAdded": {
+              "description": "The collection of reactions added to the conversation.",
+              "type": "array",
+              "title": "reactionsAdded",
+              "items": {
+                "description": "Message reaction object",
+                "title": "MessageReaction",
+                "type": "object",
+                "required": [
+                  "type"
+                ],
+                "properties": {
+                  "type": {
+                    "description": "Message reaction type. Possible values include: 'like', 'plusOne'",
+                    "type": "string",
+                    "title": "type"
+                  }
+                }
+              }
+            },
+            "reactionsRemoved": {
+              "description": "The collection of reactions removed from the conversation.",
+              "type": "array",
+              "title": "reactionsRemoved",
+              "items": {
+                "$ref": "#/definitions/Microsoft.IActivityTemplate/oneOf/1/properties/reactionsAdded/items"
+              }
+            },
+            "topicName": {
+              "description": "The updated topic name of the conversation.",
+              "type": "string",
+              "title": "topicName"
+            },
+            "historyDisclosed": {
+              "description": "Indicates whether the prior history of the channel is disclosed.",
+              "type": "boolean",
+              "title": "historyDisclosed"
+            },
+            "locale": {
+              "description": "A locale name for the contents of the text field.\nThe locale name is a combination of an ISO 639 two- or three-letter culture code associated\nwith a language\nand an ISO 3166 two-letter subculture code associated with a country or region.\nThe locale name can also correspond to a valid BCP-47 language tag.",
+              "type": "string",
+              "title": "locale"
+            },
+            "text": {
+              "description": "The text content of the message.",
+              "type": "string",
+              "title": "text"
+            },
+            "speak": {
+              "description": "The text to speak.",
+              "type": "string",
+              "title": "speak"
+            },
+            "inputHint": {
+              "description": "Indicates whether your bot is accepting,\nexpecting, or ignoring user input after the message is delivered to the client. Possible\nvalues include: 'acceptingInput', 'ignoringInput', 'expectingInput'",
+              "type": "string",
+              "title": "inputHint"
+            },
+            "summary": {
+              "description": "The text to display if the channel cannot render cards.",
+              "type": "string",
+              "title": "summary"
+            },
+            "suggestedActions": {
+              "description": "The suggested actions for the activity.",
+              "title": "suggestedActions",
+              "type": "object",
+              "required": [
+                "actions",
+                "to"
+              ],
+              "properties": {
+                "to": {
+                  "description": "Ids of the recipients that the actions should be shown to.  These Ids are relative to the\nchannelId and a subset of all recipients of the activity",
+                  "type": "array",
+                  "title": "to",
+                  "items": {
+                    "title": "Id",
+                    "description": "Id of recipient.",
+                    "type": "string"
+                  }
+                },
+                "actions": {
+                  "description": "Actions that can be shown to the user",
+                  "type": "array",
+                  "title": "actions",
+                  "items": {
+                    "description": "A clickable action",
+                    "title": "CardAction",
+                    "type": "object",
+                    "required": [
+                      "title",
+                      "type",
+                      "value"
+                    ],
+                    "properties": {
+                      "type": {
+                        "description": "The type of action implemented by this button. Possible values include: 'openUrl', 'imBack',\n'postBack', 'playAudio', 'playVideo', 'showImage', 'downloadFile', 'signin', 'call',\n'payment', 'messageBack'",
+                        "type": "string",
+                        "title": "type"
+                      },
+                      "title": {
+                        "description": "Text description which appears on the button",
+                        "type": "string",
+                        "title": "title"
+                      },
+                      "image": {
+                        "description": "Image URL which will appear on the button, next to text label",
+                        "type": "string",
+                        "title": "image"
+                      },
+                      "text": {
+                        "description": "Text for this action",
+                        "type": "string",
+                        "title": "text"
+                      },
+                      "displayText": {
+                        "description": "(Optional) text to display in the chat feed if the button is clicked",
+                        "type": "string",
+                        "title": "displayText"
+                      },
+                      "value": {
+                        "description": "Supplementary parameter for action. Content of this property depends on the ActionType",
+                        "title": "value"
+                      },
+                      "channelData": {
+                        "description": "Channel-specific data associated with this action",
+                        "title": "channelData"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "attachments": {
+              "description": "Attachments",
+              "type": "array",
+              "title": "attachments",
+              "items": {
+                "description": "An attachment within an activity",
+                "title": "Attachment",
+                "type": "object",
+                "required": [
+                  "contentType"
+                ],
+                "properties": {
+                  "contentType": {
+                    "description": "mimetype/Contenttype for the file",
+                    "type": "string",
+                    "title": "contentType"
+                  },
+                  "contentUrl": {
+                    "description": "Content Url",
+                    "type": "string",
+                    "title": "contentUrl"
+                  },
+                  "content": {
+                    "type": "object",
+                    "description": "Embedded content",
+                    "title": "content"
+                  },
+                  "name": {
+                    "description": "(OPTIONAL) The name of the attachment",
+                    "type": "string",
+                    "title": "name"
+                  },
+                  "thumbnailUrl": {
+                    "description": "(OPTIONAL) Thumbnail associated with attachment",
+                    "type": "string",
+                    "title": "thumbnailUrl"
+                  }
+                }
+              }
+            },
+            "entities": {
+              "description": "Represents the entities that were mentioned in the message.",
+              "type": "array",
+              "title": "entities",
+              "items": {
+                "description": "Metadata object pertaining to an activity",
+                "title": "Entity",
+                "type": "object",
+                "required": [
+                  "type"
+                ],
+                "properties": {
+                  "type": {
+                    "description": "Type of this entity (RFC 3987 IRI)",
+                    "type": "string",
+                    "title": "type"
+                  }
+                }
+              }
+            },
+            "channelData": {
+              "description": "Contains channel-specific content.",
+              "title": "channelData"
+            },
+            "action": {
+              "description": "Indicates whether the recipient of a contactRelationUpdate was added or removed from the\nsender's contact list.",
+              "type": "string",
+              "title": "action"
+            },
+            "replyToId": {
+              "description": "Contains the ID of the message to which this message is a reply.",
+              "type": "string",
+              "title": "replyToId"
+            },
+            "label": {
+              "description": "A descriptive label for the activity.",
+              "type": "string",
+              "title": "label"
+            },
+            "valueType": {
+              "description": "The type of the activity's value object.",
+              "type": "string",
+              "title": "valueType"
+            },
+            "value": {
+              "description": "A value that is associated with the activity.",
+              "title": "value"
+            },
+            "name": {
+              "description": "The name of the operation associated with an invoke or event activity.",
+              "type": "string",
+              "title": "name"
+            },
+            "relatesTo": {
+              "description": "A reference to another conversation or activity.",
+              "title": "relatesTo",
+              "type": "object",
+              "required": [
+                "bot",
+                "channelId",
+                "conversation",
+                "serviceUrl"
+              ],
+              "properties": {
+                "activityId": {
+                  "description": "(Optional) ID of the activity to refer to",
+                  "type": "string",
+                  "title": "activityId"
+                },
+                "user": {
+                  "description": "(Optional) User participating in this conversation",
+                  "$ref": "#/definitions/Microsoft.IActivityTemplate/oneOf/1/properties/membersAdded/items",
+                  "title": "user"
+                },
+                "bot": {
+                  "$ref": "#/definitions/Microsoft.IActivityTemplate/oneOf/1/properties/membersAdded/items",
+                  "description": "Bot participating in this conversation",
+                  "title": "bot"
+                },
+                "conversation": {
+                  "$ref": "#/definitions/Microsoft.IActivityTemplate/oneOf/1/properties/conversation",
+                  "description": "Conversation reference",
+                  "title": "conversation"
+                },
+                "channelId": {
+                  "description": "Channel ID",
+                  "type": "string",
+                  "title": "channelId"
+                },
+                "serviceUrl": {
+                  "description": "Service endpoint where operations concerning the referenced conversation may be performed",
+                  "type": "string",
+                  "title": "serviceUrl"
+                }
+              }
+            },
+            "code": {
+              "description": "The a code for endOfConversation activities that indicates why the conversation ended.\nPossible values include: 'unknown', 'completedSuccessfully', 'userCancelled', 'botTimedOut',\n'botIssuedInvalidMessage', 'channelFailed'",
+              "type": "string",
+              "title": "code"
+            },
+            "expiration": {
+              "description": "The time at which the activity should be considered to be \"expired\" and should not be\npresented to the recipient.",
+              "type": "string",
+              "format": "date-time",
+              "title": "expiration"
+            },
+            "importance": {
+              "description": "The importance of the activity. Possible values include: 'low', 'normal', 'high'",
+              "type": "string",
+              "title": "importance"
+            },
+            "deliveryMode": {
+              "description": "A delivery hint to signal to the recipient alternate delivery paths for the activity.\nThe default delivery mode is \"default\". Possible values include: 'normal', 'notification'",
+              "type": "string",
+              "title": "deliveryMode"
+            },
+            "listenFor": {
+              "description": "List of phrases and references that speech and language priming systems should listen for",
+              "type": "array",
+              "title": "listenFor",
+              "items": {
+                "type": "string",
+                "title": "Phrase",
+                "description": "Phrase to listen for."
+              }
+            },
+            "textHighlights": {
+              "description": "The collection of text fragments to highlight when the activity contains a ReplyToId value.",
+              "type": "array",
+              "title": "textHighlights",
+              "items": {
+                "description": "Refers to a substring of content within another field",
+                "title": "TextHighlight",
+                "type": "object",
+                "required": [
+                  "occurrence",
+                  "text"
+                ],
+                "properties": {
+                  "text": {
+                    "description": "Defines the snippet of text to highlight",
+                    "type": "string",
+                    "title": "text"
+                  },
+                  "occurrence": {
+                    "description": "Occurrence of the text field within the referenced text, if multiple exist.",
+                    "type": "number",
+                    "title": "occurrence"
+                  }
+                }
+              }
+            },
+            "semanticAction": {
+              "description": "An optional programmatic action accompanying this request",
+              "title": "semanticAction",
+              "type": "object",
+              "required": [
+                "entities",
+                "id"
+              ],
+              "properties": {
+                "id": {
+                  "description": "ID of this action",
+                  "type": "string",
+                  "title": "id"
+                },
+                "entities": {
+                  "description": "Entities associated with this action",
+                  "type": "object",
+                  "title": "entities",
+                  "additionalProperties": {
+                    "$ref": "#/definitions/Microsoft.IActivityTemplate/oneOf/1/properties/entities/items"
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "$ref": "#/definitions/Microsoft.ActivityTemplate"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.StaticActivityTemplate"
+        }
+      ],
+      "$package": {
+        "name": "Microsoft.Bot.Builder.Dialogs.Declarative",
+        "version": "4.11.0"
+      }
+    },
+    "Microsoft.IDialog": {
+      "title": "Microsoft dialogs",
+      "description": "Components which derive from Dialog",
+      "$role": "interface",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.QnAMakerDialog"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.AdaptiveDialog"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.BeginDialog"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.BeginSkill"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.BreakLoop"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.CancelAllDialogs"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.CancelDialog"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.ContinueConversationLater"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.ContinueLoop"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.DebugBreak"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.DeleteActivity"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.DeleteProperties"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.DeleteProperty"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.EditActions"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.EditArray"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.EmitEvent"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.EndDialog"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.EndTurn"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.Foreach"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.ForeachPage"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.GetActivityMembers"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.GetConversationMembers"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.GotoAction"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.HttpRequest"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.IfCondition"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.LogAction"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.RepeatDialog"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.ReplaceDialog"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.SendActivity"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.SetProperties"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.SetProperty"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.SignOutUser"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.SwitchCondition"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.TelemetryTrackEvent"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.ThrowException"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.TraceActivity"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.UpdateActivity"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.Ask"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.AttachmentInput"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.ChoiceInput"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.ConfirmInput"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.DateTimeInput"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.NumberInput"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.OAuthInput"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.TextInput"
+        }
+      ],
+      "$package": {
+        "name": "Microsoft.Bot.Builder.Dialogs.Declarative",
+        "version": "4.11.0"
+      }
+    },
+    "Microsoft.IEntityRecognizer": {
+      "$role": "interface",
+      "title": "Entity recognizers",
+      "description": "Components which derive from EntityRecognizer.",
+      "type": "object",
+      "$package": {
+        "name": "Microsoft.Bot.Builder.Dialogs.Adaptive",
+        "version": "4.11.0"
+      },
+      "oneOf": [
+        {
+          "type": "string",
+          "title": "Reference to Microsoft.IEntityRecognizer",
+          "description": "Reference to Microsoft.IEntityRecognizer .dialog file."
+        },
+        {
+          "$ref": "#/definitions/Microsoft.AgeEntityRecognizer"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.ConfirmationEntityRecognizer"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.CurrencyEntityRecognizer"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.DateTimeEntityRecognizer"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.DimensionEntityRecognizer"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.EmailEntityRecognizer"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.GuidEntityRecognizer"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.HashtagEntityRecognizer"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.IpEntityRecognizer"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.MentionEntityRecognizer"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.NumberEntityRecognizer"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.NumberRangeEntityRecognizer"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.OrdinalEntityRecognizer"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.PercentageEntityRecognizer"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.PhoneNumberEntityRecognizer"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.RegexEntityRecognizer"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.TemperatureEntityRecognizer"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.UrlEntityRecognizer"
+        }
+      ]
+    },
+    "Microsoft.ILanguageGenerator": {
+      "title": "Microsoft LanguageGenerator",
+      "description": "Components which dervie from the LanguageGenerator class",
+      "$role": "interface",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.ResourceMultiLanguageGenerator"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.TemplateEngineLanguageGenerator"
+        }
+      ],
+      "$package": {
+        "name": "Microsoft.Bot.Builder.Dialogs.Adaptive",
+        "version": "4.11.0"
+      }
+    },
+    "Microsoft.IRecognizer": {
+      "title": "Microsoft recognizer",
+      "description": "Components which derive from Recognizer class",
+      "$role": "interface",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.LuisRecognizer"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.QnAMakerRecognizer"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.CrossTrainedRecognizerSet"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.MultiLanguageRecognizer"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.RecognizerSet"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.RegexRecognizer"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.AgeEntityRecognizer"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.ChannelMentionEntityRecognizer"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.ConfirmationEntityRecognizer"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.CurrencyEntityRecognizer"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.DateTimeEntityRecognizer"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.DimensionEntityRecognizer"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.EmailEntityRecognizer"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.GuidEntityRecognizer"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.HashtagEntityRecognizer"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.IpEntityRecognizer"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.MentionEntityRecognizer"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.NumberEntityRecognizer"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.NumberRangeEntityRecognizer"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.OrdinalEntityRecognizer"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.PercentageEntityRecognizer"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.PhoneNumberEntityRecognizer"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.RegexEntityRecognizer"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.TemperatureEntityRecognizer"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.UrlEntityRecognizer"
+        }
+      ],
+      "$package": {
+        "name": "Microsoft.Bot.Builder.Dialogs.Declarative",
+        "version": "4.11.0"
+      }
+    },
+    "Microsoft.ITextTemplate": {
+      "title": "Microsoft TextTemplate",
+      "description": "Components which derive from TextTemplate class",
+      "$role": "interface",
+      "oneOf": [
+        {
+          "type": "string"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.TextTemplate"
+        }
+      ],
+      "$package": {
+        "name": "Microsoft.Bot.Builder.Dialogs.Declarative",
+        "version": "4.11.0"
+      }
+    },
+    "Microsoft.ITrigger": {
+      "$role": "interface",
+      "title": "Microsoft Triggers",
+      "description": "Components which derive from OnCondition class.",
+      "$package": {
+        "name": "Microsoft.Bot.Builder.Dialogs.Adaptive",
+        "version": "4.11.0"
+      },
+      "oneOf": [
+        {
+          "type": "string",
+          "title": "Reference to Microsoft.ITrigger",
+          "description": "Reference to Microsoft.ITrigger .dialog file."
+        },
+        {
+          "$ref": "#/definitions/Microsoft.OnActivity"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.OnAssignEntity"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.OnBeginDialog"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.OnCancelDialog"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.OnChooseEntity"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.OnChooseIntent"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.OnChooseProperty"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.OnCondition"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.OnContinueConversation"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.OnConversationUpdateActivity"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.OnDialogEvent"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.OnEndOfActions"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.OnEndOfConversationActivity"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.OnError"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.OnEventActivity"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.OnHandoffActivity"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.OnInstallationUpdateActivity"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.OnIntent"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.OnInvokeActivity"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.OnMessageActivity"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.OnMessageDeleteActivity"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.OnMessageReactionActivity"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.OnMessageUpdateActivity"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.OnQnAMatch"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.OnRepromptDialog"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.OnTypingActivity"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.OnUnknownIntent"
+        }
+      ]
+    },
+    "Microsoft.ITriggerSelector": {
+      "$role": "interface",
+      "title": "Selectors",
+      "description": "Components which derive from TriggerSelector class.",
+      "$package": {
+        "name": "Microsoft.Bot.Builder.Dialogs.Adaptive",
+        "version": "4.11.0"
+      },
+      "oneOf": [
+        {
+          "type": "string",
+          "title": "Reference to Microsoft.ITriggerSelector",
+          "description": "Reference to Microsoft.ITriggerSelector .dialog file."
+        },
+        {
+          "$ref": "#/definitions/Microsoft.ConditionalSelector"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.FirstSelector"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.MostSpecificSelector"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.RandomSelector"
+        },
+        {
+          "$ref": "#/definitions/Microsoft.TrueSelector"
+        }
+      ]
+    },
+    "Microsoft.IfCondition": {
+      "$role": "implements(Microsoft.IDialog)",
+      "title": "If condition",
+      "description": "Two-way branch the conversation flow based on a condition.",
+      "type": "object",
+      "required": [
+        "condition",
+        "actions",
+        "$kind"
+      ],
+      "$package": {
+        "name": "Microsoft.Bot.Builder.Dialogs.Adaptive",
+        "version": "4.11.0"
+      },
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\$": {
+          "title": "Tooling property",
+          "description": "Open ended property for tooling."
+        }
+      },
+      "properties": {
+        "id": {
+          "type": "string",
+          "title": "Id",
+          "description": "Optional id for the dialog"
+        },
+        "condition": {
+          "$ref": "#/definitions/condition",
+          "title": "Condition",
+          "description": "Expression to evaluate.",
+          "examples": [
+            "user.age > 3"
+          ]
+        },
+        "disabled": {
+          "$ref": "#/definitions/booleanExpression",
+          "title": "Disabled",
+          "description": "Optional condition which if true will disable this action.",
+          "examples": [
+            true,
+            "=user.age > 3"
+          ]
+        },
+        "actions": {
+          "type": "array",
+          "title": "Actions",
+          "description": "Actions to execute if condition is true.",
+          "items": {
+            "$kind": "Microsoft.IDialog",
+            "$ref": "#/definitions/Microsoft.IDialog"
+          }
+        },
+        "elseActions": {
+          "type": "array",
+          "title": "Else",
+          "description": "Actions to execute if condition is false.",
+          "items": {
+            "$kind": "Microsoft.IDialog",
+            "$ref": "#/definitions/Microsoft.IDialog"
+          }
+        },
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.IfCondition"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
+        }
+      }
+    },
+    "Microsoft.InputDialog": {
+      "type": "object",
+      "$package": {
+        "name": "Microsoft.Bot.Builder.Dialogs.Adaptive",
+        "version": "4.11.0"
+      },
+      "required": [
+        "$kind"
+      ],
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\$": {
+          "title": "Tooling property",
+          "description": "Open ended property for tooling."
+        }
+      },
+      "properties": {
+        "id": {
+          "type": "string",
+          "title": "Id",
+          "description": "Optional id for the dialog"
+        },
+        "disabled": {
+          "$ref": "#/definitions/booleanExpression",
+          "title": "Disabled",
+          "description": "Optional condition which if true will disable this action.",
+          "default": false,
+          "examples": [
+            false,
+            "=user.isVip"
+          ]
+        },
+        "prompt": {
+          "$kind": "Microsoft.IActivityTemplate",
+          "title": "Initial prompt",
+          "description": "Message to send to collect information.",
+          "examples": [
+            "What is your birth date?"
+          ],
+          "$ref": "#/definitions/Microsoft.IActivityTemplate"
+        },
+        "unrecognizedPrompt": {
+          "$kind": "Microsoft.IActivityTemplate",
+          "title": "Unrecognized prompt",
+          "description": "Message to send when max turn count (if specified) has been exceeded and the default value is selected as the value.",
+          "examples": [
+            "Sorry, I'm having trouble understanding you. I will just use {this.options.defaultValue} for now. You can say 'I'm 36 years old' to change it."
+          ],
+          "$ref": "#/definitions/Microsoft.IActivityTemplate"
+        },
+        "invalidPrompt": {
+          "$kind": "Microsoft.IActivityTemplate",
+          "title": "Invalid prompt",
+          "description": "Message to send when the user input does not meet any validation expression.",
+          "examples": [
+            "Sorry, '{this.value}' does not work. I need a number between 1-150. What is your age?"
+          ],
+          "$ref": "#/definitions/Microsoft.IActivityTemplate"
+        },
+        "defaultValueResponse": {
+          "$kind": "Microsoft.IActivityTemplate",
+          "title": "Default value response",
+          "description": "Message to send when max turn count (if specified) has been exceeded and the default value is selected as the value.",
+          "examples": [
+            "Sorry, I'm having trouble understanding you. I will just use {this.options.defaultValue} for now. You can say 'I'm 36 years old' to change it."
+          ],
+          "$ref": "#/definitions/Microsoft.IActivityTemplate"
+        },
+        "maxTurnCount": {
+          "$ref": "#/definitions/integerExpression",
+          "title": "Max turn count",
+          "description": "Maximum number of re-prompt attempts to collect information.",
+          "default": 3,
+          "examples": [
+            3,
+            "=settings.xyz"
+          ]
+        },
+        "validations": {
+          "type": "array",
+          "title": "Validation expressions",
+          "description": "Expression to validate user input.",
+          "items": {
+            "$ref": "#/definitions/condition",
+            "title": "Condition",
+            "description": "Expression which needs to met for the input to be considered valid",
+            "examples": [
+              "int(this.value) > 1 && int(this.value) <= 150",
+              "count(this.value) < 300"
+            ]
+          }
+        },
+        "property": {
+          "$ref": "#/definitions/stringExpression",
+          "title": "Property",
+          "description": "Property to store collected information. Input will be skipped if property has value (unless 'Always prompt' is true).",
+          "examples": [
+            "$birthday",
+            "dialog.${user.name}",
+            "=f(x)"
+          ]
+        },
+        "alwaysPrompt": {
+          "$ref": "#/definitions/booleanExpression",
+          "title": "Always prompt",
+          "description": "Collect information even if the specified 'property' is not empty.",
+          "default": false,
+          "examples": [
+            false,
+            "=$val"
+          ]
+        },
+        "allowInterruptions": {
+          "$ref": "#/definitions/booleanExpression",
+          "title": "Allow Interruptions",
+          "description": "A boolean expression that determines whether the parent should be allowed to interrupt the input.",
+          "default": true,
+          "examples": [
+            true,
+            "=user.xyz"
+          ]
+        },
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.InputDialog"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
+        }
+      }
+    },
+    "Microsoft.IpEntityRecognizer": {
+      "$role": [
+        "implements(Microsoft.IRecognizer)",
+        "implements(Microsoft.IEntityRecognizer)"
+      ],
+      "title": "IP entity recognizer",
+      "description": "Recognizer which recognizes internet IP patterns (like 192.1.1.1).",
+      "type": "object",
+      "$package": {
+        "name": "Microsoft.Bot.Builder.Dialogs.Adaptive",
+        "version": "4.11.0"
+      },
+      "required": [
+        "$kind"
+      ],
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\$": {
+          "title": "Tooling property",
+          "description": "Open ended property for tooling."
+        }
+      },
+      "properties": {
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.IpEntityRecognizer"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
+        }
+      }
+    },
+    "Microsoft.LanguagePolicy": {
+      "title": "Language policy",
+      "description": "This represents a policy map for locales lookups to use for language",
+      "type": "object",
+      "$package": {
+        "name": "Microsoft.Bot.Builder.Dialogs.Adaptive",
+        "version": "4.11.0"
+      },
+      "required": [
+        "$kind"
+      ],
+      "additionalProperties": {
+        "type": "array",
+        "title": "Per-locale policy",
+        "description": "Language policy per locale.",
+        "items": {
+          "type": "string",
+          "title": "Locale",
+          "description": "Locale like en-us."
+        }
+      },
+      "patternProperties": {
+        "^\\$": {
+          "title": "Tooling property",
+          "description": "Open ended property for tooling."
+        }
+      },
+      "properties": {
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.LanguagePolicy"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
+        }
+      }
+    },
+    "Microsoft.LogAction": {
+      "$role": "implements(Microsoft.IDialog)",
+      "title": "Log to console",
+      "description": "Log a message to the host application. Send a TraceActivity to Bot Framework Emulator (optional).",
+      "type": "object",
+      "required": [
+        "text",
+        "$kind"
+      ],
+      "$package": {
+        "name": "Microsoft.Bot.Builder.Dialogs.Adaptive",
+        "version": "4.11.0"
+      },
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\$": {
+          "title": "Tooling property",
+          "description": "Open ended property for tooling."
+        }
+      },
+      "properties": {
+        "id": {
+          "type": "string",
+          "title": "Id",
+          "description": "Optional id for the dialog"
+        },
+        "disabled": {
+          "$ref": "#/definitions/booleanExpression",
+          "title": "Disabled",
+          "description": "Optional condition which if true will disable this action.",
+          "examples": [
+            true,
+            "=user.age > 3"
+          ]
+        },
+        "text": {
+          "$ref": "#/definitions/stringExpression",
+          "title": "Text",
+          "description": "Information to log."
+        },
+        "label": {
+          "$ref": "#/definitions/stringExpression",
+          "title": "Label",
+          "description": "Label for the trace activity (used to identify it in a list of trace activities.)"
+        },
+        "traceActivity": {
+          "$ref": "#/definitions/booleanExpression",
+          "title": "Send trace activity",
+          "description": "If true, automatically sends a TraceActivity (view in Bot Framework Emulator)."
+        },
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.LogAction"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
+        }
+      }
+    },
+    "Microsoft.LuisRecognizer": {
+      "$role": "implements(Microsoft.IRecognizer)",
+      "title": "LUIS Recognizer",
+      "description": "LUIS recognizer.",
+      "type": "object",
+      "required": [
+        "applicationId",
+        "endpoint",
+        "endpointKey",
+        "$kind"
+      ],
+      "$package": {
+        "name": "Microsoft.Bot.Builder.AI.Luis",
+        "version": "4.11.0"
+      },
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\$": {
+          "title": "Tooling property",
+          "description": "Open ended property for tooling."
+        }
+      },
+      "properties": {
+        "id": {
+          "type": "string",
+          "title": "Id",
+          "description": "Optional unique id using with RecognizerSet.  Other recognizers should return 'DeferToRecognizer_{Id}' intent when cross training data for this recognizer."
+        },
+        "applicationId": {
+          "$ref": "#/definitions/stringExpression",
+          "title": "LUIS application id",
+          "description": "Application ID for your model from the LUIS service."
+        },
+        "version": {
+          "$ref": "#/definitions/stringExpression",
+          "title": "LUIS version",
+          "description": "Optional version to target.  If null then predictionOptions.Slot is used."
+        },
+        "endpoint": {
+          "$ref": "#/definitions/stringExpression",
+          "title": "LUIS endpoint",
+          "description": "Endpoint to use for LUIS service like https://westus.api.cognitive.microsoft.com."
+        },
+        "endpointKey": {
+          "$ref": "#/definitions/stringExpression",
+          "title": "LUIS prediction key",
+          "description": "LUIS prediction key used to call endpoint."
+        },
+        "externalEntityRecognizer": {
+          "$kind": "Microsoft.IRecognizer",
+          "title": "External entity recognizer",
+          "description": "Entities recognized by this recognizer will be passed to LUIS as external entities.",
+          "$ref": "#/definitions/Microsoft.IRecognizer"
+        },
+        "dynamicLists": {
+          "$ref": "#/definitions/arrayExpression",
+          "title": "Dynamic lists",
+          "description": "Runtime defined entity lists.",
+          "items": {
+            "title": "Entity list",
+            "description": "Lists of canonical values and synonyms for an entity.",
+            "type": "object",
+            "properties": {
+              "entity": {
+                "title": "Entity",
+                "description": "Entity to extend with a dynamic list.",
+                "type": "string"
+              },
+              "list": {
+                "title": "Dynamic list",
+                "description": "List of canonical forms and synonyms.",
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "title": "List entry",
+                  "description": "Canonical form and synonynms.",
+                  "properties": {
+                    "canonicalForm": {
+                      "title": "Canonical form",
+                      "description": "Resolution if any synonym matches.",
+                      "type": "string"
+                    },
+                    "synonyms": {
+                      "title": "Synonyms",
+                      "description": "List of synonyms for a canonical form.",
+                      "type": "array",
+                      "items": {
+                        "title": "Synonym",
+                        "description": "Synonym for canonical form.",
+                        "type": "string"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "predictionOptions": {
+          "type": "object",
+          "title": "Prediction options",
+          "description": "Options to control LUIS prediction behavior.",
+          "properties": {
+            "includeAllIntents": {
+              "$ref": "#/definitions/booleanExpression",
+              "title": "Include all intents",
+              "description": "True for all intents, false for only top intent."
+            },
+            "includeInstanceData": {
+              "$ref": "#/definitions/booleanExpression",
+              "title": "Include $instance",
+              "description": "True to include $instance metadata in the LUIS response."
+            },
+            "log": {
+              "$ref": "#/definitions/booleanExpression",
+              "title": "Log utterances",
+              "description": "True to log utterances on LUIS service."
+            },
+            "preferExternalEntities": {
+              "$ref": "#/definitions/booleanExpression",
+              "title": "Prefer external entities",
+              "description": "True to prefer external entities to those generated by LUIS models."
+            },
+            "slot": {
+              "$ref": "#/definitions/stringExpression",
+              "title": "Slot",
+              "description": "Slot to use for talking to LUIS service like production or staging."
+            }
+          }
+        },
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.LuisRecognizer"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
+        }
+      }
+    },
+    "Microsoft.MentionEntityRecognizer": {
+      "$role": [
+        "implements(Microsoft.IRecognizer)",
+        "implements(Microsoft.IEntityRecognizer)"
+      ],
+      "title": "Mentions entity recognizer",
+      "description": "Recognizer which recognizes @Mentions",
+      "type": "object",
+      "$package": {
+        "name": "Microsoft.Bot.Builder.Dialogs.Adaptive",
+        "version": "4.11.0"
+      },
+      "required": [
+        "$kind"
+      ],
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\$": {
+          "title": "Tooling property",
+          "description": "Open ended property for tooling."
+        }
+      },
+      "properties": {
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.MentionEntityRecognizer"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
+        }
+      }
+    },
+    "Microsoft.MostSpecificSelector": {
+      "$role": "implements(Microsoft.ITriggerSelector)",
+      "title": "Most specific trigger selector",
+      "description": "Select most specific true events with optional additional selector",
+      "type": "object",
+      "$package": {
+        "name": "Microsoft.Bot.Builder.Dialogs.Adaptive",
+        "version": "4.11.0"
+      },
+      "required": [
+        "$kind"
+      ],
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\$": {
+          "title": "Tooling property",
+          "description": "Open ended property for tooling."
+        }
+      },
+      "properties": {
+        "selector": {
+          "$kind": "Microsoft.ITriggerSelector",
+          "$ref": "#/definitions/Microsoft.ITriggerSelector"
+        },
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.MostSpecificSelector"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
+        }
+      }
+    },
+    "Microsoft.MultiLanguageRecognizer": {
+      "$role": "implements(Microsoft.IRecognizer)",
+      "title": "Multi-language recognizer",
+      "description": "Configure one recognizer per language and the specify the language fallback policy.",
+      "type": "object",
+      "required": [
+        "recognizers",
+        "$kind"
+      ],
+      "$package": {
+        "name": "Microsoft.Bot.Builder.Dialogs.Adaptive",
+        "version": "4.11.0"
+      },
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\$": {
+          "title": "Tooling property",
+          "description": "Open ended property for tooling."
+        }
+      },
+      "properties": {
+        "id": {
+          "type": "string",
+          "title": "Id",
+          "description": "Optional unique id using with RecognizerSet.  Other recognizers should return 'DeferToRecognizer_{Id}' intent when cross training data for this recognizer."
+        },
+        "languagePolicy": {
+          "$kind": "Microsoft.LanguagePolicy",
+          "type": "object",
+          "title": "Language policy",
+          "description": "Defines fall back languages to try per user input language.",
+          "$ref": "#/definitions/Microsoft.LanguagePolicy"
+        },
+        "recognizers": {
+          "type": "object",
+          "title": "Recognizers",
+          "description": "Map of language -> Recognizer",
+          "additionalProperties": {
+            "$kind": "Microsoft.IRecognizer",
+            "$ref": "#/definitions/Microsoft.IRecognizer"
+          }
+        },
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.MultiLanguageRecognizer"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
+        }
+      }
+    },
+    "Microsoft.NumberEntityRecognizer": {
+      "$role": [
+        "implements(Microsoft.IRecognizer)",
+        "implements(Microsoft.IEntityRecognizer)"
+      ],
+      "title": "Number entity recognizer",
+      "description": "Recognizer which recognizes numbers.",
+      "type": "object",
+      "$package": {
+        "name": "Microsoft.Bot.Builder.Dialogs.Adaptive",
+        "version": "4.11.0"
+      },
+      "required": [
+        "$kind"
+      ],
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\$": {
+          "title": "Tooling property",
+          "description": "Open ended property for tooling."
+        }
+      },
+      "properties": {
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.NumberEntityRecognizer"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
+        }
+      }
+    },
+    "Microsoft.NumberInput": {
+      "$role": [
+        "implements(Microsoft.IDialog)",
+        "extends(Microsoft.InputDialog)"
+      ],
+      "title": "Number input dialog",
+      "description": "Collect information - Ask for a number.",
+      "type": "object",
+      "$package": {
+        "name": "Microsoft.Bot.Builder.Dialogs.Adaptive",
+        "version": "4.11.0"
+      },
+      "required": [
+        "$kind"
+      ],
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\$": {
+          "title": "Tooling property",
+          "description": "Open ended property for tooling."
+        }
+      },
+      "properties": {
+        "defaultValue": {
+          "$ref": "#/definitions/numberExpression",
+          "title": "Default value",
+          "description": "'Property' will be set to the value of this expression when max turn count is exceeded.",
+          "examples": [
+            13,
+            "=user.age"
+          ]
+        },
+        "value": {
+          "$ref": "#/definitions/numberExpression",
+          "title": "Value",
+          "description": "'Property' will be set to the value of this expression unless it evaluates to null.",
+          "examples": [
+            13,
+            "=user.age"
+          ]
+        },
+        "outputFormat": {
+          "$ref": "#/definitions/expression",
+          "title": "Output format",
+          "description": "Expression to format the number output.",
+          "examples": [
+            "=this.value",
+            "=int(this.text)"
+          ]
+        },
+        "defaultLocale": {
+          "$ref": "#/definitions/stringExpression",
+          "title": "Default locale",
+          "description": "Default locale to use if there is no locale available..",
+          "default": "en-us"
+        },
+        "id": {
+          "type": "string",
+          "title": "Id",
+          "description": "Optional id for the dialog"
+        },
+        "disabled": {
+          "$ref": "#/definitions/booleanExpression",
+          "title": "Disabled",
+          "description": "Optional condition which if true will disable this action.",
+          "default": false,
+          "examples": [
+            false,
+            "=user.isVip"
+          ]
+        },
+        "prompt": {
+          "$kind": "Microsoft.IActivityTemplate",
+          "title": "Initial prompt",
+          "description": "Message to send to collect information.",
+          "examples": [
+            "What is your birth date?"
+          ],
+          "$ref": "#/definitions/Microsoft.IActivityTemplate"
+        },
+        "unrecognizedPrompt": {
+          "$kind": "Microsoft.IActivityTemplate",
+          "title": "Unrecognized prompt",
+          "description": "Message to send when max turn count (if specified) has been exceeded and the default value is selected as the value.",
+          "examples": [
+            "Sorry, I'm having trouble understanding you. I will just use {this.options.defaultValue} for now. You can say 'I'm 36 years old' to change it."
+          ],
+          "$ref": "#/definitions/Microsoft.IActivityTemplate"
+        },
+        "invalidPrompt": {
+          "$kind": "Microsoft.IActivityTemplate",
+          "title": "Invalid prompt",
+          "description": "Message to send when the user input does not meet any validation expression.",
+          "examples": [
+            "Sorry, '{this.value}' does not work. I need a number between 1-150. What is your age?"
+          ],
+          "$ref": "#/definitions/Microsoft.IActivityTemplate"
+        },
+        "defaultValueResponse": {
+          "$kind": "Microsoft.IActivityTemplate",
+          "title": "Default value response",
+          "description": "Message to send when max turn count (if specified) has been exceeded and the default value is selected as the value.",
+          "examples": [
+            "Sorry, I'm having trouble understanding you. I will just use {this.options.defaultValue} for now. You can say 'I'm 36 years old' to change it."
+          ],
+          "$ref": "#/definitions/Microsoft.IActivityTemplate"
+        },
+        "maxTurnCount": {
+          "$ref": "#/definitions/integerExpression",
+          "title": "Max turn count",
+          "description": "Maximum number of re-prompt attempts to collect information.",
+          "default": 3,
+          "examples": [
+            3,
+            "=settings.xyz"
+          ]
+        },
+        "validations": {
+          "type": "array",
+          "title": "Validation expressions",
+          "description": "Expression to validate user input.",
+          "items": {
+            "$ref": "#/definitions/condition",
+            "title": "Condition",
+            "description": "Expression which needs to met for the input to be considered valid",
+            "examples": [
+              "int(this.value) > 1 && int(this.value) <= 150",
+              "count(this.value) < 300"
+            ]
+          }
+        },
+        "property": {
+          "$ref": "#/definitions/stringExpression",
+          "title": "Property",
+          "description": "Property to store collected information. Input will be skipped if property has value (unless 'Always prompt' is true).",
+          "examples": [
+            "$birthday",
+            "dialog.${user.name}",
+            "=f(x)"
+          ]
+        },
+        "alwaysPrompt": {
+          "$ref": "#/definitions/booleanExpression",
+          "title": "Always prompt",
+          "description": "Collect information even if the specified 'property' is not empty.",
+          "default": false,
+          "examples": [
+            false,
+            "=$val"
+          ]
+        },
+        "allowInterruptions": {
+          "$ref": "#/definitions/booleanExpression",
+          "title": "Allow Interruptions",
+          "description": "A boolean expression that determines whether the parent should be allowed to interrupt the input.",
+          "default": true,
+          "examples": [
+            true,
+            "=user.xyz"
+          ]
+        },
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.NumberInput"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
+        }
+      }
+    },
+    "Microsoft.NumberRangeEntityRecognizer": {
+      "$role": [
+        "implements(Microsoft.IRecognizer)",
+        "implements(Microsoft.IEntityRecognizer)"
+      ],
+      "title": "Number range entity recognizer",
+      "description": "Recognizer which recognizes ranges of numbers (Example:2 to 5).",
+      "type": "object",
+      "$package": {
+        "name": "Microsoft.Bot.Builder.Dialogs.Adaptive",
+        "version": "4.11.0"
+      },
+      "required": [
+        "$kind"
+      ],
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\$": {
+          "title": "Tooling property",
+          "description": "Open ended property for tooling."
+        }
+      },
+      "properties": {
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.NumberRangeEntityRecognizer"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
+        }
+      }
+    },
+    "Microsoft.OAuthInput": {
+      "$role": "implements(Microsoft.IDialog)",
+      "title": "OAuthInput Dialog",
+      "description": "Collect login information.",
+      "type": "object",
+      "required": [
+        "connectionName",
+        "$kind"
+      ],
+      "$package": {
+        "name": "Microsoft.Bot.Builder.Dialogs.Adaptive",
+        "version": "4.11.0"
+      },
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\$": {
+          "title": "Tooling property",
+          "description": "Open ended property for tooling."
+        }
+      },
+      "properties": {
+        "connectionName": {
+          "$ref": "#/definitions/stringExpression",
+          "title": "Connection name",
+          "description": "The connection name configured in Azure Web App Bot OAuth settings.",
+          "examples": [
+            "msgraphOAuthConnection"
+          ]
+        },
+        "disabled": {
+          "$ref": "#/definitions/booleanExpression",
+          "title": "Disabled",
+          "description": "Optional condition which if true will disable this action.",
+          "examples": [
+            true,
+            "=user.age > 3"
+          ]
+        },
+        "text": {
+          "$ref": "#/definitions/stringExpression",
+          "title": "Text",
+          "description": "Text shown in the OAuth signin card.",
+          "examples": [
+            "Please sign in. ",
+            "=concat(x,y,z)"
+          ]
+        },
+        "title": {
+          "$ref": "#/definitions/stringExpression",
+          "title": "Title",
+          "description": "Title shown in the OAuth signin card.",
+          "examples": [
+            "Login"
+          ]
+        },
+        "timeout": {
+          "$ref": "#/definitions/integerExpression",
+          "title": "Timeout",
+          "description": "Time out setting for the OAuth signin card.",
+          "default": 900000
+        },
+        "property": {
+          "$ref": "#/definitions/stringExpression",
+          "title": "Token property",
+          "description": "Property to store the OAuth token result.",
+          "examples": [
+            "dialog.token"
+          ]
+        },
+        "invalidPrompt": {
+          "$kind": "Microsoft.IActivityTemplate",
+          "title": "Invalid prompt",
+          "description": "Message to send if user response is invalid.",
+          "examples": [
+            "Sorry, the login info you provided is not valid."
+          ],
+          "$ref": "#/definitions/Microsoft.IActivityTemplate"
+        },
+        "defaultValueResponse": {
+          "$kind": "Microsoft.IActivityTemplate",
+          "title": "Default value response",
+          "description": "Message to send when max turn count (if specified) has been exceeded and the default value is selected as the value.",
+          "examples": [
+            "Login failed."
+          ],
+          "$ref": "#/definitions/Microsoft.IActivityTemplate"
+        },
+        "maxTurnCount": {
+          "$ref": "#/definitions/integerExpression",
+          "title": "Max turn count",
+          "description": "Maximum number of re-prompt attempts to collect information.",
+          "default": 3,
+          "examples": [
+            3
+          ]
+        },
+        "defaultValue": {
+          "$ref": "#/definitions/expression",
+          "title": "Default value",
+          "description": "Expression to examine on each turn of the conversation as possible value to the property.",
+          "examples": [
+            "@token"
+          ]
+        },
+        "allowInterruptions": {
+          "$ref": "#/definitions/booleanExpression",
+          "title": "Allow interruptions",
+          "description": "A boolean expression that determines whether the parent should be allowed to interrupt the input.",
+          "default": true,
+          "examples": [
+            true,
+            "=f(x)"
+          ]
+        },
+        "alwaysPrompt": {
+          "$ref": "#/definitions/booleanExpression",
+          "title": "Always prompt",
+          "description": "Collect information even if the specified 'property' is not empty.",
+          "examples": [
+            true,
+            "=f(x)"
+          ]
+        },
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.OAuthInput"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
+        }
+      }
+    },
+    "Microsoft.OnActivity": {
+      "$role": [
+        "implements(Microsoft.ITrigger)",
+        "extends(Microsoft.OnCondition)"
+      ],
+      "title": "On activity",
+      "description": "Actions to perform on receipt of a generic activity.",
+      "type": "object",
+      "required": [
+        "type",
+        "actions",
+        "$kind"
+      ],
+      "$package": {
+        "name": "Microsoft.Bot.Builder.Dialogs.Adaptive",
+        "version": "4.11.0"
+      },
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\$": {
+          "title": "Tooling property",
+          "description": "Open ended property for tooling."
+        }
+      },
+      "properties": {
+        "type": {
+          "type": "string",
+          "title": "Activity type",
+          "description": "The Activity.Type to match"
+        },
+        "condition": {
+          "$ref": "#/definitions/condition",
+          "title": "Condition",
+          "description": "Condition (expression).",
+          "examples": [
+            "user.vip == true"
+          ]
+        },
+        "actions": {
+          "type": "array",
+          "title": "Actions",
+          "description": "Sequence of actions to execute.",
+          "items": {
+            "$kind": "Microsoft.IDialog",
+            "$ref": "#/definitions/Microsoft.IDialog"
+          }
+        },
+        "priority": {
+          "$ref": "#/definitions/integerExpression",
+          "title": "Priority",
+          "description": "Priority for trigger with 0 being the highest and < 0 ignored."
+        },
+        "runOnce": {
+          "$ref": "#/definitions/booleanExpression",
+          "title": "Run Once",
+          "description": "True if rule should run once per unique conditions",
+          "examples": [
+            true,
+            "=f(x)"
+          ]
+        },
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.OnActivity"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
+        }
+      }
+    },
+    "Microsoft.OnAssignEntity": {
+      "$role": [
+        "implements(Microsoft.ITrigger)",
+        "extends(Microsoft.OnCondition)"
+      ],
+      "title": "On entity assignment",
+      "description": "Actions to take when an entity should be assigned to a property.",
+      "type": "object",
+      "$package": {
+        "name": "Microsoft.Bot.Builder.Dialogs.Adaptive",
+        "version": "4.11.0"
+      },
+      "required": [
+        "actions",
+        "$kind"
+      ],
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\$": {
+          "title": "Tooling property",
+          "description": "Open ended property for tooling."
+        }
+      },
+      "properties": {
+        "property": {
+          "type": "string",
+          "title": "Property",
+          "description": "Property that will be set after entity is selected."
+        },
+        "entity": {
+          "type": "string",
+          "title": "Entity",
+          "description": "Entity being put into property"
+        },
+        "operation": {
+          "type": "string",
+          "title": "Operation",
+          "description": "Operation for assigning entity."
+        },
+        "condition": {
+          "$ref": "#/definitions/condition",
+          "title": "Condition",
+          "description": "Condition (expression).",
+          "examples": [
+            "user.vip == true"
+          ]
+        },
+        "actions": {
+          "type": "array",
+          "title": "Actions",
+          "description": "Sequence of actions to execute.",
+          "items": {
+            "$kind": "Microsoft.IDialog",
+            "$ref": "#/definitions/Microsoft.IDialog"
+          }
+        },
+        "priority": {
+          "$ref": "#/definitions/integerExpression",
+          "title": "Priority",
+          "description": "Priority for trigger with 0 being the highest and < 0 ignored."
+        },
+        "runOnce": {
+          "$ref": "#/definitions/booleanExpression",
+          "title": "Run Once",
+          "description": "True if rule should run once per unique conditions",
+          "examples": [
+            true,
+            "=f(x)"
+          ]
+        },
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.OnAssignEntity"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
+        }
+      }
+    },
+    "Microsoft.OnBeginDialog": {
+      "$role": [
+        "implements(Microsoft.ITrigger)",
+        "extends(Microsoft.OnCondition)"
+      ],
+      "title": "On begin dialog",
+      "description": "Actions to perform when this dialog begins.",
+      "type": "object",
+      "$package": {
+        "name": "Microsoft.Bot.Builder.Dialogs.Adaptive",
+        "version": "4.11.0"
+      },
+      "required": [
+        "actions",
+        "$kind"
+      ],
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\$": {
+          "title": "Tooling property",
+          "description": "Open ended property for tooling."
+        }
+      },
+      "properties": {
+        "condition": {
+          "$ref": "#/definitions/condition",
+          "title": "Condition",
+          "description": "Condition (expression).",
+          "examples": [
+            "user.vip == true"
+          ]
+        },
+        "actions": {
+          "type": "array",
+          "title": "Actions",
+          "description": "Sequence of actions to execute.",
+          "items": {
+            "$kind": "Microsoft.IDialog",
+            "$ref": "#/definitions/Microsoft.IDialog"
+          }
+        },
+        "priority": {
+          "$ref": "#/definitions/integerExpression",
+          "title": "Priority",
+          "description": "Priority for trigger with 0 being the highest and < 0 ignored."
+        },
+        "runOnce": {
+          "$ref": "#/definitions/booleanExpression",
+          "title": "Run Once",
+          "description": "True if rule should run once per unique conditions",
+          "examples": [
+            true,
+            "=f(x)"
+          ]
+        },
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.OnBeginDialog"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
+        }
+      }
+    },
+    "Microsoft.OnCancelDialog": {
+      "$role": [
+        "implements(Microsoft.ITrigger)",
+        "extends(Microsoft.OnCondition)"
+      ],
+      "title": "On cancel dialog",
+      "description": "Actions to perform on cancel dialog event.",
+      "type": "object",
+      "$package": {
+        "name": "Microsoft.Bot.Builder.Dialogs.Adaptive",
+        "version": "4.11.0"
+      },
+      "required": [
+        "actions",
+        "$kind"
+      ],
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\$": {
+          "title": "Tooling property",
+          "description": "Open ended property for tooling."
+        }
+      },
+      "properties": {
+        "condition": {
+          "$ref": "#/definitions/condition",
+          "title": "Condition",
+          "description": "Condition (expression).",
+          "examples": [
+            "user.vip == true"
+          ]
+        },
+        "actions": {
+          "type": "array",
+          "title": "Actions",
+          "description": "Sequence of actions to execute.",
+          "items": {
+            "$kind": "Microsoft.IDialog",
+            "$ref": "#/definitions/Microsoft.IDialog"
+          }
+        },
+        "priority": {
+          "$ref": "#/definitions/integerExpression",
+          "title": "Priority",
+          "description": "Priority for trigger with 0 being the highest and < 0 ignored."
+        },
+        "runOnce": {
+          "$ref": "#/definitions/booleanExpression",
+          "title": "Run Once",
+          "description": "True if rule should run once per unique conditions",
+          "examples": [
+            true,
+            "=f(x)"
+          ]
+        },
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.OnCancelDialog"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
+        }
+      }
+    },
+    "Microsoft.OnChooseEntity": {
+      "$role": [
+        "implements(Microsoft.ITrigger)",
+        "extends(Microsoft.OnCondition)"
+      ],
+      "title": "On choose entity",
+      "description": "Actions to be performed when an entity value needs to be resolved.",
+      "type": "object",
+      "$package": {
+        "name": "Microsoft.Bot.Builder.Dialogs.Adaptive",
+        "version": "4.11.0"
+      },
+      "required": [
+        "actions",
+        "$kind"
+      ],
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\$": {
+          "title": "Tooling property",
+          "description": "Open ended property for tooling."
+        }
+      },
+      "properties": {
+        "property": {
+          "type": "string",
+          "title": "Property to be set",
+          "description": "Property that will be set after entity is selected."
+        },
+        "entity": {
+          "type": "string",
+          "title": "Ambiguous entity",
+          "description": "Ambiguous entity"
+        },
+        "condition": {
+          "$ref": "#/definitions/condition",
+          "title": "Condition",
+          "description": "Condition (expression).",
+          "examples": [
+            "user.vip == true"
+          ]
+        },
+        "actions": {
+          "type": "array",
+          "title": "Actions",
+          "description": "Sequence of actions to execute.",
+          "items": {
+            "$kind": "Microsoft.IDialog",
+            "$ref": "#/definitions/Microsoft.IDialog"
+          }
+        },
+        "priority": {
+          "$ref": "#/definitions/integerExpression",
+          "title": "Priority",
+          "description": "Priority for trigger with 0 being the highest and < 0 ignored."
+        },
+        "runOnce": {
+          "$ref": "#/definitions/booleanExpression",
+          "title": "Run Once",
+          "description": "True if rule should run once per unique conditions",
+          "examples": [
+            true,
+            "=f(x)"
+          ]
+        },
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.OnChooseEntity"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
+        }
+      }
+    },
+    "Microsoft.OnChooseIntent": {
+      "$role": [
+        "implements(Microsoft.ITrigger)",
+        "extends(Microsoft.OnCondition)"
+      ],
+      "title": "On ambigious intent",
+      "description": "Actions to perform on when an intent is ambigious.",
+      "type": "object",
+      "required": [
+        "actions",
+        "$kind"
+      ],
+      "$package": {
+        "name": "Microsoft.Bot.Builder.Dialogs.Adaptive",
+        "version": "4.11.0"
+      },
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\$": {
+          "title": "Tooling property",
+          "description": "Open ended property for tooling."
+        }
+      },
+      "properties": {
+        "intents": {
+          "type": "array",
+          "title": "Intents",
+          "description": "Intents that must be in the ChooseIntent result for this condition to trigger.",
+          "items": {
+            "title": "Intent",
+            "description": "Intent name to trigger on.",
+            "type": "string"
+          }
+        },
+        "condition": {
+          "$ref": "#/definitions/condition",
+          "title": "Condition",
+          "description": "Condition (expression).",
+          "examples": [
+            "user.vip == true"
+          ]
+        },
+        "actions": {
+          "type": "array",
+          "title": "Actions",
+          "description": "Sequence of actions to execute.",
+          "items": {
+            "$kind": "Microsoft.IDialog",
+            "$ref": "#/definitions/Microsoft.IDialog"
+          }
+        },
+        "priority": {
+          "$ref": "#/definitions/integerExpression",
+          "title": "Priority",
+          "description": "Priority for trigger with 0 being the highest and < 0 ignored."
+        },
+        "runOnce": {
+          "$ref": "#/definitions/booleanExpression",
+          "title": "Run Once",
+          "description": "True if rule should run once per unique conditions",
+          "examples": [
+            true,
+            "=f(x)"
+          ]
+        },
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.OnChooseIntent"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
+        }
+      }
+    },
+    "Microsoft.OnChooseProperty": {
+      "$role": [
+        "implements(Microsoft.ITrigger)",
+        "extends(Microsoft.OnCondition)"
+      ],
+      "title": "On choose property",
+      "description": "Actions to take when there are multiple possible mappings of entities to properties.",
+      "type": "object",
+      "$package": {
+        "name": "Microsoft.Bot.Builder.Dialogs.Adaptive",
+        "version": "4.11.0"
+      },
+      "required": [
+        "actions",
+        "$kind"
+      ],
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\$": {
+          "title": "Tooling property",
+          "description": "Open ended property for tooling."
+        }
+      },
+      "properties": {
+        "entity": {
+          "type": "string",
+          "title": "Entity being assigned",
+          "description": "Entity being assigned to property choice"
+        },
+        "properties": {
+          "type": "array",
+          "title": "Possible properties",
+          "description": "Properties to be chosen between.",
+          "items": {
+            "type": "string",
+            "title": "Property name",
+            "description": "Possible property to choose."
+          }
+        },
+        "entities": {
+          "type": "array",
+          "title": "Entities",
+          "description": "Ambiguous entity names.",
+          "items": {
+            "type": "string",
+            "title": "Entity name",
+            "description": "Entity name being chosen between."
+          }
+        },
+        "condition": {
+          "$ref": "#/definitions/condition",
+          "title": "Condition",
+          "description": "Condition (expression).",
+          "examples": [
+            "user.vip == true"
+          ]
+        },
+        "actions": {
+          "type": "array",
+          "title": "Actions",
+          "description": "Sequence of actions to execute.",
+          "items": {
+            "$kind": "Microsoft.IDialog",
+            "$ref": "#/definitions/Microsoft.IDialog"
+          }
+        },
+        "priority": {
+          "$ref": "#/definitions/integerExpression",
+          "title": "Priority",
+          "description": "Priority for trigger with 0 being the highest and < 0 ignored."
+        },
+        "runOnce": {
+          "$ref": "#/definitions/booleanExpression",
+          "title": "Run Once",
+          "description": "True if rule should run once per unique conditions",
+          "examples": [
+            true,
+            "=f(x)"
+          ]
+        },
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.OnChooseProperty"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
+        }
+      }
+    },
+    "Microsoft.OnCondition": {
+      "$role": "implements(Microsoft.ITrigger)",
+      "title": "On condition",
+      "description": "Actions to perform when specified condition is true.",
+      "type": "object",
+      "required": [
+        "actions",
+        "$kind"
+      ],
+      "$package": {
+        "name": "Microsoft.Bot.Builder.Dialogs.Adaptive",
+        "version": "4.11.0"
+      },
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\$": {
+          "title": "Tooling property",
+          "description": "Open ended property for tooling."
+        }
+      },
+      "properties": {
+        "condition": {
+          "$ref": "#/definitions/condition",
+          "title": "Condition",
+          "description": "Condition (expression).",
+          "examples": [
+            "user.vip == true"
+          ]
+        },
+        "actions": {
+          "type": "array",
+          "title": "Actions",
+          "description": "Sequence of actions to execute.",
+          "items": {
+            "$kind": "Microsoft.IDialog",
+            "$ref": "#/definitions/Microsoft.IDialog"
+          }
+        },
+        "priority": {
+          "$ref": "#/definitions/integerExpression",
+          "title": "Priority",
+          "description": "Priority for trigger with 0 being the highest and < 0 ignored."
+        },
+        "runOnce": {
+          "$ref": "#/definitions/booleanExpression",
+          "title": "Run Once",
+          "description": "True if rule should run once per unique conditions",
+          "examples": [
+            true,
+            "=f(x)"
+          ]
+        },
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.OnCondition"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
+        }
+      }
+    },
+    "Microsoft.OnContinueConversation": {
+      "$role": [
+        "implements(Microsoft.ITrigger)",
+        "extends(Microsoft.OnCondition)"
+      ],
+      "title": "On continue conversation",
+      "description": "Actions to perform when a conversation is started up again from a ContinueConversationLater action.",
+      "type": "object",
+      "required": [
+        "actions",
+        "$kind"
+      ],
+      "$package": {
+        "name": "Microsoft.Bot.Builder.Dialogs.Adaptive",
+        "version": "4.11.0"
+      },
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\$": {
+          "title": "Tooling property",
+          "description": "Open ended property for tooling."
+        }
+      },
+      "properties": {
+        "condition": {
+          "$ref": "#/definitions/condition",
+          "title": "Condition",
+          "description": "Condition (expression).",
+          "examples": [
+            "user.vip == true"
+          ]
+        },
+        "actions": {
+          "type": "array",
+          "title": "Actions",
+          "description": "Sequence of actions to execute.",
+          "items": {
+            "$kind": "Microsoft.IDialog",
+            "$ref": "#/definitions/Microsoft.IDialog"
+          }
+        },
+        "priority": {
+          "$ref": "#/definitions/integerExpression",
+          "title": "Priority",
+          "description": "Priority for trigger with 0 being the highest and < 0 ignored."
+        },
+        "runOnce": {
+          "$ref": "#/definitions/booleanExpression",
+          "title": "Run Once",
+          "description": "True if rule should run once per unique conditions",
+          "examples": [
+            true,
+            "=f(x)"
+          ]
+        },
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.OnContinueConversation"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
+        }
+      }
+    },
+    "Microsoft.OnConversationUpdateActivity": {
+      "$role": [
+        "implements(Microsoft.ITrigger)",
+        "extends(Microsoft.OnCondition)"
+      ],
+      "title": "On ConversationUpdate activity",
+      "description": "Actions to perform on receipt of an activity with type 'ConversationUpdate'.",
+      "type": "object",
+      "required": [
+        "actions",
+        "$kind"
+      ],
+      "$package": {
+        "name": "Microsoft.Bot.Builder.Dialogs.Adaptive",
+        "version": "4.11.0"
+      },
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\$": {
+          "title": "Tooling property",
+          "description": "Open ended property for tooling."
+        }
+      },
+      "properties": {
+        "condition": {
+          "$ref": "#/definitions/condition",
+          "title": "Condition",
+          "description": "Condition (expression).",
+          "examples": [
+            "user.vip == true"
+          ]
+        },
+        "actions": {
+          "type": "array",
+          "title": "Actions",
+          "description": "Sequence of actions to execute.",
+          "items": {
+            "$kind": "Microsoft.IDialog",
+            "$ref": "#/definitions/Microsoft.IDialog"
+          }
+        },
+        "priority": {
+          "$ref": "#/definitions/integerExpression",
+          "title": "Priority",
+          "description": "Priority for trigger with 0 being the highest and < 0 ignored."
+        },
+        "runOnce": {
+          "$ref": "#/definitions/booleanExpression",
+          "title": "Run Once",
+          "description": "True if rule should run once per unique conditions",
+          "examples": [
+            true,
+            "=f(x)"
+          ]
+        },
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.OnConversationUpdateActivity"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
+        }
+      }
+    },
+    "Microsoft.OnDialogEvent": {
+      "$role": [
+        "implements(Microsoft.ITrigger)",
+        "extends(Microsoft.OnCondition)"
+      ],
+      "title": "On dialog event",
+      "description": "Actions to perform when a specific dialog event occurs.",
+      "type": "object",
+      "required": [
+        "actions",
+        "event",
+        "$kind"
+      ],
+      "$package": {
+        "name": "Microsoft.Bot.Builder.Dialogs.Adaptive",
+        "version": "4.11.0"
+      },
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\$": {
+          "title": "Tooling property",
+          "description": "Open ended property for tooling."
+        }
+      },
+      "properties": {
+        "event": {
+          "type": "string",
+          "title": "Dialog event name",
+          "description": "Name of dialog event."
+        },
+        "condition": {
+          "$ref": "#/definitions/condition",
+          "title": "Condition",
+          "description": "Condition (expression).",
+          "examples": [
+            "user.vip == true"
+          ]
+        },
+        "actions": {
+          "type": "array",
+          "title": "Actions",
+          "description": "Sequence of actions to execute.",
+          "items": {
+            "$kind": "Microsoft.IDialog",
+            "$ref": "#/definitions/Microsoft.IDialog"
+          }
+        },
+        "priority": {
+          "$ref": "#/definitions/integerExpression",
+          "title": "Priority",
+          "description": "Priority for trigger with 0 being the highest and < 0 ignored."
+        },
+        "runOnce": {
+          "$ref": "#/definitions/booleanExpression",
+          "title": "Run Once",
+          "description": "True if rule should run once per unique conditions",
+          "examples": [
+            true,
+            "=f(x)"
+          ]
+        },
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.OnDialogEvent"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
+        }
+      }
+    },
+    "Microsoft.OnEndOfActions": {
+      "$role": [
+        "implements(Microsoft.ITrigger)",
+        "extends(Microsoft.OnCondition)"
+      ],
+      "title": "On end of actions",
+      "description": "Actions to take when there are no more actions in the current dialog.",
+      "$package": {
+        "name": "Microsoft.Bot.Builder.Dialogs.Adaptive",
+        "version": "4.11.0"
+      },
+      "type": "object",
+      "required": [
+        "actions",
+        "$kind"
+      ],
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\$": {
+          "title": "Tooling property",
+          "description": "Open ended property for tooling."
+        }
+      },
+      "properties": {
+        "condition": {
+          "$ref": "#/definitions/condition",
+          "title": "Condition",
+          "description": "Condition (expression).",
+          "examples": [
+            "user.vip == true"
+          ]
+        },
+        "actions": {
+          "type": "array",
+          "title": "Actions",
+          "description": "Sequence of actions to execute.",
+          "items": {
+            "$kind": "Microsoft.IDialog",
+            "$ref": "#/definitions/Microsoft.IDialog"
+          }
+        },
+        "priority": {
+          "$ref": "#/definitions/integerExpression",
+          "title": "Priority",
+          "description": "Priority for trigger with 0 being the highest and < 0 ignored."
+        },
+        "runOnce": {
+          "$ref": "#/definitions/booleanExpression",
+          "title": "Run Once",
+          "description": "True if rule should run once per unique conditions",
+          "examples": [
+            true,
+            "=f(x)"
+          ]
+        },
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.OnEndOfActions"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
+        }
+      }
+    },
+    "Microsoft.OnEndOfConversationActivity": {
+      "$role": [
+        "implements(Microsoft.ITrigger)",
+        "extends(Microsoft.OnCondition)"
+      ],
+      "title": "On EndOfConversation activity",
+      "description": "Actions to perform on receipt of an activity with type 'EndOfConversation'.",
+      "type": "object",
+      "required": [
+        "actions",
+        "$kind"
+      ],
+      "$package": {
+        "name": "Microsoft.Bot.Builder.Dialogs.Adaptive",
+        "version": "4.11.0"
+      },
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\$": {
+          "title": "Tooling property",
+          "description": "Open ended property for tooling."
+        }
+      },
+      "properties": {
+        "condition": {
+          "$ref": "#/definitions/condition",
+          "title": "Condition",
+          "description": "Condition (expression).",
+          "examples": [
+            "user.vip == true"
+          ]
+        },
+        "actions": {
+          "type": "array",
+          "title": "Actions",
+          "description": "Sequence of actions to execute.",
+          "items": {
+            "$kind": "Microsoft.IDialog",
+            "$ref": "#/definitions/Microsoft.IDialog"
+          }
+        },
+        "priority": {
+          "$ref": "#/definitions/integerExpression",
+          "title": "Priority",
+          "description": "Priority for trigger with 0 being the highest and < 0 ignored."
+        },
+        "runOnce": {
+          "$ref": "#/definitions/booleanExpression",
+          "title": "Run Once",
+          "description": "True if rule should run once per unique conditions",
+          "examples": [
+            true,
+            "=f(x)"
+          ]
+        },
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.OnEndOfConversationActivity"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
+        }
+      }
+    },
+    "Microsoft.OnError": {
+      "$role": [
+        "implements(Microsoft.ITrigger)",
+        "extends(Microsoft.OnCondition)"
+      ],
+      "title": "On error",
+      "description": "Action to perform when an 'Error' dialog event occurs.",
+      "type": "object",
+      "$package": {
+        "name": "Microsoft.Bot.Builder.Dialogs.Adaptive",
+        "version": "4.11.0"
+      },
+      "required": [
+        "actions",
+        "$kind"
+      ],
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\$": {
+          "title": "Tooling property",
+          "description": "Open ended property for tooling."
+        }
+      },
+      "properties": {
+        "condition": {
+          "$ref": "#/definitions/condition",
+          "title": "Condition",
+          "description": "Condition (expression).",
+          "examples": [
+            "user.vip == true"
+          ]
+        },
+        "actions": {
+          "type": "array",
+          "title": "Actions",
+          "description": "Sequence of actions to execute.",
+          "items": {
+            "$kind": "Microsoft.IDialog",
+            "$ref": "#/definitions/Microsoft.IDialog"
+          }
+        },
+        "priority": {
+          "$ref": "#/definitions/integerExpression",
+          "title": "Priority",
+          "description": "Priority for trigger with 0 being the highest and < 0 ignored."
+        },
+        "runOnce": {
+          "$ref": "#/definitions/booleanExpression",
+          "title": "Run Once",
+          "description": "True if rule should run once per unique conditions",
+          "examples": [
+            true,
+            "=f(x)"
+          ]
+        },
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.OnError"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
+        }
+      }
+    },
+    "Microsoft.OnEventActivity": {
+      "$role": [
+        "implements(Microsoft.ITrigger)",
+        "extends(Microsoft.OnCondition)"
+      ],
+      "title": "On Event activity",
+      "description": "Actions to perform on receipt of an activity with type 'Event'.",
+      "type": "object",
+      "required": [
+        "actions",
+        "$kind"
+      ],
+      "$package": {
+        "name": "Microsoft.Bot.Builder.Dialogs.Adaptive",
+        "version": "4.11.0"
+      },
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\$": {
+          "title": "Tooling property",
+          "description": "Open ended property for tooling."
+        }
+      },
+      "properties": {
+        "condition": {
+          "$ref": "#/definitions/condition",
+          "title": "Condition",
+          "description": "Condition (expression).",
+          "examples": [
+            "user.vip == true"
+          ]
+        },
+        "actions": {
+          "type": "array",
+          "title": "Actions",
+          "description": "Sequence of actions to execute.",
+          "items": {
+            "$kind": "Microsoft.IDialog",
+            "$ref": "#/definitions/Microsoft.IDialog"
+          }
+        },
+        "priority": {
+          "$ref": "#/definitions/integerExpression",
+          "title": "Priority",
+          "description": "Priority for trigger with 0 being the highest and < 0 ignored."
+        },
+        "runOnce": {
+          "$ref": "#/definitions/booleanExpression",
+          "title": "Run Once",
+          "description": "True if rule should run once per unique conditions",
+          "examples": [
+            true,
+            "=f(x)"
+          ]
+        },
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.OnEventActivity"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
+        }
+      }
+    },
+    "Microsoft.OnHandoffActivity": {
+      "$role": [
+        "implements(Microsoft.ITrigger)",
+        "extends(Microsoft.OnCondition)"
+      ],
+      "title": "On Handoff activity",
+      "description": "Actions to perform on receipt of an activity with type 'HandOff'.",
+      "type": "object",
+      "required": [
+        "actions",
+        "$kind"
+      ],
+      "$package": {
+        "name": "Microsoft.Bot.Builder.Dialogs.Adaptive",
+        "version": "4.11.0"
+      },
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\$": {
+          "title": "Tooling property",
+          "description": "Open ended property for tooling."
+        }
+      },
+      "properties": {
+        "condition": {
+          "$ref": "#/definitions/condition",
+          "title": "Condition",
+          "description": "Condition (expression).",
+          "examples": [
+            "user.vip == true"
+          ]
+        },
+        "actions": {
+          "type": "array",
+          "title": "Actions",
+          "description": "Sequence of actions to execute.",
+          "items": {
+            "$kind": "Microsoft.IDialog",
+            "$ref": "#/definitions/Microsoft.IDialog"
+          }
+        },
+        "priority": {
+          "$ref": "#/definitions/integerExpression",
+          "title": "Priority",
+          "description": "Priority for trigger with 0 being the highest and < 0 ignored."
+        },
+        "runOnce": {
+          "$ref": "#/definitions/booleanExpression",
+          "title": "Run Once",
+          "description": "True if rule should run once per unique conditions",
+          "examples": [
+            true,
+            "=f(x)"
+          ]
+        },
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.OnHandoffActivity"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
+        }
+      }
+    },
+    "Microsoft.OnInstallationUpdateActivity": {
+      "$role": [
+        "implements(Microsoft.ITrigger)",
+        "extends(Microsoft.OnCondition)"
+      ],
+      "title": "On InstallationUpdate activity",
+      "description": "Actions to perform on receipt of an activity with type 'InstallationUpdate'.",
+      "type": "object",
+      "required": [
+        "actions",
+        "$kind"
+      ],
+      "$package": {
+        "name": "Microsoft.Bot.Builder.Dialogs.Adaptive",
+        "version": "4.11.0"
+      },
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\$": {
+          "title": "Tooling property",
+          "description": "Open ended property for tooling."
+        }
+      },
+      "properties": {
+        "condition": {
+          "$ref": "#/definitions/condition",
+          "title": "Condition",
+          "description": "Condition (expression).",
+          "examples": [
+            "user.vip == true"
+          ]
+        },
+        "actions": {
+          "type": "array",
+          "title": "Actions",
+          "description": "Sequence of actions to execute.",
+          "items": {
+            "$kind": "Microsoft.IDialog",
+            "$ref": "#/definitions/Microsoft.IDialog"
+          }
+        },
+        "priority": {
+          "$ref": "#/definitions/integerExpression",
+          "title": "Priority",
+          "description": "Priority for trigger with 0 being the highest and < 0 ignored."
+        },
+        "runOnce": {
+          "$ref": "#/definitions/booleanExpression",
+          "title": "Run Once",
+          "description": "True if rule should run once per unique conditions",
+          "examples": [
+            true,
+            "=f(x)"
+          ]
+        },
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.OnInstallationUpdateActivity"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
+        }
+      }
+    },
+    "Microsoft.OnIntent": {
+      "$role": [
+        "implements(Microsoft.ITrigger)",
+        "extends(Microsoft.OnCondition)"
+      ],
+      "title": "On intent recognition",
+      "description": "Actions to perform when specified intent is recognized.",
+      "type": "object",
+      "required": [
+        "actions",
+        "$kind"
+      ],
+      "$package": {
+        "name": "Microsoft.Bot.Builder.Dialogs.Adaptive",
+        "version": "4.11.0"
+      },
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\$": {
+          "title": "Tooling property",
+          "description": "Open ended property for tooling."
+        }
+      },
+      "properties": {
+        "intent": {
+          "type": "string",
+          "title": "Intent",
+          "description": "Name of intent."
+        },
+        "entities": {
+          "type": "array",
+          "title": "Entities",
+          "description": "Required entities.",
+          "items": {
+            "type": "string",
+            "title": "Entity",
+            "description": "Entity that must be present."
+          }
+        },
+        "condition": {
+          "$ref": "#/definitions/condition",
+          "title": "Condition",
+          "description": "Condition (expression).",
+          "examples": [
+            "user.vip == true"
+          ]
+        },
+        "actions": {
+          "type": "array",
+          "title": "Actions",
+          "description": "Sequence of actions to execute.",
+          "items": {
+            "$kind": "Microsoft.IDialog",
+            "$ref": "#/definitions/Microsoft.IDialog"
+          }
+        },
+        "priority": {
+          "$ref": "#/definitions/integerExpression",
+          "title": "Priority",
+          "description": "Priority for trigger with 0 being the highest and < 0 ignored."
+        },
+        "runOnce": {
+          "$ref": "#/definitions/booleanExpression",
+          "title": "Run Once",
+          "description": "True if rule should run once per unique conditions",
+          "examples": [
+            true,
+            "=f(x)"
+          ]
+        },
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.OnIntent"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
+        }
+      }
+    },
+    "Microsoft.OnInvokeActivity": {
+      "$role": [
+        "implements(Microsoft.ITrigger)",
+        "extends(Microsoft.OnCondition)"
+      ],
+      "title": "On Invoke activity",
+      "description": "Actions to perform on receipt of an activity with type 'Invoke'.",
+      "type": "object",
+      "required": [
+        "actions",
+        "$kind"
+      ],
+      "$package": {
+        "name": "Microsoft.Bot.Builder.Dialogs.Adaptive",
+        "version": "4.11.0"
+      },
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\$": {
+          "title": "Tooling property",
+          "description": "Open ended property for tooling."
+        }
+      },
+      "properties": {
+        "condition": {
+          "$ref": "#/definitions/condition",
+          "title": "Condition",
+          "description": "Condition (expression).",
+          "examples": [
+            "user.vip == true"
+          ]
+        },
+        "actions": {
+          "type": "array",
+          "title": "Actions",
+          "description": "Sequence of actions to execute.",
+          "items": {
+            "$kind": "Microsoft.IDialog",
+            "$ref": "#/definitions/Microsoft.IDialog"
+          }
+        },
+        "priority": {
+          "$ref": "#/definitions/integerExpression",
+          "title": "Priority",
+          "description": "Priority for trigger with 0 being the highest and < 0 ignored."
+        },
+        "runOnce": {
+          "$ref": "#/definitions/booleanExpression",
+          "title": "Run Once",
+          "description": "True if rule should run once per unique conditions",
+          "examples": [
+            true,
+            "=f(x)"
+          ]
+        },
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.OnInvokeActivity"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
+        }
+      }
+    },
+    "Microsoft.OnMessageActivity": {
+      "$role": [
+        "implements(Microsoft.ITrigger)",
+        "extends(Microsoft.OnCondition)"
+      ],
+      "title": "On Message activity",
+      "description": "Actions to perform on receipt of an activity with type 'Message'. Overrides Intent trigger.",
+      "type": "object",
+      "required": [
+        "actions",
+        "$kind"
+      ],
+      "$package": {
+        "name": "Microsoft.Bot.Builder.Dialogs.Adaptive",
+        "version": "4.11.0"
+      },
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\$": {
+          "title": "Tooling property",
+          "description": "Open ended property for tooling."
+        }
+      },
+      "properties": {
+        "condition": {
+          "$ref": "#/definitions/condition",
+          "title": "Condition",
+          "description": "Condition (expression).",
+          "examples": [
+            "user.vip == true"
+          ]
+        },
+        "actions": {
+          "type": "array",
+          "title": "Actions",
+          "description": "Sequence of actions to execute.",
+          "items": {
+            "$kind": "Microsoft.IDialog",
+            "$ref": "#/definitions/Microsoft.IDialog"
+          }
+        },
+        "priority": {
+          "$ref": "#/definitions/integerExpression",
+          "title": "Priority",
+          "description": "Priority for trigger with 0 being the highest and < 0 ignored."
+        },
+        "runOnce": {
+          "$ref": "#/definitions/booleanExpression",
+          "title": "Run Once",
+          "description": "True if rule should run once per unique conditions",
+          "examples": [
+            true,
+            "=f(x)"
+          ]
+        },
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.OnMessageActivity"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
+        }
+      }
+    },
+    "Microsoft.OnMessageDeleteActivity": {
+      "$role": [
+        "implements(Microsoft.ITrigger)",
+        "extends(Microsoft.OnCondition)"
+      ],
+      "title": "On MessageDelete activity",
+      "description": "Actions to perform on receipt of an activity with type 'MessageDelete'.",
+      "type": "object",
+      "required": [
+        "actions",
+        "$kind"
+      ],
+      "$package": {
+        "name": "Microsoft.Bot.Builder.Dialogs.Adaptive",
+        "version": "4.11.0"
+      },
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\$": {
+          "title": "Tooling property",
+          "description": "Open ended property for tooling."
+        }
+      },
+      "properties": {
+        "condition": {
+          "$ref": "#/definitions/condition",
+          "title": "Condition",
+          "description": "Condition (expression).",
+          "examples": [
+            "user.vip == true"
+          ]
+        },
+        "actions": {
+          "type": "array",
+          "title": "Actions",
+          "description": "Sequence of actions to execute.",
+          "items": {
+            "$kind": "Microsoft.IDialog",
+            "$ref": "#/definitions/Microsoft.IDialog"
+          }
+        },
+        "priority": {
+          "$ref": "#/definitions/integerExpression",
+          "title": "Priority",
+          "description": "Priority for trigger with 0 being the highest and < 0 ignored."
+        },
+        "runOnce": {
+          "$ref": "#/definitions/booleanExpression",
+          "title": "Run Once",
+          "description": "True if rule should run once per unique conditions",
+          "examples": [
+            true,
+            "=f(x)"
+          ]
+        },
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.OnMessageDeleteActivity"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
+        }
+      }
+    },
+    "Microsoft.OnMessageReactionActivity": {
+      "$role": [
+        "implements(Microsoft.ITrigger)",
+        "extends(Microsoft.OnCondition)"
+      ],
+      "title": "On MessageReaction activity",
+      "description": "Actions to perform on receipt of an activity with type 'MessageReaction'.",
+      "type": "object",
+      "required": [
+        "actions",
+        "$kind"
+      ],
+      "$package": {
+        "name": "Microsoft.Bot.Builder.Dialogs.Adaptive",
+        "version": "4.11.0"
+      },
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\$": {
+          "title": "Tooling property",
+          "description": "Open ended property for tooling."
+        }
+      },
+      "properties": {
+        "condition": {
+          "$ref": "#/definitions/condition",
+          "title": "Condition",
+          "description": "Condition (expression).",
+          "examples": [
+            "user.vip == true"
+          ]
+        },
+        "actions": {
+          "type": "array",
+          "title": "Actions",
+          "description": "Sequence of actions to execute.",
+          "items": {
+            "$kind": "Microsoft.IDialog",
+            "$ref": "#/definitions/Microsoft.IDialog"
+          }
+        },
+        "priority": {
+          "$ref": "#/definitions/integerExpression",
+          "title": "Priority",
+          "description": "Priority for trigger with 0 being the highest and < 0 ignored."
+        },
+        "runOnce": {
+          "$ref": "#/definitions/booleanExpression",
+          "title": "Run Once",
+          "description": "True if rule should run once per unique conditions",
+          "examples": [
+            true,
+            "=f(x)"
+          ]
+        },
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.OnMessageReactionActivity"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
+        }
+      }
+    },
+    "Microsoft.OnMessageUpdateActivity": {
+      "$role": [
+        "implements(Microsoft.ITrigger)",
+        "extends(Microsoft.OnCondition)"
+      ],
+      "title": "On MessageUpdate activity",
+      "description": "Actions to perform on receipt of an activity with type 'MessageUpdate'.",
+      "type": "object",
+      "required": [
+        "actions",
+        "$kind"
+      ],
+      "$package": {
+        "name": "Microsoft.Bot.Builder.Dialogs.Adaptive",
+        "version": "4.11.0"
+      },
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\$": {
+          "title": "Tooling property",
+          "description": "Open ended property for tooling."
+        }
+      },
+      "properties": {
+        "condition": {
+          "$ref": "#/definitions/condition",
+          "title": "Condition",
+          "description": "Condition (expression).",
+          "examples": [
+            "user.vip == true"
+          ]
+        },
+        "actions": {
+          "type": "array",
+          "title": "Actions",
+          "description": "Sequence of actions to execute.",
+          "items": {
+            "$kind": "Microsoft.IDialog",
+            "$ref": "#/definitions/Microsoft.IDialog"
+          }
+        },
+        "priority": {
+          "$ref": "#/definitions/integerExpression",
+          "title": "Priority",
+          "description": "Priority for trigger with 0 being the highest and < 0 ignored."
+        },
+        "runOnce": {
+          "$ref": "#/definitions/booleanExpression",
+          "title": "Run Once",
+          "description": "True if rule should run once per unique conditions",
+          "examples": [
+            true,
+            "=f(x)"
+          ]
+        },
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.OnMessageUpdateActivity"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
+        }
+      }
+    },
+    "Microsoft.OnQnAMatch": {
+      "$role": [
+        "implements(Microsoft.ITrigger)",
+        "extends(Microsoft.OnCondition)"
+      ],
+      "title": "On QnAMaker match",
+      "description": "Actions to perform on when an match from QnAMaker is found.",
+      "type": "object",
+      "required": [
+        "actions",
+        "$kind"
+      ],
+      "$package": {
+        "name": "Microsoft.Bot.Builder.Dialogs.Adaptive",
+        "version": "4.11.0"
+      },
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\$": {
+          "title": "Tooling property",
+          "description": "Open ended property for tooling."
+        }
+      },
+      "properties": {
+        "condition": {
+          "$ref": "#/definitions/condition",
+          "title": "Condition",
+          "description": "Condition (expression).",
+          "examples": [
+            "user.vip == true"
+          ]
+        },
+        "actions": {
+          "type": "array",
+          "title": "Actions",
+          "description": "Sequence of actions to execute.",
+          "items": {
+            "$kind": "Microsoft.IDialog",
+            "$ref": "#/definitions/Microsoft.IDialog"
+          }
+        },
+        "priority": {
+          "$ref": "#/definitions/integerExpression",
+          "title": "Priority",
+          "description": "Priority for trigger with 0 being the highest and < 0 ignored."
+        },
+        "runOnce": {
+          "$ref": "#/definitions/booleanExpression",
+          "title": "Run Once",
+          "description": "True if rule should run once per unique conditions",
+          "examples": [
+            true,
+            "=f(x)"
+          ]
+        },
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.OnQnAMatch"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
+        }
+      }
+    },
+    "Microsoft.OnRepromptDialog": {
+      "$role": [
+        "implements(Microsoft.ITrigger)",
+        "extends(Microsoft.OnCondition)"
+      ],
+      "title": "On RepromptDialog",
+      "description": "Actions to perform when 'RepromptDialog' event occurs.",
+      "type": "object",
+      "$package": {
+        "name": "Microsoft.Bot.Builder.Dialogs.Adaptive",
+        "version": "4.11.0"
+      },
+      "required": [
+        "actions",
+        "$kind"
+      ],
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\$": {
+          "title": "Tooling property",
+          "description": "Open ended property for tooling."
+        }
+      },
+      "properties": {
+        "condition": {
+          "$ref": "#/definitions/condition",
+          "title": "Condition",
+          "description": "Condition (expression).",
+          "examples": [
+            "user.vip == true"
+          ]
+        },
+        "actions": {
+          "type": "array",
+          "title": "Actions",
+          "description": "Sequence of actions to execute.",
+          "items": {
+            "$kind": "Microsoft.IDialog",
+            "$ref": "#/definitions/Microsoft.IDialog"
+          }
+        },
+        "priority": {
+          "$ref": "#/definitions/integerExpression",
+          "title": "Priority",
+          "description": "Priority for trigger with 0 being the highest and < 0 ignored."
+        },
+        "runOnce": {
+          "$ref": "#/definitions/booleanExpression",
+          "title": "Run Once",
+          "description": "True if rule should run once per unique conditions",
+          "examples": [
+            true,
+            "=f(x)"
+          ]
+        },
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.OnRepromptDialog"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
+        }
+      }
+    },
+    "Microsoft.OnTypingActivity": {
+      "$role": [
+        "implements(Microsoft.ITrigger)",
+        "extends(Microsoft.OnCondition)"
+      ],
+      "title": "On Typing activity",
+      "description": "Actions to perform on receipt of an activity with type 'Typing'.",
+      "type": "object",
+      "required": [
+        "actions",
+        "$kind"
+      ],
+      "$package": {
+        "name": "Microsoft.Bot.Builder.Dialogs.Adaptive",
+        "version": "4.11.0"
+      },
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\$": {
+          "title": "Tooling property",
+          "description": "Open ended property for tooling."
+        }
+      },
+      "properties": {
+        "condition": {
+          "$ref": "#/definitions/condition",
+          "title": "Condition",
+          "description": "Condition (expression).",
+          "examples": [
+            "user.vip == true"
+          ]
+        },
+        "actions": {
+          "type": "array",
+          "title": "Actions",
+          "description": "Sequence of actions to execute.",
+          "items": {
+            "$kind": "Microsoft.IDialog",
+            "$ref": "#/definitions/Microsoft.IDialog"
+          }
+        },
+        "priority": {
+          "$ref": "#/definitions/integerExpression",
+          "title": "Priority",
+          "description": "Priority for trigger with 0 being the highest and < 0 ignored."
+        },
+        "runOnce": {
+          "$ref": "#/definitions/booleanExpression",
+          "title": "Run Once",
+          "description": "True if rule should run once per unique conditions",
+          "examples": [
+            true,
+            "=f(x)"
+          ]
+        },
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.OnTypingActivity"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
+        }
+      }
+    },
+    "Microsoft.OnUnknownIntent": {
+      "$role": [
+        "implements(Microsoft.ITrigger)",
+        "extends(Microsoft.OnCondition)"
+      ],
+      "title": "On unknown intent",
+      "description": "Action to perform when user input is unrecognized or if none of the 'on intent recognition' triggers match recognized intent.",
+      "type": "object",
+      "required": [
+        "actions",
+        "$kind"
+      ],
+      "$package": {
+        "name": "Microsoft.Bot.Builder.Dialogs.Adaptive",
+        "version": "4.11.0"
+      },
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\$": {
+          "title": "Tooling property",
+          "description": "Open ended property for tooling."
+        }
+      },
+      "properties": {
+        "condition": {
+          "$ref": "#/definitions/condition",
+          "title": "Condition",
+          "description": "Condition (expression).",
+          "examples": [
+            "user.vip == true"
+          ]
+        },
+        "actions": {
+          "type": "array",
+          "title": "Actions",
+          "description": "Sequence of actions to execute.",
+          "items": {
+            "$kind": "Microsoft.IDialog",
+            "$ref": "#/definitions/Microsoft.IDialog"
+          }
+        },
+        "priority": {
+          "$ref": "#/definitions/integerExpression",
+          "title": "Priority",
+          "description": "Priority for trigger with 0 being the highest and < 0 ignored."
+        },
+        "runOnce": {
+          "$ref": "#/definitions/booleanExpression",
+          "title": "Run Once",
+          "description": "True if rule should run once per unique conditions",
+          "examples": [
+            true,
+            "=f(x)"
+          ]
+        },
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.OnUnknownIntent"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
+        }
+      }
+    },
+    "Microsoft.OrdinalEntityRecognizer": {
+      "$role": [
+        "implements(Microsoft.IRecognizer)",
+        "implements(Microsoft.IEntityRecognizer)"
+      ],
+      "title": "Ordinal entity recognizer",
+      "description": "Recognizer which recognizes ordinals (example: first, second, 3rd).",
+      "type": "object",
+      "$package": {
+        "name": "Microsoft.Bot.Builder.Dialogs.Adaptive",
+        "version": "4.11.0"
+      },
+      "required": [
+        "$kind"
+      ],
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\$": {
+          "title": "Tooling property",
+          "description": "Open ended property for tooling."
+        }
+      },
+      "properties": {
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.OrdinalEntityRecognizer"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
+        }
+      }
+    },
+    "Microsoft.PercentageEntityRecognizer": {
+      "$role": [
+        "implements(Microsoft.IRecognizer)",
+        "implements(Microsoft.IEntityRecognizer)"
+      ],
+      "title": "Percentage entity recognizer",
+      "description": "Recognizer which recognizes percentages.",
+      "type": "object",
+      "$package": {
+        "name": "Microsoft.Bot.Builder.Dialogs.Adaptive",
+        "version": "4.11.0"
+      },
+      "required": [
+        "$kind"
+      ],
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\$": {
+          "title": "Tooling property",
+          "description": "Open ended property for tooling."
+        }
+      },
+      "properties": {
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.PercentageEntityRecognizer"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
+        }
+      }
+    },
+    "Microsoft.PhoneNumberEntityRecognizer": {
+      "$role": [
+        "implements(Microsoft.IRecognizer)",
+        "implements(Microsoft.IEntityRecognizer)"
+      ],
+      "title": "Phone number entity recognizer",
+      "description": "Recognizer which recognizes phone numbers.",
+      "type": "object",
+      "$package": {
+        "name": "Microsoft.Bot.Builder.Dialogs.Adaptive",
+        "version": "4.11.0"
+      },
+      "required": [
+        "$kind"
+      ],
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\$": {
+          "title": "Tooling property",
+          "description": "Open ended property for tooling."
+        }
+      },
+      "properties": {
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.PhoneNumberEntityRecognizer"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
+        }
+      }
+    },
+    "Microsoft.QnAMakerDialog": {
+      "$role": "implements(Microsoft.IDialog)",
+      "title": "QnAMaker dialog",
+      "description": "Dialog which uses QnAMAker knowledge base to answer questions.",
+      "type": "object",
+      "required": [
+        "knowledgeBaseId",
+        "endpointKey",
+        "hostname",
+        "$kind"
+      ],
+      "$package": {
+        "name": "Microsoft.Bot.Builder.AI.QnA",
+        "version": "4.11.0"
+      },
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\$": {
+          "title": "Tooling property",
+          "description": "Open ended property for tooling."
+        }
+      },
+      "properties": {
+        "knowledgeBaseId": {
+          "$ref": "#/definitions/stringExpression",
+          "title": "KnowledgeBase Id",
+          "description": "KnowledgeBase Id of your QnA Maker KnowledgeBase.",
+          "default": "=settings.qna.knowledgebaseid"
+        },
+        "endpointKey": {
+          "$ref": "#/definitions/stringExpression",
+          "title": "Endpoint key",
+          "description": "Endpoint key for the QnA Maker KB.",
+          "default": "=settings.qna.endpointkey"
+        },
+        "hostname": {
+          "$ref": "#/definitions/stringExpression",
+          "title": "Hostname",
+          "description": "Hostname for your QnA Maker service.",
+          "default": "=settings.qna.hostname",
+          "examples": [
+            "https://yourserver.azurewebsites.net/qnamaker"
+          ]
+        },
+        "noAnswer": {
+          "$kind": "Microsoft.IActivityTemplate",
+          "title": "Fallback answer",
+          "description": "Default answer to return when none found in KB.",
+          "default": "Sorry, I did not find an answer.",
+          "$ref": "#/definitions/Microsoft.IActivityTemplate"
+        },
+        "threshold": {
+          "$ref": "#/definitions/numberExpression",
+          "title": "Threshold",
+          "description": "Threshold score to filter results.",
+          "default": 0.3
+        },
+        "activeLearningCardTitle": {
+          "$ref": "#/definitions/stringExpression",
+          "title": "Active learning card title",
+          "description": "Title for active learning suggestions card.",
+          "default": "Did you mean:"
+        },
+        "cardNoMatchText": {
+          "$ref": "#/definitions/stringExpression",
+          "title": "Card no match text",
+          "description": "Text for no match option.",
+          "default": "None of the above."
+        },
+        "cardNoMatchResponse": {
+          "$kind": "Microsoft.IActivityTemplate",
+          "title": "Card no match response",
+          "description": "Custom response when no match option was selected.",
+          "default": "Thanks for the feedback.",
+          "$ref": "#/definitions/Microsoft.IActivityTemplate"
+        },
+        "strictFilters": {
+          "$ref": "#/definitions/arrayExpression",
+          "title": "Strict filters",
+          "description": "Metadata filters to use when calling the QnA Maker KB.",
+          "items": {
+            "type": "object",
+            "title": "Metadata filter",
+            "description": "Metadata filter.",
+            "properties": {
+              "name": {
+                "type": "string",
+                "title": "Name",
+                "description": "Name of filter property.",
+                "maximum": 100
+              },
+              "value": {
+                "type": "string",
+                "title": "Value",
+                "description": "Value to filter on.",
+                "maximum": 100
+              }
+            }
+          }
+        },
+        "top": {
+          "$ref": "#/definitions/numberExpression",
+          "title": "Top",
+          "description": "The number of answers you want to retrieve.",
+          "default": 3
+        },
+        "isTest": {
+          "type": "boolean",
+          "title": "IsTest",
+          "description": "True, if pointing to Test environment, else false.",
+          "default": false
+        },
+        "rankerType": {
+          "$ref": "#/definitions/stringExpression",
+          "title": "Ranker type",
+          "description": "Type of Ranker.",
+          "oneOf": [
+            {
+              "title": "Standard ranker",
+              "description": "Standard ranker types.",
+              "enum": [
+                "default",
+                "questionOnly",
+                "autoSuggestQuestion"
+              ],
+              "default": "default"
+            },
+            {
+              "$ref": "#/definitions/equalsExpression"
+            }
+          ]
+        },
+        "strictFiltersJoinOperator": {
+          "$ref": "#/definitions/stringExpression",
+          "title": "StrictFiltersJoinOperator",
+          "description": "Join operator for Strict Filters.",
+          "oneOf": [
+            {
+              "title": "Join operator",
+              "description": "Value of Join Operator to be used as conjunction with Strict Filter values.",
+              "enum": [
+                "AND",
+                "OR"
+              ],
+              "default": "AND"
+            },
+            {
+              "$ref": "#/definitions/equalsExpression"
+            }
+          ]
+        },
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.QnAMakerDialog"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
+        }
+      }
+    },
+    "Microsoft.QnAMakerRecognizer": {
+      "$role": "implements(Microsoft.IRecognizer)",
+      "title": "QnAMaker recognizer",
+      "description": "Recognizer for generating QnAMatch intents from a KB.",
+      "type": "object",
+      "required": [
+        "knowledgeBaseId",
+        "endpointKey",
+        "hostname",
+        "$kind"
+      ],
+      "$package": {
+        "name": "Microsoft.Bot.Builder.AI.QnA",
+        "version": "4.11.0"
+      },
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\$": {
+          "title": "Tooling property",
+          "description": "Open ended property for tooling."
+        }
+      },
+      "properties": {
+        "id": {
+          "type": "string",
+          "title": "Id",
+          "description": "Optional unique id using with RecognizerSet."
+        },
+        "knowledgeBaseId": {
+          "$ref": "#/definitions/stringExpression",
+          "title": "KnowledgeBase Id",
+          "description": "Knowledge base Id of your QnA Maker knowledge base.",
+          "default": "=settings.qna.knowledgebaseid"
+        },
+        "endpointKey": {
+          "$ref": "#/definitions/stringExpression",
+          "title": "Endpoint key",
+          "description": "Endpoint key for the QnA Maker KB.",
+          "default": "=settings.qna.endpointkey"
+        },
+        "hostname": {
+          "$ref": "#/definitions/stringExpression",
+          "title": "Hostname",
+          "description": "Hostname for your QnA Maker service.",
+          "default": "=settings.qna.hostname",
+          "examples": [
+            "https://yourserver.azurewebsites.net/qnamaker"
+          ]
+        },
+        "threshold": {
+          "$ref": "#/definitions/numberExpression",
+          "title": "Threshold",
+          "description": "Threshold score to filter results.",
+          "default": 0.3
+        },
+        "strictFilters": {
+          "$ref": "#/definitions/arrayExpression",
+          "title": "Strict filters",
+          "description": "Metadata filters to use when calling the QnA Maker KB.",
+          "items": {
+            "type": "object",
+            "title": "Metadata filters",
+            "description": "Metadata filters to use when querying QnA Maker KB.",
+            "properties": {
+              "name": {
+                "type": "string",
+                "title": "Name",
+                "description": "Name to filter on.",
+                "maximum": 100
+              },
+              "value": {
+                "type": "string",
+                "title": "Value",
+                "description": "Value to restrict filter.",
+                "maximum": 100
+              }
+            }
+          }
+        },
+        "top": {
+          "$ref": "#/definitions/numberExpression",
+          "title": "Top",
+          "description": "The number of answers you want to retrieve.",
+          "default": 3
+        },
+        "isTest": {
+          "$ref": "#/definitions/booleanExpression",
+          "title": "Use test environment",
+          "description": "True, if pointing to Test environment, else false.",
+          "examples": [
+            true,
+            "=f(x)"
+          ]
+        },
+        "rankerType": {
+          "title": "Ranker type",
+          "description": "Type of Ranker.",
+          "oneOf": [
+            {
+              "type": "string",
+              "title": "Ranker type",
+              "description": "Type of Ranker.",
+              "enum": [
+                "default",
+                "questionOnly",
+                "autoSuggestQuestion"
+              ],
+              "default": "default"
+            },
+            {
+              "$ref": "#/definitions/equalsExpression"
+            }
+          ]
+        },
+        "strictFiltersJoinOperator": {
+          "$ref": "#/definitions/stringExpression",
+          "title": "StrictFiltersJoinOperator",
+          "description": "Join operator for Strict Filters.",
+          "oneOf": [
+            {
+              "title": "Join operator",
+              "description": "Value of Join Operator to be used as onjuction with Strict Filter values.",
+              "enum": [
+                "AND",
+                "OR"
+              ],
+              "default": "AND"
+            },
+            {
+              "$ref": "#/definitions/equalsExpression"
+            }
+          ]
+        },
+        "includeDialogNameInMetadata": {
+          "$ref": "#/definitions/booleanExpression",
+          "title": "Include dialog name",
+          "description": "When set to false, the dialog name will not be passed to QnAMaker. (default) is true",
+          "default": true,
+          "examples": [
+            true,
+            "=f(x)"
+          ]
+        },
+        "metadata": {
+          "$ref": "#/definitions/arrayExpression",
+          "title": "Metadata filters",
+          "description": "Metadata filters to use when calling the QnA Maker KB.",
+          "items": {
+            "type": "object",
+            "title": "Metadata filter",
+            "description": "Metadata filter to use when calling the QnA Maker KB.",
+            "properties": {
+              "name": {
+                "type": "string",
+                "title": "Name",
+                "description": "Name of value to test."
+              },
+              "value": {
+                "type": "string",
+                "title": "Value",
+                "description": "Value to filter against."
+              }
+            }
+          }
+        },
+        "context": {
+          "$ref": "#/definitions/objectExpression",
+          "title": "QnA request context",
+          "description": "Context to use for ranking."
+        },
+        "qnaId": {
+          "$ref": "#/definitions/integerExpression",
+          "title": "QnA Id",
+          "description": "A number or expression which is the QnAId to paass to QnAMaker API."
+        },
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.QnAMakerRecognizer"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
+        }
+      }
+    },
+    "Microsoft.RandomSelector": {
+      "$role": "implements(Microsoft.ITriggerSelector)",
+      "title": "Random rule selector",
+      "description": "Select most specific true rule.",
+      "type": "object",
+      "$package": {
+        "name": "Microsoft.Bot.Builder.Dialogs.Adaptive",
+        "version": "4.11.0"
+      },
+      "required": [
+        "$kind"
+      ],
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\$": {
+          "title": "Tooling property",
+          "description": "Open ended property for tooling."
+        }
+      },
+      "properties": {
+        "seed": {
+          "type": "integer",
+          "title": "Random seed",
+          "description": "Random seed to start random number generation."
+        },
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.RandomSelector"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
+        }
+      }
+    },
+    "Microsoft.RecognizerSet": {
+      "$role": "implements(Microsoft.IRecognizer)",
+      "title": "Recognizer set",
+      "description": "Creates the union of the intents and entities of the recognizers in the set.",
+      "type": "object",
+      "required": [
+        "recognizers",
+        "$kind"
+      ],
+      "$package": {
+        "name": "Microsoft.Bot.Builder.Dialogs.Adaptive",
+        "version": "4.11.0"
+      },
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\$": {
+          "title": "Tooling property",
+          "description": "Open ended property for tooling."
+        }
+      },
+      "properties": {
+        "id": {
+          "type": "string",
+          "title": "Id",
+          "description": "Optional unique id using with RecognizerSet.  Other recognizers should return 'DeferToRecognizer_{Id}' intent when cross training data for this recognizer."
+        },
+        "recognizers": {
+          "type": "array",
+          "title": "Recognizers",
+          "description": "List of Recognizers defined for this set.",
+          "items": {
+            "$kind": "Microsoft.IRecognizer",
+            "$ref": "#/definitions/Microsoft.IRecognizer"
+          }
+        },
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.RecognizerSet"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
+        }
+      }
+    },
+    "Microsoft.RegexEntityRecognizer": {
+      "$role": [
+        "implements(Microsoft.IRecognizer)",
+        "implements(Microsoft.IEntityRecognizer)"
+      ],
+      "title": "Regex entity recognizer",
+      "description": "Recognizer which recognizes patterns of input based on regex.",
+      "type": "object",
+      "required": [
+        "name",
+        "pattern",
+        "$kind"
+      ],
+      "$package": {
+        "name": "Microsoft.Bot.Builder.Dialogs.Adaptive",
+        "version": "4.11.0"
+      },
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\$": {
+          "title": "Tooling property",
+          "description": "Open ended property for tooling."
+        }
+      },
+      "properties": {
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "Name of the entity"
+        },
+        "pattern": {
+          "type": "string",
+          "title": "Pattern",
+          "description": "Pattern expressed as regular expression."
+        },
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.RegexEntityRecognizer"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
+        }
+      }
+    },
+    "Microsoft.RegexRecognizer": {
+      "$role": "implements(Microsoft.IRecognizer)",
+      "title": "Regex recognizer",
+      "description": "Use regular expressions to recognize intents and entities from user input.",
+      "type": "object",
+      "$package": {
+        "name": "Microsoft.Bot.Builder.Dialogs.Adaptive",
+        "version": "4.11.0"
+      },
+      "required": [
+        "$kind"
+      ],
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\$": {
+          "title": "Tooling property",
+          "description": "Open ended property for tooling."
+        }
+      },
+      "properties": {
+        "id": {
+          "type": "string",
+          "title": "Id",
+          "description": "Optional unique id using with RecognizerSet.  Other recognizers should return 'DeferToRecognizer_{Id}' intent when cross training data for this recognizer."
+        },
+        "intents": {
+          "type": "array",
+          "title": "RegEx patterns to intents",
+          "description": "Collection of patterns to match for an intent.",
+          "items": {
+            "type": "object",
+            "title": "Pattern",
+            "description": "Intent and regex pattern.",
+            "properties": {
+              "intent": {
+                "type": "string",
+                "title": "Intent",
+                "description": "The intent name."
+              },
+              "pattern": {
+                "type": "string",
+                "title": "Pattern",
+                "description": "The regular expression pattern."
+              }
+            }
+          }
+        },
+        "entities": {
+          "type": "array",
+          "title": "Entity recognizers",
+          "description": "Collection of entity recognizers to use.",
+          "items": {
+            "$kind": "Microsoft.IEntityRecognizer",
+            "$ref": "#/definitions/Microsoft.IEntityRecognizer"
+          }
+        },
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.RegexRecognizer"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
+        }
+      }
+    },
+    "Microsoft.RepeatDialog": {
+      "$role": "implements(Microsoft.IDialog)",
+      "type": "object",
+      "title": "Repeat dialog",
+      "description": "Repeat current dialog.",
+      "$package": {
+        "name": "Microsoft.Bot.Builder.Dialogs.Adaptive",
+        "version": "4.11.0"
+      },
+      "required": [
+        "$kind"
+      ],
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\$": {
+          "title": "Tooling property",
+          "description": "Open ended property for tooling."
+        }
+      },
+      "properties": {
+        "id": {
+          "type": "string",
+          "title": "Id",
+          "description": "Optional id for the dialog"
+        },
+        "allowLoop": {
+          "$ref": "#/definitions/booleanExpression",
+          "title": "AllowLoop",
+          "description": "Optional condition which if true will allow loop of the repeated dialog.",
+          "examples": [
+            "user.age > 3"
+          ]
+        },
+        "disabled": {
+          "$ref": "#/definitions/booleanExpression",
+          "title": "Disabled",
+          "description": "Optional condition which if true will disable this action.",
+          "examples": [
+            "user.age > 3"
+          ]
+        },
+        "options": {
+          "$ref": "#/definitions/objectExpression",
+          "title": "Options",
+          "description": "One or more options that are passed to the dialog that is called.",
+          "additionalProperties": {
+            "type": "string",
+            "title": "Options",
+            "description": "Options for repeating dialog."
+          }
+        },
+        "activityProcessed": {
+          "$ref": "#/definitions/booleanExpression",
+          "title": "Activity processed",
+          "description": "When set to false, the dialog that is called can process the current activity.",
+          "default": true
+        },
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.RepeatDialog"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
+        }
+      }
+    },
+    "Microsoft.ReplaceDialog": {
+      "$role": "implements(Microsoft.IDialog)",
+      "type": "object",
+      "title": "Replace dialog",
+      "description": "Replace current dialog with another dialog.",
+      "$package": {
+        "name": "Microsoft.Bot.Builder.Dialogs.Adaptive",
+        "version": "4.11.0"
+      },
+      "required": [
+        "$kind"
+      ],
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\$": {
+          "title": "Tooling property",
+          "description": "Open ended property for tooling."
+        }
+      },
+      "properties": {
+        "id": {
+          "type": "string",
+          "title": "Id",
+          "description": "Optional id for the dialog"
+        },
+        "disabled": {
+          "$ref": "#/definitions/booleanExpression",
+          "title": "Disabled",
+          "description": "Optional condition which if true will disable this action.",
+          "examples": [
+            "user.age > 3"
+          ]
+        },
+        "dialog": {
+          "oneOf": [
+            {
+              "$kind": "Microsoft.IDialog",
+              "pattern": "^(?!(=)).*",
+              "title": "Dialog",
+              "$ref": "#/definitions/Microsoft.IDialog"
+            },
+            {
+              "$ref": "#/definitions/equalsExpression",
+              "examples": [
+                "=settings.dialogId"
+              ]
+            }
+          ],
+          "title": "Dialog name",
+          "description": "Name of the dialog to call."
+        },
+        "options": {
+          "$ref": "#/definitions/objectExpression",
+          "title": "Options",
+          "description": "One or more options that are passed to the dialog that is called.",
+          "additionalProperties": {
+            "type": "string",
+            "title": "Options",
+            "description": "Options for replacing dialog."
+          }
+        },
+        "activityProcessed": {
+          "$ref": "#/definitions/booleanExpression",
+          "title": "Activity processed",
+          "description": "When set to false, the dialog that is called can process the current activity.",
+          "default": true
+        },
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.ReplaceDialog"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
+        }
+      }
+    },
+    "Microsoft.ResourceMultiLanguageGenerator": {
+      "$role": "implements(Microsoft.ILanguageGenerator)",
+      "title": "Resource multi-language generator",
+      "description": "MultiLanguage Generator which is bound to resource by resource Id.",
+      "type": "object",
+      "$package": {
+        "name": "Microsoft.Bot.Builder.Dialogs.Adaptive",
+        "version": "4.11.0"
+      },
+      "required": [
+        "$kind"
+      ],
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\$": {
+          "title": "Tooling property",
+          "description": "Open ended property for tooling."
+        }
+      },
+      "properties": {
+        "id": {
+          "type": "string",
+          "title": "Id",
+          "description": "Optional generator ID."
+        },
+        "resourceId": {
+          "type": "string",
+          "title": "Resource Id",
+          "description": "Resource which is the root language generator.  Other generaters with the same name and language suffix will be loaded into this generator and used based on the Language Policy.",
+          "default": "dialog.result"
+        },
+        "languagePolicy": {
+          "type": "object",
+          "title": "Language policy",
+          "description": "Set alternate language policy for this generator.  If not set, the global language policy will be used."
+        },
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.ResourceMultiLanguageGenerator"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
+        }
+      }
+    },
+    "Microsoft.SendActivity": {
+      "$role": "implements(Microsoft.IDialog)",
+      "title": "Send an activity",
+      "description": "Respond with an activity.",
+      "type": "object",
+      "$package": {
+        "name": "Microsoft.Bot.Builder.Dialogs.Adaptive",
+        "version": "4.11.0"
+      },
+      "required": [
+        "$kind"
+      ],
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\$": {
+          "title": "Tooling property",
+          "description": "Open ended property for tooling."
+        }
+      },
+      "properties": {
+        "id": {
+          "type": "string",
+          "title": "Id",
+          "description": "Optional id for the dialog"
+        },
+        "disabled": {
+          "$ref": "#/definitions/booleanExpression",
+          "title": "Disabled",
+          "description": "Optional condition which if true will disable this action."
+        },
+        "activity": {
+          "$kind": "Microsoft.IActivityTemplate",
+          "title": "Activity",
+          "description": "Activity to send.",
+          "$ref": "#/definitions/Microsoft.IActivityTemplate"
+        },
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.SendActivity"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
+        }
+      }
+    },
+    "Microsoft.SetProperties": {
+      "$role": "implements(Microsoft.IDialog)",
+      "title": "Set property",
+      "description": "Set one or more property values.",
+      "type": "object",
+      "required": [
+        "assignments",
+        "$kind"
+      ],
+      "$package": {
+        "name": "Microsoft.Bot.Builder.Dialogs.Adaptive",
+        "version": "4.11.0"
+      },
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\$": {
+          "title": "Tooling property",
+          "description": "Open ended property for tooling."
+        }
+      },
+      "properties": {
+        "id": {
+          "type": "string",
+          "title": "Id",
+          "description": "Optional id for the dialog"
+        },
+        "disabled": {
+          "$ref": "#/definitions/booleanExpression",
+          "title": "Disabled",
+          "description": "Optional condition which if true will disable this action.",
+          "examples": [
+            true,
+            "=user.age > 3"
+          ]
+        },
+        "assignments": {
+          "type": "array",
+          "title": "Assignments",
+          "description": "Property value assignments to set.",
+          "items": {
+            "type": "object",
+            "title": "Assignment",
+            "description": "Property assignment.",
+            "properties": {
+              "property": {
+                "$ref": "#/definitions/stringExpression",
+                "title": "Property",
+                "description": "Property (named location to store information).",
+                "examples": [
+                  "user.age"
+                ]
+              },
+              "value": {
+                "$ref": "#/definitions/valueExpression",
+                "title": "Value",
+                "description": "New value or expression.",
+                "examples": [
+                  "='milk'",
+                  "=dialog.favColor",
+                  "=dialog.favColor == 'red'"
+                ]
+              }
+            }
+          }
+        },
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.SetProperties"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
+        }
+      }
+    },
+    "Microsoft.SetProperty": {
+      "$role": "implements(Microsoft.IDialog)",
+      "title": "Set property",
+      "description": "Set property to a value.",
+      "type": "object",
+      "required": [
+        "property",
+        "value",
+        "$kind"
+      ],
+      "$package": {
+        "name": "Microsoft.Bot.Builder.Dialogs.Adaptive",
+        "version": "4.11.0"
+      },
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\$": {
+          "title": "Tooling property",
+          "description": "Open ended property for tooling."
+        }
+      },
+      "properties": {
+        "id": {
+          "type": "string",
+          "title": "Id",
+          "description": "Optional id for the dialog"
+        },
+        "disabled": {
+          "$ref": "#/definitions/booleanExpression",
+          "title": "Disabled",
+          "description": "Optional condition which if true will disable this action.",
+          "examples": [
+            true,
+            "=user.age > 3"
+          ]
+        },
+        "property": {
+          "$ref": "#/definitions/stringExpression",
+          "title": "Property",
+          "description": "Property (named location to store information).",
+          "examples": [
+            "user.age"
+          ]
+        },
+        "value": {
+          "$ref": "#/definitions/valueExpression",
+          "title": "Value",
+          "description": "New value or expression.",
+          "examples": [
+            "='milk'",
+            "=dialog.favColor",
+            "=dialog.favColor == 'red'"
+          ]
+        },
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.SetProperty"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
+        }
+      }
+    },
+    "Microsoft.SignOutUser": {
+      "$role": "implements(Microsoft.IDialog)",
+      "title": "Sign out user",
+      "description": "Sign a user out that was logged in previously using OAuthInput.",
+      "type": "object",
+      "$package": {
+        "name": "Microsoft.Bot.Builder.Dialogs.Adaptive",
+        "version": "4.11.0"
+      },
+      "required": [
+        "$kind"
+      ],
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\$": {
+          "title": "Tooling property",
+          "description": "Open ended property for tooling."
+        }
+      },
+      "properties": {
+        "id": {
+          "type": "string",
+          "title": "Id",
+          "description": "Optional id for the dialog"
+        },
+        "userId": {
+          "$ref": "#/definitions/stringExpression",
+          "title": "UserId",
+          "description": "Expression to an user to signout. Default is user.id.",
+          "default": "=user.id"
+        },
+        "connectionName": {
+          "$ref": "#/definitions/stringExpression",
+          "title": "Connection name",
+          "description": "Connection name that was used with OAuthInput to log a user in."
+        },
+        "disabled": {
+          "$ref": "#/definitions/booleanExpression",
+          "title": "Disabled",
+          "description": "Optional condition which if true will disable this action.",
+          "examples": [
+            true,
+            "=user.age > 3"
+          ]
+        },
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.SignOutUser"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
+        }
+      }
+    },
+    "Microsoft.StaticActivityTemplate": {
+      "$role": "implements(Microsoft.IActivityTemplate)",
+      "title": "Microsoft static activity template",
+      "description": "This allows you to define a static Activity object",
+      "type": "object",
+      "required": [
+        "activity",
+        "$kind"
+      ],
+      "$package": {
+        "name": "Microsoft.Bot.Builder.Dialogs.Adaptive",
+        "version": "4.11.0"
+      },
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\$": {
+          "title": "Tooling property",
+          "description": "Open ended property for tooling."
+        }
+      },
+      "properties": {
+        "activity": {
+          "$ref": "#/definitions/Microsoft.IActivityTemplate/oneOf/1",
+          "title": "Activity",
+          "description": "A static Activity to used.",
+          "required": [
+            "type"
+          ]
+        },
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.StaticActivityTemplate"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
+        }
+      }
+    },
+    "Microsoft.SwitchCondition": {
+      "$role": "implements(Microsoft.IDialog)",
+      "title": "Switch condition",
+      "description": "Execute different actions based on the value of a property.",
+      "type": "object",
+      "required": [
+        "condition",
+        "$kind"
+      ],
+      "$package": {
+        "name": "Microsoft.Bot.Builder.Dialogs.Adaptive",
+        "version": "4.11.0"
+      },
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\$": {
+          "title": "Tooling property",
+          "description": "Open ended property for tooling."
+        }
+      },
+      "properties": {
+        "id": {
+          "type": "string",
+          "title": "Id",
+          "description": "Optional id for the dialog"
+        },
+        "condition": {
+          "$ref": "#/definitions/stringExpression",
+          "title": "Condition",
+          "description": "Property to evaluate.",
+          "examples": [
+            "user.favColor"
+          ]
+        },
+        "disabled": {
+          "$ref": "#/definitions/booleanExpression",
+          "title": "Disabled",
+          "description": "Optional condition which if true will disable this action.",
+          "examples": [
+            true,
+            "=user.age > 3"
+          ]
+        },
+        "cases": {
+          "type": "array",
+          "title": "Cases",
+          "description": "Actions for each possible condition.",
+          "items": {
+            "type": "object",
+            "title": "Case",
+            "description": "Case and actions.",
+            "required": [
+              "value",
+              "actions"
+            ],
+            "properties": {
+              "value": {
+                "type": [
+                  "number",
+                  "integer",
+                  "boolean",
+                  "string"
+                ],
+                "title": "Value",
+                "description": "The value to compare the condition with.",
+                "examples": [
+                  "red",
+                  "true",
+                  "13"
+                ]
+              },
+              "actions": {
+                "type": "array",
+                "title": "Actions",
+                "description": "Actions to execute.",
+                "items": {
+                  "$kind": "Microsoft.IDialog",
+                  "$ref": "#/definitions/Microsoft.IDialog"
+                }
+              }
+            }
+          }
+        },
+        "default": {
+          "type": "array",
+          "title": "Default",
+          "description": "Actions to execute if none of the cases meet the condition.",
+          "items": {
+            "$kind": "Microsoft.IDialog",
+            "$ref": "#/definitions/Microsoft.IDialog"
+          }
+        },
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.SwitchCondition"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
+        }
+      }
+    },
+    "Microsoft.TelemetryTrackEvent": {
+      "$role": "implements(Microsoft.IDialog)",
+      "type": "object",
+      "title": "Telemetry - track event",
+      "description": "Track a custom event using the registered Telemetry Client.",
+      "required": [
+        "url",
+        "method",
+        "$kind"
+      ],
+      "$package": {
+        "name": "Microsoft.Bot.Builder.Dialogs.Adaptive",
+        "version": "4.11.0"
+      },
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\$": {
+          "title": "Tooling property",
+          "description": "Open ended property for tooling."
+        }
+      },
+      "properties": {
+        "id": {
+          "type": "string",
+          "title": "Id",
+          "description": "Optional id for the dialog"
+        },
+        "disabled": {
+          "$ref": "#/definitions/booleanExpression",
+          "title": "Disabled",
+          "description": "Optional condition which if true will disable this action.",
+          "examples": [
+            "user.age > 3"
+          ]
+        },
+        "eventName": {
+          "$ref": "#/definitions/stringExpression",
+          "title": "Event name",
+          "description": "The name of the event to track.",
+          "examples": [
+            "MyEventStarted",
+            "MyEventCompleted"
+          ]
+        },
+        "properties": {
+          "type": "object",
+          "title": "Properties",
+          "description": "One or more properties to attach to the event being tracked.",
+          "additionalProperties": {
+            "$ref": "#/definitions/stringExpression"
+          }
+        },
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.TelemetryTrackEvent"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
+        }
+      }
+    },
+    "Microsoft.TemperatureEntityRecognizer": {
+      "$role": [
+        "implements(Microsoft.IRecognizer)",
+        "implements(Microsoft.IEntityRecognizer)"
+      ],
+      "title": "Temperature recognizer",
+      "description": "Recognizer which recognizes temperatures.",
+      "type": "object",
+      "$package": {
+        "name": "Microsoft.Bot.Builder.Dialogs.Adaptive",
+        "version": "4.11.0"
+      },
+      "required": [
+        "$kind"
+      ],
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\$": {
+          "title": "Tooling property",
+          "description": "Open ended property for tooling."
+        }
+      },
+      "properties": {
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.TemperatureEntityRecognizer"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
+        }
+      }
+    },
+    "Microsoft.TemplateEngineLanguageGenerator": {
+      "$role": "implements(Microsoft.ILanguageGenerator)",
+      "title": "Template multi-language generator",
+      "description": "Template Generator which allows only inline evaluation of templates.",
+      "type": "object",
+      "$package": {
+        "name": "Microsoft.Bot.Builder.Dialogs.Adaptive",
+        "version": "4.11.0"
+      },
+      "required": [
+        "$kind"
+      ],
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\$": {
+          "title": "Tooling property",
+          "description": "Open ended property for tooling."
+        }
+      },
+      "properties": {
+        "id": {
+          "type": "string",
+          "title": "Id",
+          "description": "Optional generator ID."
+        },
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.TemplateEngineLanguageGenerator"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
+        }
+      }
+    },
+    "Microsoft.TextInput": {
+      "$role": [
+        "implements(Microsoft.IDialog)",
+        "extends(Microsoft.InputDialog)"
+      ],
+      "type": "object",
+      "title": "Text input dialog",
+      "description": "Collection information - Ask for a word or sentence.",
+      "$package": {
+        "name": "Microsoft.Bot.Builder.Dialogs.Adaptive",
+        "version": "4.11.0"
+      },
+      "required": [
+        "$kind"
+      ],
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\$": {
+          "title": "Tooling property",
+          "description": "Open ended property for tooling."
+        }
+      },
+      "properties": {
+        "defaultValue": {
+          "$ref": "#/definitions/stringExpression",
+          "title": "Default value",
+          "description": "'Property' will be set to the value of this expression when max turn count is exceeded.",
+          "examples": [
+            "hello world",
+            "Hello ${user.name}",
+            "=concat(user.firstname, user.lastName)"
+          ]
+        },
+        "value": {
+          "$ref": "#/definitions/stringExpression",
+          "title": "Value",
+          "description": "'Property' will be set to the value of this expression unless it evaluates to null.",
+          "examples": [
+            "hello world",
+            "Hello ${user.name}",
+            "=concat(user.firstname, user.lastName)"
+          ]
+        },
+        "outputFormat": {
+          "$ref": "#/definitions/stringExpression",
+          "title": "Output format",
+          "description": "Expression to format the output.",
+          "examples": [
+            "=toUpper(this.value)",
+            "${toUpper(this.value)}"
+          ]
+        },
+        "id": {
+          "type": "string",
+          "title": "Id",
+          "description": "Optional id for the dialog"
+        },
+        "disabled": {
+          "$ref": "#/definitions/booleanExpression",
+          "title": "Disabled",
+          "description": "Optional condition which if true will disable this action.",
+          "default": false,
+          "examples": [
+            false,
+            "=user.isVip"
+          ]
+        },
+        "prompt": {
+          "$kind": "Microsoft.IActivityTemplate",
+          "title": "Initial prompt",
+          "description": "Message to send to collect information.",
+          "examples": [
+            "What is your birth date?"
+          ],
+          "$ref": "#/definitions/Microsoft.IActivityTemplate"
+        },
+        "unrecognizedPrompt": {
+          "$kind": "Microsoft.IActivityTemplate",
+          "title": "Unrecognized prompt",
+          "description": "Message to send when max turn count (if specified) has been exceeded and the default value is selected as the value.",
+          "examples": [
+            "Sorry, I'm having trouble understanding you. I will just use {this.options.defaultValue} for now. You can say 'I'm 36 years old' to change it."
+          ],
+          "$ref": "#/definitions/Microsoft.IActivityTemplate"
+        },
+        "invalidPrompt": {
+          "$kind": "Microsoft.IActivityTemplate",
+          "title": "Invalid prompt",
+          "description": "Message to send when the user input does not meet any validation expression.",
+          "examples": [
+            "Sorry, '{this.value}' does not work. I need a number between 1-150. What is your age?"
+          ],
+          "$ref": "#/definitions/Microsoft.IActivityTemplate"
+        },
+        "defaultValueResponse": {
+          "$kind": "Microsoft.IActivityTemplate",
+          "title": "Default value response",
+          "description": "Message to send when max turn count (if specified) has been exceeded and the default value is selected as the value.",
+          "examples": [
+            "Sorry, I'm having trouble understanding you. I will just use {this.options.defaultValue} for now. You can say 'I'm 36 years old' to change it."
+          ],
+          "$ref": "#/definitions/Microsoft.IActivityTemplate"
+        },
+        "maxTurnCount": {
+          "$ref": "#/definitions/integerExpression",
+          "title": "Max turn count",
+          "description": "Maximum number of re-prompt attempts to collect information.",
+          "default": 3,
+          "examples": [
+            3,
+            "=settings.xyz"
+          ]
+        },
+        "validations": {
+          "type": "array",
+          "title": "Validation expressions",
+          "description": "Expression to validate user input.",
+          "items": {
+            "$ref": "#/definitions/condition",
+            "title": "Condition",
+            "description": "Expression which needs to met for the input to be considered valid",
+            "examples": [
+              "int(this.value) > 1 && int(this.value) <= 150",
+              "count(this.value) < 300"
+            ]
+          }
+        },
+        "property": {
+          "$ref": "#/definitions/stringExpression",
+          "title": "Property",
+          "description": "Property to store collected information. Input will be skipped if property has value (unless 'Always prompt' is true).",
+          "examples": [
+            "$birthday",
+            "dialog.${user.name}",
+            "=f(x)"
+          ]
+        },
+        "alwaysPrompt": {
+          "$ref": "#/definitions/booleanExpression",
+          "title": "Always prompt",
+          "description": "Collect information even if the specified 'property' is not empty.",
+          "default": false,
+          "examples": [
+            false,
+            "=$val"
+          ]
+        },
+        "allowInterruptions": {
+          "$ref": "#/definitions/booleanExpression",
+          "title": "Allow Interruptions",
+          "description": "A boolean expression that determines whether the parent should be allowed to interrupt the input.",
+          "default": true,
+          "examples": [
+            true,
+            "=user.xyz"
+          ]
+        },
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.TextInput"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
+        }
+      }
+    },
+    "Microsoft.TextTemplate": {
+      "$role": "implements(Microsoft.ITextTemplate)",
+      "title": "Microsoft TextTemplate",
+      "description": "Use LG Templates to create text",
+      "type": "object",
+      "required": [
+        "template",
+        "$kind"
+      ],
+      "$package": {
+        "name": "Microsoft.Bot.Builder.Dialogs.Adaptive",
+        "version": "4.11.0"
+      },
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\$": {
+          "title": "Tooling property",
+          "description": "Open ended property for tooling."
+        }
+      },
+      "properties": {
+        "template": {
+          "title": "Template",
+          "description": "Language Generator template to evaluate to create the text.",
+          "type": "string"
+        },
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.TextTemplate"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
+        }
+      }
+    },
+    "Microsoft.ThrowException": {
+      "$role": "implements(Microsoft.IDialog)",
+      "title": "Throw an exception",
+      "description": "Throw an exception. Capture this exception with OnError trigger.",
+      "type": "object",
+      "required": [
+        "errorValue",
+        "$kind"
+      ],
+      "$package": {
+        "name": "Microsoft.Bot.Builder.Dialogs.Adaptive",
+        "version": "4.11.0"
+      },
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\$": {
+          "title": "Tooling property",
+          "description": "Open ended property for tooling."
+        }
+      },
+      "properties": {
+        "id": {
+          "type": "string",
+          "title": "Id",
+          "description": "Optional id for the dialog"
+        },
+        "disabled": {
+          "$ref": "#/definitions/booleanExpression",
+          "title": "Disabled",
+          "description": "Optional condition which if true will disable this action.",
+          "examples": [
+            "user.age > 3"
+          ]
+        },
+        "errorValue": {
+          "$ref": "#/definitions/valueExpression",
+          "title": "Error value",
+          "description": "Error value to throw."
+        },
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.ThrowException"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
+        }
+      }
+    },
+    "Microsoft.TraceActivity": {
+      "$role": "implements(Microsoft.IDialog)",
+      "title": "Send a TraceActivity",
+      "description": "Send a trace activity to the transcript logger and/ or Bot Framework Emulator.",
+      "type": "object",
+      "$package": {
+        "name": "Microsoft.Bot.Builder.Dialogs.Adaptive",
+        "version": "4.11.0"
+      },
+      "required": [
+        "$kind"
+      ],
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\$": {
+          "title": "Tooling property",
+          "description": "Open ended property for tooling."
+        }
+      },
+      "properties": {
+        "id": {
+          "type": "string",
+          "title": "Id",
+          "description": "Optional id for the dialog"
+        },
+        "disabled": {
+          "$ref": "#/definitions/booleanExpression",
+          "title": "Disabled",
+          "description": "Optional condition which if true will disable this action.",
+          "examples": [
+            true,
+            "=user.age > 3"
+          ]
+        },
+        "name": {
+          "$ref": "#/definitions/stringExpression",
+          "title": "Name",
+          "description": "Name of the trace activity"
+        },
+        "label": {
+          "$ref": "#/definitions/stringExpression",
+          "title": "Label",
+          "description": "Label for the trace activity (used to identify it in a list of trace activities.)"
+        },
+        "valueType": {
+          "$ref": "#/definitions/stringExpression",
+          "title": "Value type",
+          "description": "Type of value"
+        },
+        "value": {
+          "$ref": "#/definitions/valueExpression",
+          "title": "Value",
+          "description": "Property that holds the value to send as trace activity."
+        },
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.TraceActivity"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
+        }
+      }
+    },
+    "Microsoft.TrueSelector": {
+      "$role": "implements(Microsoft.ITriggerSelector)",
+      "title": "True trigger selector",
+      "description": "Selector for all true events",
+      "type": "object",
+      "$package": {
+        "name": "Microsoft.Bot.Builder.Dialogs.Adaptive",
+        "version": "4.11.0"
+      },
+      "required": [
+        "$kind"
+      ],
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\$": {
+          "title": "Tooling property",
+          "description": "Open ended property for tooling."
+        }
+      },
+      "properties": {
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.TrueSelector"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
+        }
+      }
+    },
+    "Microsoft.UpdateActivity": {
+      "$role": "implements(Microsoft.IDialog)",
+      "title": "Update an activity",
+      "description": "Respond with an activity.",
+      "type": "object",
+      "$package": {
+        "name": "Microsoft.Bot.Builder.Dialogs.Adaptive",
+        "version": "4.11.0"
+      },
+      "required": [
+        "$kind"
+      ],
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\$": {
+          "title": "Tooling property",
+          "description": "Open ended property for tooling."
+        }
+      },
+      "properties": {
+        "id": {
+          "type": "string",
+          "title": "Id",
+          "description": "Optional id for the dialog"
+        },
+        "disabled": {
+          "$ref": "#/definitions/booleanExpression",
+          "title": "Disabled",
+          "description": "Optional condition which if true will disable this action.",
+          "examples": [
+            true,
+            "=user.age > 3"
+          ]
+        },
+        "activityId": {
+          "$ref": "#/definitions/stringExpression",
+          "title": "Activity Id",
+          "description": "An string expression with the activity id to update.",
+          "examples": [
+            "=dialog.lastActivityId"
+          ]
+        },
+        "activity": {
+          "$kind": "Microsoft.IActivityTemplate",
+          "title": "Activity",
+          "description": "Activity to send.",
+          "$ref": "#/definitions/Microsoft.IActivityTemplate"
+        },
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.UpdateActivity"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
+        }
+      }
+    },
+    "Microsoft.UrlEntityRecognizer": {
+      "$role": [
+        "implements(Microsoft.IRecognizer)",
+        "implements(Microsoft.IEntityRecognizer)"
+      ],
+      "title": "Url recognizer",
+      "description": "Recognizer which recognizes urls.",
+      "type": "object",
+      "$package": {
+        "name": "Microsoft.Bot.Builder.Dialogs.Adaptive",
+        "version": "4.11.0"
+      },
+      "required": [
+        "$kind"
+      ],
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\$": {
+          "title": "Tooling property",
+          "description": "Open ended property for tooling."
+        }
+      },
+      "properties": {
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$",
+          "const": "Microsoft.UrlEntityRecognizer"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
+        }
+      }
+    },
+    "arrayExpression": {
+      "$role": "expression",
+      "title": "Array or expression",
+      "description": "Array or expression to evaluate.",
+      "oneOf": [
+        {
+          "type": "array",
+          "title": "Array",
+          "description": "Array constant."
+        },
+        {
+          "$ref": "#/definitions/equalsExpression"
+        }
+      ]
+    },
+    "booleanExpression": {
+      "$role": "expression",
+      "title": "Boolean or expression",
+      "description": "Boolean constant or expression to evaluate.",
+      "oneOf": [
+        {
+          "type": "boolean",
+          "title": "Boolean",
+          "description": "Boolean constant.",
+          "default": false,
+          "examples": [
+            false
+          ]
+        },
+        {
+          "$ref": "#/definitions/equalsExpression",
+          "examples": [
+            "=user.isVip"
+          ]
+        }
+      ]
+    },
+    "component": {
+      "required": [
+        "$kind"
+      ],
+      "additionalProperties": false,
+      "patternProperties": {
+        "^\\$": {
+          "title": "Tooling property",
+          "description": "Open ended property for tooling."
+        }
+      },
+      "properties": {
+        "$kind": {
+          "title": "Kind of dialog object",
+          "description": "Defines the valid properties for the component you are configuring (from a dialog .schema file)",
+          "type": "string",
+          "pattern": "^[a-zA-Z][a-zA-Z0-9.]*$"
+        },
+        "$designer": {
+          "title": "Designer information",
+          "type": "object",
+          "description": "Extra information for the Bot Framework Composer."
+        }
+      }
+    },
+    "condition": {
+      "$role": "expression",
+      "title": "Boolean condition",
+      "description": "Boolean constant or expression to evaluate.",
+      "oneOf": [
+        {
+          "$ref": "#/definitions/expression"
+        },
+        {
+          "type": "boolean",
+          "title": "Boolean",
+          "description": "Boolean value.",
+          "default": true,
+          "examples": [
+            false
+          ]
+        }
+      ]
+    },
+    "equalsExpression": {
+      "$role": "expression",
+      "type": "string",
+      "title": "Expression",
+      "description": "Expression starting with =.",
+      "pattern": "^=.*\\S.*",
+      "examples": [
+        "=user.name"
+      ]
+    },
+    "expression": {
+      "$role": "expression",
+      "type": "string",
+      "title": "Expression",
+      "description": "Expression to evaluate.",
+      "pattern": "^.*\\S.*",
+      "examples": [
+        "user.age > 13"
+      ]
+    },
+    "integerExpression": {
+      "$role": "expression",
+      "title": "Integer or expression",
+      "description": "Integer constant or expression to evaluate.",
+      "oneOf": [
+        {
+          "type": "integer",
+          "title": "Integer",
+          "description": "Integer constant.",
+          "default": 0,
+          "examples": [
+            15
+          ]
+        },
+        {
+          "$ref": "#/definitions/equalsExpression",
+          "examples": [
+            "=user.age"
+          ]
+        }
+      ]
+    },
+    "numberExpression": {
+      "$role": "expression",
+      "title": "Number or expression",
+      "description": "Number constant or expression to evaluate.",
+      "oneOf": [
+        {
+          "type": "number",
+          "title": "Number",
+          "description": "Number constant.",
+          "default": 0,
+          "examples": [
+            15.5
+          ]
+        },
+        {
+          "$ref": "#/definitions/equalsExpression",
+          "examples": [
+            "=dialog.quantity"
+          ]
+        }
+      ]
+    },
+    "objectExpression": {
+      "$role": "expression",
+      "title": "Object or expression",
+      "description": "Object or expression to evaluate.",
+      "oneOf": [
+        {
+          "type": "object",
+          "title": "Object",
+          "description": "Object constant."
+        },
+        {
+          "$ref": "#/definitions/equalsExpression"
+        }
+      ]
+    },
+    "role": {
+      "title": "$role",
+      "description": "Defines the role played in the dialog schema from [expression|interface|implements($kind)|extends($kind)].",
+      "type": "string",
+      "pattern": "^((expression)|(interface)|(implements\\([a-zA-Z][a-zA-Z0-9.]*\\))|(extends\\([a-zA-Z][a-zA-Z0-9.]*\\)))$"
+    },
+    "stringExpression": {
+      "$role": "expression",
+      "title": "String or expression",
+      "description": "Interpolated string or expression to evaluate.",
+      "oneOf": [
+        {
+          "type": "string",
+          "title": "String",
+          "description": "Interpolated string",
+          "pattern": "^(?!(=)).*",
+          "examples": [
+            "Hello ${user.name}"
+          ]
+        },
+        {
+          "$ref": "#/definitions/equalsExpression",
+          "examples": [
+            "=concat('x','y','z')"
+          ]
+        }
+      ]
+    },
+    "valueExpression": {
+      "$role": "expression",
+      "title": "Any or expression",
+      "description": "Any constant or expression to evaluate.",
+      "oneOf": [
+        {
+          "type": "object",
+          "title": "Object",
+          "description": "Object constant."
+        },
+        {
+          "type": "array",
+          "title": "Array",
+          "description": "Array constant."
+        },
+        {
+          "type": "string",
+          "title": "String",
+          "description": "Interpolated string.",
+          "pattern": "^(?!(=)).*",
+          "examples": [
+            "Hello ${user.name}"
+          ]
+        },
+        {
+          "type": "boolean",
+          "title": "Boolean",
+          "description": "Boolean constant",
+          "examples": [
+            false
+          ]
+        },
+        {
+          "type": "number",
+          "title": "Number",
+          "description": "Number constant.",
+          "examples": [
+            15.5
+          ]
+        },
+        {
+          "$ref": "#/definitions/equalsExpression",
+          "examples": [
+            "=..."
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/generators/generator-microsoft-bot-adaptive/generators/app/templates/assets/schemas/sdk.uischema
+++ b/generators/generator-microsoft-bot-adaptive/generators/app/templates/assets/schemas/sdk.uischema
@@ -1,0 +1,781 @@
+{
+  "$schema": "https://schemas.botframework.com/schemas/ui/v1.0/ui.schema",
+  "Microsoft.AdaptiveDialog": {
+    "form": {
+      "description": "This configures a data driven dialog via a collection of events and actions.",
+      "helpLink": "https://aka.ms/bf-composer-docs-dialog",
+      "hidden": [
+        "triggers",
+        "generator",
+        "selector",
+        "schema"
+      ],
+      "label": "Adaptive dialog",
+      "order": [
+        "recognizer",
+        "*"
+      ],
+      "properties": {
+        "recognizer": {
+          "description": "To understand what the user says, your dialog needs a \"Recognizer\"; that includes example words and sentences that users may use.",
+          "label": "Language Understanding"
+        }
+      }
+    }
+  },
+  "Microsoft.BeginDialog": {
+    "form": {
+      "helpLink": "https://aka.ms/bfc-understanding-dialogs",
+      "label": "Begin a new dialog",
+      "order": [
+        "dialog",
+        "options",
+        "resultProperty",
+        "*"
+      ],
+      "properties": {
+        "resultProperty": {
+          "intellisenseScopes": [
+            "variable-scopes"
+          ]
+        }
+      },
+      "subtitle": "Begin Dialog"
+    }
+  },
+  "Microsoft.BeginSkill": {
+    "form": {
+      "helpLink": "https://aka.ms/bf-composer-docs-connect-skill",
+      "label": "Connect to a skill",
+      "properties": {
+        "resultProperty": {
+          "intellisenseScopes": [
+            "variable-scopes"
+          ]
+        }
+      },
+      "subtitle": "Skill Dialog"
+    }
+  },
+  "Microsoft.BreakLoop": {
+    "form": {
+      "label": "Break out of loop",
+      "subtitle": "Break out of loop"
+    }
+  },
+  "Microsoft.CancelAllDialogs": {
+    "form": {
+      "helpLink": "https://aka.ms/bfc-understanding-dialogs",
+      "label": "Cancel all active dialogs",
+      "subtitle": "Cancel All Dialogs"
+    }
+  },
+  "Microsoft.ContinueLoop": {
+    "form": {
+      "label": "Continue loop",
+      "subtitle": "Continue loop"
+    }
+  },
+  "Microsoft.DebugBreak": {
+    "form": {
+      "label": "Debug Break"
+    }
+  },
+  "Microsoft.DeleteProperties": {
+    "form": {
+      "helpLink": "https://aka.ms/bfc-using-memory",
+      "label": "Delete properties",
+      "properties": {
+        "properties": {
+          "intellisenseScopes": [
+            "user-variables"
+          ]
+        }
+      },
+      "subtitle": "Delete Properties"
+    }
+  },
+  "Microsoft.DeleteProperty": {
+    "form": {
+      "helpLink": "https://aka.ms/bfc-using-memory",
+      "label": "Delete a property",
+      "properties": {
+        "property": {
+          "intellisenseScopes": [
+            "user-variables"
+          ]
+        }
+      },
+      "subtitle": "Delete Property"
+    }
+  },
+  "Microsoft.EditActions": {
+    "form": {
+      "label": "Modify active dialog",
+      "subtitle": "Edit Actions"
+    }
+  },
+  "Microsoft.EditArray": {
+    "form": {
+      "helpLink": "https://aka.ms/bfc-using-memory",
+      "label": "Edit an array property",
+      "properties": {
+        "itemsProperty": {
+          "intellisenseScopes": [
+            "user-variables"
+          ]
+        },
+        "resultProperty": {
+          "intellisenseScopes": [
+            "variable-scopes"
+          ]
+        }
+      },
+      "subtitle": "Edit Array"
+    }
+  },
+  "Microsoft.EmitEvent": {
+    "form": {
+      "helpLink": "https://aka.ms/bfc-custom-events",
+      "label": "Emit a custom event",
+      "subtitle": "Emit Event"
+    }
+  },
+  "Microsoft.EndDialog": {
+    "form": {
+      "helpLink": "https://aka.ms/bfc-understanding-dialogs",
+      "label": "End this dialog",
+      "subtitle": "End Dialog"
+    }
+  },
+  "Microsoft.EndTurn": {
+    "form": {
+      "helpLink": "https://aka.ms/bfc-understanding-dialogs",
+      "label": "End turn",
+      "subtitle": "End Turn"
+    }
+  },
+  "Microsoft.Foreach": {
+    "form": {
+      "helpLink": "https://aka.ms/bfc-controlling-conversation-flow",
+      "hidden": [
+        "actions"
+      ],
+      "label": "Loop: For each item",
+      "order": [
+        "itemsProperty",
+        "*"
+      ],
+      "properties": {
+        "index": {
+          "intellisenseScopes": [
+            "variable-scopes"
+          ]
+        },
+        "itemsProperty": {
+          "intellisenseScopes": [
+            "user-variables"
+          ]
+        },
+        "value": {
+          "intellisenseScopes": [
+            "variable-scopes"
+          ]
+        }
+      },
+      "subtitle": "For Each"
+    }
+  },
+  "Microsoft.ForeachPage": {
+    "form": {
+      "helpLink": "https://aka.ms/bfc-controlling-conversation-flow",
+      "hidden": [
+        "actions"
+      ],
+      "label": "Loop: For each page (multiple items)",
+      "order": [
+        "itemsProperty",
+        "pageSize",
+        "*"
+      ],
+      "properties": {
+        "itemsProperty": {
+          "intellisenseScopes": [
+            "user-variables"
+          ]
+        },
+        "page": {
+          "intellisenseScopes": [
+            "variable-scopes"
+          ]
+        },
+        "pageIndex": {
+          "intellisenseScopes": [
+            "variable-scopes"
+          ]
+        }
+      },
+      "subtitle": "For Each Page"
+    }
+  },
+  "Microsoft.HttpRequest": {
+    "form": {
+      "helpLink": "https://aka.ms/bfc-using-http",
+      "label": "Send an HTTP request",
+      "order": [
+        "method",
+        "url",
+        "body",
+        "headers",
+        "*"
+      ],
+      "properties": {
+        "resultProperty": {
+          "intellisenseScopes": [
+            "variable-scopes"
+          ]
+        }
+      },
+      "subtitle": "HTTP Request"
+    }
+  },
+  "Microsoft.IfCondition": {
+    "form": {
+      "helpLink": "https://aka.ms/bfc-controlling-conversation-flow",
+      "hidden": [
+        "actions",
+        "elseActions"
+      ],
+      "label": "Branch: If/Else",
+      "subtitle": "If Condition"
+    }
+  },
+  "Microsoft.LogAction": {
+    "form": {
+      "helpLink": "https://aka.ms/composer-telemetry",
+      "label": "Log to console",
+      "subtitle": "Log Action"
+    }
+  },
+  "Microsoft.RepeatDialog": {
+    "form": {
+      "helpLink": "https://aka.ms/bfc-understanding-dialogs",
+      "label": "Repeat this dialog",
+      "order": [
+        "options",
+        "*"
+      ],
+      "subtitle": "Repeat Dialog"
+    }
+  },
+  "Microsoft.ReplaceDialog": {
+    "form": {
+      "helpLink": "https://aka.ms/bfc-understanding-dialogs",
+      "label": "Replace this dialog",
+      "order": [
+        "dialog",
+        "options",
+        "*"
+      ],
+      "subtitle": "Replace Dialog"
+    }
+  },
+  "Microsoft.SendActivity": {
+    "form": {
+      "helpLink": "https://aka.ms/bfc-send-activity",
+      "label": "Send a response",
+      "order": [
+        "activity",
+        "*"
+      ],
+      "subtitle": "Send Activity"
+    }
+  },
+  "Microsoft.SetProperties": {
+    "form": {
+      "helpLink": "https://aka.ms/bfc-using-memory",
+      "label": "Set properties",
+      "properties": {
+        "assignments": {
+          "properties": {
+            "property": {
+              "intellisenseScopes": [
+                "variable-scopes"
+              ]
+            }
+          }
+        }
+      },
+      "subtitle": "Set Properties"
+    }
+  },
+  "Microsoft.SetProperty": {
+    "form": {
+      "helpLink": "https://aka.ms/bfc-using-memory",
+      "label": "Set a property",
+      "properties": {
+        "property": {
+          "intellisenseScopes": [
+            "variable-scopes"
+          ]
+        }
+      },
+      "subtitle": "Set Property"
+    }
+  },
+  "Microsoft.SignOutUser": {
+    "form": {
+      "label": "Sign out user",
+      "subtitle": "Signout User"
+    }
+  },
+  "Microsoft.SwitchCondition": {
+    "form": {
+      "helpLink": "https://aka.ms/bfc-controlling-conversation-flow",
+      "hidden": [
+        "default"
+      ],
+      "label": "Branch: Switch (multiple options)",
+      "properties": {
+        "cases": {
+          "hidden": [
+            "actions"
+          ]
+        },
+        "condition": {
+          "intellisenseScopes": [
+            "user-variables"
+          ]
+        }
+      },
+      "subtitle": "Switch Condition"
+    }
+  },
+  "Microsoft.ThrowException": {
+    "form": {
+      "label": "Throw an exception",
+      "subtitle": "Throw an exception"
+    }
+  },
+  "Microsoft.TraceActivity": {
+    "form": {
+      "helpLink": "https://aka.ms/composer-telemetry",
+      "label": "Emit a trace event",
+      "subtitle": "Trace Activity"
+    }
+  },
+  "Microsoft.Ask": {
+    "form": {
+      "helpLink": "https://aka.ms/bfc-send-activity",
+      "label": "Send a response to ask a question",
+      "order": [
+        "activity",
+        "*"
+      ],
+      "subtitle": "Ask Activity"
+    }
+  },
+  "Microsoft.AttachmentInput": {
+    "form": {
+      "helpLink": "https://aka.ms/bfc-ask-for-user-input",
+      "label": "Prompt for a file or an attachment",
+      "properties": {
+        "property": {
+          "intellisenseScopes": [
+            "variable-scopes"
+          ]
+        }
+      },
+      "subtitle": "Attachment Input"
+    }
+  },
+  "Microsoft.ChoiceInput": {
+    "form": {
+      "helpLink": "https://aka.ms/bfc-ask-for-user-input",
+      "label": "Prompt with multi-choice",
+      "properties": {
+        "property": {
+          "intellisenseScopes": [
+            "variable-scopes"
+          ]
+        }
+      },
+      "subtitle": "Choice Input"
+    }
+  },
+  "Microsoft.ConfirmInput": {
+    "form": {
+      "helpLink": "https://aka.ms/bfc-ask-for-user-input",
+      "label": "Prompt for confirmation",
+      "properties": {
+        "property": {
+          "intellisenseScopes": [
+            "variable-scopes"
+          ]
+        }
+      },
+      "subtitle": "Confirm Input"
+    }
+  },
+  "Microsoft.DateTimeInput": {
+    "form": {
+      "helpLink": "https://aka.ms/bfc-ask-for-user-input",
+      "label": "Prompt for a date or a time",
+      "properties": {
+        "property": {
+          "intellisenseScopes": [
+            "variable-scopes"
+          ]
+        }
+      },
+      "subtitle": "Date Time Input"
+    }
+  },
+  "Microsoft.NumberInput": {
+    "form": {
+      "helpLink": "https://aka.ms/bfc-ask-for-user-input",
+      "label": "Prompt for a number",
+      "properties": {
+        "property": {
+          "intellisenseScopes": [
+            "variable-scopes"
+          ]
+        }
+      },
+      "subtitle": "Number Input"
+    }
+  },
+  "Microsoft.OAuthInput": {
+    "form": {
+      "helpLink": "https://aka.ms/bfc-using-oauth",
+      "label": "OAuth login",
+      "order": [
+        "connectionName",
+        "*"
+      ],
+      "subtitle": "OAuth Input"
+    }
+  },
+  "Microsoft.TextInput": {
+    "form": {
+      "helpLink": "https://aka.ms/bfc-ask-for-user-input",
+      "label": "Prompt for text",
+      "properties": {
+        "property": {
+          "intellisenseScopes": [
+            "variable-scopes"
+          ]
+        }
+      },
+      "subtitle": "Text Input"
+    }
+  },
+  "Microsoft.RegexRecognizer": {
+    "form": {
+      "hidden": [
+        "entities"
+      ]
+    }
+  },
+  "Microsoft.OnActivity": {
+    "form": {
+      "hidden": [
+        "actions"
+      ],
+      "label": "Activities",
+      "order": [
+        "condition",
+        "*"
+      ],
+      "subtitle": "Activity received"
+    }
+  },
+  "Microsoft.OnAssignEntity": {
+    "form": {
+      "hidden": [
+        "actions"
+      ],
+      "label": "Handle a condition when an entity is assigned",
+      "order": [
+        "condition",
+        "*"
+      ],
+      "subtitle": "EntityAssigned activity"
+    }
+  },
+  "Microsoft.OnBeginDialog": {
+    "form": {
+      "hidden": [
+        "actions"
+      ],
+      "label": "Dialog started",
+      "order": [
+        "condition",
+        "*"
+      ],
+      "subtitle": "Begin dialog event"
+    }
+  },
+  "Microsoft.OnCancelDialog": {
+    "form": {
+      "hidden": [
+        "actions"
+      ],
+      "label": "Dialog cancelled",
+      "order": [
+        "condition",
+        "*"
+      ],
+      "subtitle": "Cancel dialog event"
+    }
+  },
+  "Microsoft.OnChooseIntent": {
+    "form": {
+      "hidden": [
+        "actions"
+      ],
+      "order": [
+        "condition",
+        "*"
+      ]
+    }
+  },
+  "Microsoft.OnCondition": {
+    "form": {
+      "hidden": [
+        "actions"
+      ],
+      "label": "Handle a condition",
+      "order": [
+        "condition",
+        "*"
+      ],
+      "subtitle": "Condition"
+    }
+  },
+  "Microsoft.OnConversationUpdateActivity": {
+    "form": {
+      "description": "Handle the events fired when a user begins a new conversation with the bot.",
+      "helpLink": "https://aka.ms/bf-composer-docs-conversation-update-activity",
+      "hidden": [
+        "actions"
+      ],
+      "label": "Greeting",
+      "order": [
+        "condition",
+        "*"
+      ],
+      "subtitle": "ConversationUpdate activity"
+    }
+  },
+  "Microsoft.OnDialogEvent": {
+    "form": {
+      "hidden": [
+        "actions"
+      ],
+      "label": "Dialog events",
+      "order": [
+        "condition",
+        "*"
+      ],
+      "subtitle": "Dialog event"
+    }
+  },
+  "Microsoft.OnEndOfActions": {
+    "form": {
+      "hidden": [
+        "actions"
+      ],
+      "label": "Handle a condition when actions have ended",
+      "order": [
+        "condition",
+        "*"
+      ],
+      "subtitle": "EndOfActions activity"
+    }
+  },
+  "Microsoft.OnEndOfConversationActivity": {
+    "form": {
+      "hidden": [
+        "actions"
+      ],
+      "label": "Conversation ended",
+      "order": [
+        "condition",
+        "*"
+      ],
+      "subtitle": "EndOfConversation activity"
+    }
+  },
+  "Microsoft.OnError": {
+    "form": {
+      "hidden": [
+        "actions"
+      ],
+      "label": "Error occurred",
+      "order": [
+        "condition",
+        "*"
+      ],
+      "subtitle": "Error event"
+    }
+  },
+  "Microsoft.OnEventActivity": {
+    "form": {
+      "hidden": [
+        "actions"
+      ],
+      "label": "Event received",
+      "order": [
+        "condition",
+        "*"
+      ],
+      "subtitle": "Event activity"
+    }
+  },
+  "Microsoft.OnHandoffActivity": {
+    "form": {
+      "hidden": [
+        "actions"
+      ],
+      "label": "Handover to human",
+      "order": [
+        "condition",
+        "*"
+      ],
+      "subtitle": "Handoff activity"
+    }
+  },
+  "Microsoft.OnInstallationUpdateActivity": {
+    "form": {
+      "hidden": [
+        "actions"
+      ],
+      "label": "Installation updated",
+      "order": [
+        "condition",
+        "*"
+      ],
+      "subtitle": "Installation updated activity"
+    }
+  },
+  "Microsoft.OnIntent": {
+    "form": {
+      "hidden": [
+        "actions"
+      ],
+      "label": "Intent recognized",
+      "order": [
+        "intent",
+        "condition",
+        "entities",
+        "*"
+      ],
+      "subtitle": "Intent recognized"
+    }
+  },
+  "Microsoft.OnInvokeActivity": {
+    "form": {
+      "hidden": [
+        "actions"
+      ],
+      "label": "Conversation invoked",
+      "order": [
+        "condition",
+        "*"
+      ],
+      "subtitle": "Invoke activity"
+    }
+  },
+  "Microsoft.OnMessageActivity": {
+    "form": {
+      "hidden": [
+        "actions"
+      ],
+      "label": "Message received",
+      "order": [
+        "condition",
+        "*"
+      ],
+      "subtitle": "Message received activity"
+    }
+  },
+  "Microsoft.OnMessageDeleteActivity": {
+    "form": {
+      "hidden": [
+        "actions"
+      ],
+      "label": "Message deleted",
+      "order": [
+        "condition",
+        "*"
+      ],
+      "subtitle": "Message deleted activity"
+    }
+  },
+  "Microsoft.OnMessageReactionActivity": {
+    "form": {
+      "hidden": [
+        "actions"
+      ],
+      "label": "Message reaction",
+      "order": [
+        "condition",
+        "*"
+      ],
+      "subtitle": "Message reaction activity"
+    }
+  },
+  "Microsoft.OnMessageUpdateActivity": {
+    "form": {
+      "hidden": [
+        "actions"
+      ],
+      "label": "Message updated",
+      "order": [
+        "condition",
+        "*"
+      ],
+      "subtitle": "Message updated activity"
+    }
+  },
+  "Microsoft.OnRepromptDialog": {
+    "form": {
+      "hidden": [
+        "actions"
+      ],
+      "label": "Re-prompt for input",
+      "order": [
+        "condition",
+        "*"
+      ],
+      "subtitle": "Reprompt dialog event"
+    }
+  },
+  "Microsoft.OnTypingActivity": {
+    "form": {
+      "hidden": [
+        "actions"
+      ],
+      "label": "User is typing",
+      "order": [
+        "condition",
+        "*"
+      ],
+      "subtitle": "Typing activity"
+    }
+  },
+  "Microsoft.OnUnknownIntent": {
+    "form": {
+      "hidden": [
+        "actions"
+      ],
+      "label": "Unknown intent",
+      "order": [
+        "condition",
+        "*"
+      ],
+      "subtitle": "Unknown intent recognized"
+    }
+  }
+}

--- a/generators/generator-microsoft-bot-adaptive/generators/app/templates/assets/schemas/update-schema.ps1
+++ b/generators/generator-microsoft-bot-adaptive/generators/app/templates/assets/schemas/update-schema.ps1
@@ -1,0 +1,30 @@
+param (
+  [string]$runtime = "azurewebapp"
+)
+$SCHEMA_FILE="sdk.schema"
+$UISCHEMA_FILE="sdk.uischema"
+$BACKUP_SCHEMA_FILE="sdk-backup.schema"
+$BACKUP_UISCHEMA_FILE="sdk-backup.uischema"
+
+Write-Host "Running schema merge on $runtime runtime."
+
+if (Test-Path $SCHEMA_FILE -PathType leaf) { Move-Item -Force -Path $SCHEMA_FILE -Destination $BACKUP_SCHEMA_FILE }
+if (Test-Path $UISCHEMA_FILE -PathType leaf) { Move-Item -Force -Path $UISCHEMA_FILE -Destination $BACKUP_UISCHEMA_FILE }
+
+bf dialog:merge "*.schema" "!sdk-backup.schema" "*.uischema" "!sdk-backup.uischema" "!sdk.override.uischema" "../runtime/$runtime/*.csproj" -o $SCHEMA_FILE
+
+if (Test-Path $SCHEMA_FILE -PathType leaf)
+{
+  if (Test-Path $BACKUP_SCHEMA_FILE -PathType leaf) { Remove-Item -Force -Path $BACKUP_SCHEMA_FILE }
+  if (Test-Path $BACKUP_UISCHEMA_FILE -PathType leaf) { Remove-Item -Force -Path $BACKUP_UISCHEMA_FILE }
+
+  Write-Host "Schema merged succesfully."
+  if (Test-Path $SCHEMA_FILE -PathType leaf) { Write-Host "  Schema:    $SCHEMA_FILE" }
+  if (Test-Path $UISCHEMA_FILE -PathType leaf) { Write-Host "  UI Schema: $UISCHEMA_FILE" }
+}
+else
+{
+  Write-Host "Schema merge failed. Restoring previous versions."
+  if (Test-Path $BACKUP_SCHEMA_FILE -PathType leaf) { Move-Item -Force -Path $BACKUP_SCHEMA_FILE -Destination $SCHEMA_FILE }
+  if (Test-Path $BACKUP_UISCHEMA_FILE -PathType leaf) { Move-Item -Force -Path $BACKUP_UISCHEMA_FILE -Destination $UISCHEMA_FILE }
+}

--- a/generators/generator-microsoft-bot-adaptive/generators/app/templates/assets/schemas/update-schema.sh
+++ b/generators/generator-microsoft-bot-adaptive/generators/app/templates/assets/schemas/update-schema.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+runtime=${runtime:-azurewebapp}
+SCHEMA_FILE=sdk.schema
+UISCHEMA_FILE=sdk.uischema
+BACKUP_SCHEMA_FILE=sdk-backup.schema
+BACKUP_UISCHEMA_FILE=sdk-backup.uischema
+
+while [ $# -gt 0 ]; do
+   if [[ $1 == *"-"* ]]; then
+      param="${1/-/}"
+      declare $param="$2"
+   fi
+  shift
+done
+
+echo "Running schema merge on $runtime runtime."
+[ -f "$SCHEMA_FILE" ] && mv "./$SCHEMA_FILE" "./$BACKUP_SCHEMA_FILE"
+[ -f "$UISCHEMA_FILE" ] && mv "./$UISCHEMA_FILE" "./$BACKUP_UISCHEMA_FILE"
+
+bf dialog:merge "*.schema" "!sdk-backup.schema" "*.uischema" "!sdk-backup.uischema" "!sdk.override.uischema" "../runtime/$runtime/*.csproj" -o $SCHEMA_FILE
+
+if [ -f "$SCHEMA_FILE" ]; then
+  rm -rf "./$BACKUP_SCHEMA_FILE"
+  rm -rf "./$BACKUP_UISCHEMA_FILE"
+  echo "Schema merged succesfully."
+  [ -f "$SCHEMA_FILE" ] && echo "  Schema:    $SCHEMA_FILE"
+  [ -f "$UISCHEMA_FILE" ] && echo "  UI Schema: $UISCHEMA_FILE"
+else
+  echo "Schema merge failed.  Restoring previous versions."
+  [ -f "$BACKUP_SCHEMA_FILE" ] && mv "./$BACKUP_SCHEMA_FILE" "./$SCHEMA_FILE"
+  [ -f "$BACKUP_UISCHEMA_FILE" ] && mv "./$BACKUP_UISCHEMA_FILE" "./$UISCHEMA_FILE"
+fi

--- a/generators/generator-microsoft-bot-adaptive/package-lock.json
+++ b/generators/generator-microsoft-bot-adaptive/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "generator-adaptive-bot",
-  "version": "1.0.0-preview.6",
+  "name": "@microsoft/generator-microsoft-bot-adaptive",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
### Purpose
Adding the schemas directory and its contents to @microsoft/generator-microsoft-bot-adaptive to assets to ensure it is always written as part of the base generator. Also fixing _writeApplicationSettings to output the correct object.

### Changes
- Add schemas/**.* to assets output as part of scaffolding.
- Fix _writeApplicationSettings.

### Tests
Manually verified.