### PR TITLE
feat: Remove clear element from scaffolded NuGet.config

### DIFF
--- a/generators/generator-microsoft-bot-adaptive/generators/app/index.js
+++ b/generators/generator-microsoft-bot-adaptive/generators/app/index.js
@@ -237,6 +237,11 @@ module.exports = class extends Generator {
         const botName = this.options.botName;
         const fileName = 'NuGet.config';
 
+        // Due to security checks, all NuGet.config files committed to the repo must possess the <clear/>
+        // element to ensure only a single feed is utilized. This would be fine in a build context, but
+        // is not desired for scaffolding. To avoid triggering security checks, we need to manipulate
+        // the document and remove the element before outputting to the target location.
+
         const nugetConfig = this.fs.read(this.templatePath(path.join('assets', fileName)));
 
         xml2js.parseString(nugetConfig, (err, result) => {

--- a/generators/generator-microsoft-bot-adaptive/package-lock.json
+++ b/generators/generator-microsoft-bot-adaptive/package-lock.json
@@ -939,6 +939,11 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
     },
+    "sax": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+    },
     "semver": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
@@ -1206,6 +1211,20 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+    },
+    "xml2js": {
+      "version": "0.4.23",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
+      "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
+      "requires": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      }
+    },
+    "xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
     },
     "xtend": {
       "version": "4.0.2",

--- a/generators/generator-microsoft-bot-adaptive/package.json
+++ b/generators/generator-microsoft-bot-adaptive/package.json
@@ -14,6 +14,7 @@
   ],
   "dependencies": {
     "uuid": "^8.3.1",
+    "xml2js": "^0.4.23",
     "yeoman-generator": "^1.1.1"
   },
   "author": "Bot Framework",


### PR DESCRIPTION
### Purpose
We need to make sure we do not clobber other configured package sources for restoring packages. Due to security enforcements, the NuGet.config was updated to limit to a single source - we need to adjust this for the actual generated project itself and separate from our own build pipeline requirements.

### Changes
- Update handling of outputting NuGet.config to clear out 'clear' element from packageSources during scaffolding.

### Tests
Manually tested.