### PR TITLE
Adaptive generator: cleanup workaround from startup.cs

### DIFF
--- a/generators/generator-microsoft-bot-adaptive/generators/app/templates/dotnet/functions/Startup.cs
+++ b/generators/generator-microsoft-bot-adaptive/generators/app/templates/dotnet/functions/Startup.cs
@@ -1,8 +1,5 @@
 ﻿using System;
-using System.Linq;
 using Microsoft.Azure.Functions.Extensions.DependencyInjection;
-using Microsoft.Bot.Builder;
-using Microsoft.Bot.Builder.Integration.AspNet.Core;
 using Microsoft.Bot.Builder.Integration.Runtime.Extensions;
 
 [assembly: FunctionsStartup(typeof(<%= botName %>.Startup))]
@@ -14,10 +11,6 @@ namespace <%= botName %>
         public override void Configure(IFunctionsHostBuilder builder)
         {
             builder.Services.AddBotRuntime(builder.GetContext().Configuration);
-
-            // The workaround below will be removed next SDK patch, when this bug fix gets released: https://github.com/microsoft/botbuilder-dotnet/issues/5239
-            // In the meantime, we're guaranteed to have CoreAdapter registered as IBotFrameworkHttpAdapter, so look it up and register it as BotAdapter.
-            RegisterCoreBotAdapter(builder.Services);
         }
 
         public override void ConfigureAppConfiguration(IFunctionsConfigurationBuilder configurationBuilder)
@@ -26,17 +19,6 @@ namespace <%= botName %>
             string settingsDirectory = <%- settingsDirectory %>;
 
             configurationBuilder.ConfigurationBuilder.AddBotRuntimeConfiguration(applicationRoot, settingsDirectory);
-        }
-
-        private static void RegisterCoreBotAdapter(IServiceCollection services)
-        {
-            const string coreBotAdapterName = "CoreBotAdapter";
-
-            services.AddSingleton(sp =>
-            {
-                var adapters = sp.GetServices<IBotFrameworkHttpAdapter>();
-                return (BotAdapter)adapters.Single(a => typeof(BotAdapter).IsAssignableFrom(a.GetType()) && a.GetType().Name.Contains(coreBotAdapterName));
-            });
         }
     }
 }

--- a/generators/generator-microsoft-bot-adaptive/generators/app/templates/dotnet/webapp/Startup.cs
+++ b/generators/generator-microsoft-bot-adaptive/generators/app/templates/dotnet/webapp/Startup.cs
@@ -1,8 +1,5 @@
-﻿using System.Linq;
-using Microsoft.AspNetCore.Builder;
+﻿using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.Bot.Builder;
-using Microsoft.Bot.Builder.Integration.AspNet.Core;
 using Microsoft.Bot.Builder.Integration.Runtime.Extensions;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -23,10 +20,6 @@ namespace <%= botName %>
         {
             services.AddControllers().AddNewtonsoftJson();
             services.AddBotRuntime(this.Configuration);
-
-            // The workaround below will be removed with next SDK patch, when this bug fix gets released: https://github.com/microsoft/botbuilder-dotnet/issues/5239
-            // In the meantime, we're guaranteed to have CoreAdapter registered as IBotFrameworkHttpAdapter, so look it up and register it as BotAdapter.
-            RegisterCoreBotAdapter(services);
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
@@ -42,17 +35,6 @@ namespace <%= botName %>
                {
                    endpoints.MapControllers();
                });
-        }
-
-        private static void RegisterCoreBotAdapter(IServiceCollection services)
-        {
-            const string coreBotAdapterName = "CoreBotAdapter";
-
-            services.AddSingleton(sp =>
-            {
-                var adapters = sp.GetServices<IBotFrameworkHttpAdapter>();
-                return (BotAdapter)adapters.Single(a => typeof(BotAdapter).IsAssignableFrom(a.GetType()) && a.GetType().Name.Contains(coreBotAdapterName));
-            });
         }
     }
 }


### PR DESCRIPTION
Deleting code that was there to compensate for a bug in the SDK. The bug has been fixed, so we don't need that ugly workaround anymore. Yay, less code!