### PR TITLE
Pipelines: Migration to SDK_V4 ADO team

### DIFF
--- a/build/yaml/pipelines/calendar.yml
+++ b/build/yaml/pipelines/calendar.yml
@@ -1,21 +1,6 @@
-name: $(Build.DefinitionName)-$(SourceBranchName)-$(Date:yyyyMMdd)$(Rev:.r)
-
-trigger:
-  batch: true
-  branches:
-    include:
-      - main
-  paths:
-    include:
-      - packages/Calendar
-
-pr:
-  branches:
-    include:
-      - main
-  paths:
-    include:
-      - packages/Calendar
+name: $(Build.BuildId)
+trigger: none
+pr: none
 
 pool: 
   vmImage: 'windows-2019'

--- a/build/yaml/pipelines/generator-microsoft-bot-adaptive.yml
+++ b/build/yaml/pipelines/generator-microsoft-bot-adaptive.yml
@@ -1,21 +1,6 @@
-name: $(Build.DefinitionName)-$(SourceBranchName)-$(Date:yyyyMMdd)$(Rev:.r)
-
-trigger:
-  batch: true
-  branches:
-    include:
-      - main
-  paths:
-    include:
-      - generators/generator-microsoft-bot-adaptive
-
-pr:
-  branches:
-    include:
-      - main
-  paths:
-    include:
-      - generators/generator-microsoft-bot-adaptive
+name: $(Build.BuildId)
+trigger: none
+pr: none
 
 pool: 
   vmImage: 'windows-2019'

--- a/build/yaml/pipelines/generator-microsoft-bot-calendar-assistant.yml
+++ b/build/yaml/pipelines/generator-microsoft-bot-calendar-assistant.yml
@@ -1,21 +1,6 @@
-name: $(Build.DefinitionName)-$(SourceBranchName)-$(Date:yyyyMMdd)$(Rev:.r)
-
-trigger:
-  batch: true
-  branches:
-    include:
-      - main
-  paths:
-    include:
-      - generators/generator-microsoft-bot-calendar-assistant
-
-pr:
-  branches:
-    include:
-      - main
-  paths:
-    include:
-      - generators/generator-microsoft-bot-calendar-assistant
+name: $(Build.BuildId)
+trigger: none
+pr: none
 
 pool: 
   vmImage: 'windows-2019'

--- a/build/yaml/pipelines/generator-microsoft-bot-calendar.yml
+++ b/build/yaml/pipelines/generator-microsoft-bot-calendar.yml
@@ -1,21 +1,6 @@
-name: $(Build.DefinitionName)-$(SourceBranchName)-$(Date:yyyyMMdd)$(Rev:.r)
-
-trigger:
-  batch: true
-  branches:
-    include:
-      - main
-  paths:
-    include:
-      - generators/generator-microsoft-bot-calendar
-
-pr:
-  branches:
-    include:
-      - main
-  paths:
-    include:
-      - generators/generator-microsoft-bot-calendar
+name: $(Build.BuildId)
+trigger: none
+pr: none
 
 pool: 
   vmImage: 'windows-2019'

--- a/build/yaml/pipelines/generator-microsoft-bot-command-list.yml
+++ b/build/yaml/pipelines/generator-microsoft-bot-command-list.yml
@@ -1,21 +1,6 @@
-name: $(Build.DefinitionName)-$(SourceBranchName)-$(Date:yyyyMMdd)$(Rev:.r)
-
-trigger:
-  batch: true
-  branches:
-    include:
-      - main
-  paths:
-    include:
-      - generators/generator-microsoft-bot-command-list
-
-pr:
-  branches:
-    include:
-      - main
-  paths:
-    include:
-      - generators/generator-microsoft-bot-command-list
+name: $(Build.BuildId)
+trigger: none
+pr: none
 
 pool: 
   vmImage: 'windows-2019'

--- a/build/yaml/pipelines/generator-microsoft-bot-conversational-core.yml
+++ b/build/yaml/pipelines/generator-microsoft-bot-conversational-core.yml
@@ -1,21 +1,6 @@
-name: $(Build.DefinitionName)-$(SourceBranchName)-$(Date:yyyyMMdd)$(Rev:.r)
-
-trigger:
-  batch: true
-  branches:
-    include:
-      - main
-  paths:
-    include:
-      - generators/generator-microsoft-bot-conversational-core
-
-pr:
-  branches:
-    include:
-      - main
-  paths:
-    include:
-      - generators/generator-microsoft-bot-conversational-core
+name: $(Build.BuildId)
+trigger: none
+pr: none
  
 pool: 
   vmImage: 'windows-2019'

--- a/build/yaml/pipelines/generator-microsoft-bot-empty.yml
+++ b/build/yaml/pipelines/generator-microsoft-bot-empty.yml
@@ -1,21 +1,6 @@
-name: $(Build.DefinitionName)-$(SourceBranchName)-$(Date:yyyyMMdd)$(Rev:.r)
-
-trigger:
-  batch: true
-  branches:
-    include:
-      - main
-  paths:
-    include:
-      - generators/generator-microsoft-bot-empty
-
-pr:
-  branches:
-    include:
-      - main
-  paths:
-    include:
-      - generators/generator-microsoft-bot-empty
+name: $(Build.BuildId)
+trigger: none
+pr: none
 
 pool: 
   vmImage: 'windows-2019'

--- a/build/yaml/pipelines/graph.yml
+++ b/build/yaml/pipelines/graph.yml
@@ -1,21 +1,6 @@
-name: $(Build.DefinitionName)-$(SourceBranchName)-$(Date:yyyyMMdd)$(Rev:.r)
-
-trigger:
-  batch: true
-  branches:
-    include:
-      - main
-  paths:
-    include:
-      - packages/Graph
-
-pr:
-  branches:
-    include:
-      - main
-  paths:
-    include:
-      - packages/Graph
+name: $(Build.BuildId)
+trigger: none
+pr: none
 
 pool: 
   vmImage: 'windows-2019'

