### PR TITLE
bug: Update luis:environment setting value to 'composer'

### DIFF
--- a/generators/generator-microsoft-bot-command-list/generators/app/templates/settings/appsettings.json
+++ b/generators/generator-microsoft-bot-command-list/generators/app/templates/settings/appsettings.json
@@ -26,7 +26,7 @@
       "endpointKey": "",
       "authoringRegion": "",
       "defaultLanguage": "",
-      "environment": "",
+      "environment": "composer",
       "endpoint": "",
       "authoringEndpoint": ""
     },

--- a/generators/generator-microsoft-bot-conversational-core/generators/app/templates/settings/appsettings.json
+++ b/generators/generator-microsoft-bot-conversational-core/generators/app/templates/settings/appsettings.json
@@ -25,7 +25,7 @@
     "name": "templates",
     "authoringRegion": "",
     "defaultLanguage": "",
-    "environment": "",
+    "environment": "composer",
     "endpoint": "",
     "authoringEndpoint": ""
   },

--- a/generators/generator-microsoft-bot-empty/generators/app/templates/settings/appsettings.json
+++ b/generators/generator-microsoft-bot-empty/generators/app/templates/settings/appsettings.json
@@ -28,7 +28,7 @@
     "endpoint": "",
     "authoringRegion": "",
     "defaultLanguage": "",
-    "environment": ""
+    "environment": "composer"
   },
   "luFeatures": {
     "enablePattern": true,


### PR DESCRIPTION
### Purpose
Updating luis:environment setting value to 'composer' for command-list, conversational-core, and empty generators.

### Changes
- Updating luis:environment setting value to 'composer' for command-list, conversational-core, and empty generators.

### Tests
N/A