--- a/build/yaml/pipelines/helpandcancel.yml
+++ b/build/yaml/pipelines/helpandcancel.yml
@@ -1,21 +1,6 @@
-name: $(Build.DefinitionName)-$(SourceBranchName)-$(Date:yyyyMMdd)$(Rev:.r)
-
-trigger:
-  batch: true
-  branches:
-    include:
-      - main
-  paths:
-    include:
-      - packages/HelpAndCancel
-
-pr:
-  branches:
-    include:
-      - main
-  paths:
-    include:
-      - packages/HelpAndCancel
+name: $(Build.BuildId)
+trigger: none
+pr: none
 
 pool: 
   vmImage: 'windows-2019'

--- a/build/yaml/pipelines/onboarding.yml
+++ b/build/yaml/pipelines/onboarding.yml
@@ -1,21 +1,6 @@
-name: $(Build.DefinitionName)-$(SourceBranchName)-$(Date:yyyyMMdd)$(Rev:.r)
-
-trigger:
-  batch: true
-  branches:
-    include:
-      - main
-  paths:
-    include:
-      - packages/Onboarding
-
-pr:
-  branches:
-    include:
-      - main
-  paths:
-    include:
-      - packages/Onboarding
+name: $(Build.BuildId)
+trigger: none
+pr: none
 
 pool: 
   vmImage: 'windows-2019'

--- a/build/yaml/pipelines/orchestrator.yml
+++ b/build/yaml/pipelines/orchestrator.yml
@@ -1,21 +1,6 @@
-name: $(Build.DefinitionName)-$(SourceBranchName)-$(Date:yyyyMMdd)$(Rev:.r)
-
-trigger:
-  batch: true
-  branches:
-    include:
-      - main
-  paths:
-    include:
-      - packages/Orchestrator
-
-pr:
-  branches:
-    include:
-      - main
-  paths:
-    include:
-      - packages/Orchestrator
+name: $(Build.BuildId)
+trigger: none
+pr: none
 
 pool: 
   vmImage: 'windows-2019'

--- a/build/yaml/pipelines/starter-pipeline.yml
+++ b/build/yaml/pipelines/starter-pipeline.yml
@@ -1,21 +1,6 @@
-name: $(Build.DefinitionName)-$(SourceBranchName)-$(Date:yyyyMMdd)$(Rev:.r)
-
-trigger:
-  batch: true
-  branches:
-    include:
-      - main
-  paths:
-    include:
-      - {YOUR_WORKING_DIRECTORY}
-
-pr:
-  branches:
-    include:
-      - main
-  paths:
-    include:
-      - {YOUR_WORKING_DIRECTORY}
+name: $(Build.BuildId)
+trigger: none
+pr: none
 
 extends:
   template: ../templates/component-template.yml

--- a/build/yaml/pipelines/welcome.yml
+++ b/build/yaml/pipelines/welcome.yml
@@ -1,21 +1,6 @@
-name: $(Build.DefinitionName)-$(SourceBranchName)-$(Date:yyyyMMdd)$(Rev:.r)
-
-trigger:
-  batch: true
-  branches:
-    include:
-      - main
-  paths:
-    include:
-      - packages/Welcome
-
-pr:
-  branches:
-    include:
-      - main
-  paths:
-    include:
-      - packages/Welcome
+name: $(Build.BuildId)
+trigger: none
+pr: none
 
 pool: 
   vmImage: 'windows-2019'

--- a/build/yaml/templates/nuget-signing-steps.yml
+++ b/build/yaml/templates/nuget-signing-steps.yml
@@ -30,7 +30,7 @@ steps:
   displayName: 'ESRP Signing - strong name (CP-233863-SN)'
   condition: eq(variables.ComponentType, 'codeExtension')
   inputs:
-    ConnectedServiceName: 'botframework-components-esrp'
+    ConnectedServiceName: 'ESRP Code Signing Connection 2020a'
     FolderPath: '$(Build.ArtifactStagingDirectory)\signing'
     signConfigType: inlineSignParams
     inlineOperation: |
@@ -58,7 +58,7 @@ steps:
   displayName: 'ESRP Signing - authenticode (CP-230012)'
   condition: eq(variables.ComponentType, 'codeExtension')
   inputs:
-    ConnectedServiceName: 'botframework-components-esrp'
+    ConnectedServiceName: 'ESRP Code Signing Connection 2020a'
     FolderPath: '$(Build.ArtifactStagingDirectory)\signing'
     signConfigType: inlineSignParams
     inlineOperation: |
@@ -113,7 +113,7 @@ steps:
 - task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
   displayName: 'ESRP Signing - *.nupkg,*.snupkg (CP-401405)'
   inputs:
-    ConnectedServiceName: 'botframework-components-esrp'
+    ConnectedServiceName: 'ESRP Code Signing Connection 2020a'
     FolderPath: '$(Build.ArtifactStagingDirectory)\signing'
     Pattern: '*.nupkg,*.snupkg'
     signConfigType: inlineSignParams


### PR DESCRIPTION
<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
### Purpose
*What is the context of this pull request? Why is it being done?*
Update pipelines to work on the SDK_V4 ADO team

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*
- Pipeline names are simply BuildId value so they are easier to parse
- CI & PR triggers wil be configured in Pipelines, so they can share the same YAML templates as the Daily builds
- Use the same signing service connection as SDK

