### PR TITLE
fix: Change runtime key field to match new value in Composer

### DIFF
--- a/generators/generator-bot-template-generator/app/templates/generators/app/templates/settings/appsettings.json
+++ b/generators/generator-bot-template-generator/app/templates/generators/app/templates/settings/appsettings.json
@@ -38,7 +38,7 @@
     "customRuntime": true,
     "path": "../",
     "command": "dotnet run --project < botName >.csproj",
-    "key": "csharp-azurewebapp-v2"
+    "key": "adaptive-runtime-dotnet-webapp"
   },
   "downsampling": {
     "maxImbalanceRatio": 10

--- a/generators/generator-microsoft-bot-calendar-assistant/generators/app/templates/settings/appsettings.json
+++ b/generators/generator-microsoft-bot-calendar-assistant/generators/app/templates/settings/appsettings.json
@@ -55,7 +55,7 @@
     "customRuntime": true,
     "path": "../",
     "command": "dotnet run --project <%= botName %>.csproj",
-    "key": "csharp-azurewebapp-v2"
+    "key": "adaptive-runtime-dotnet-webapp"
   },
   "downsampling": {
     "maxImbalanceRatio": -1

--- a/generators/generator-microsoft-bot-calendar/generators/app/templates/settings/appsettings.json
+++ b/generators/generator-microsoft-bot-calendar/generators/app/templates/settings/appsettings.json
@@ -50,7 +50,7 @@
     "customRuntime": true,
     "path": "../",
     "command": "dotnet run --project <%= botName %>.csproj",
-    "key": "csharp-azurewebapp-v2"
+    "key": "adaptive-runtime-dotnet-webapp"
   },
   "downsampling": {
     "maxImbalanceRatio": 10,

--- a/generators/generator-microsoft-bot-command-list/generators/app/templates/settings/appsettings.json
+++ b/generators/generator-microsoft-bot-command-list/generators/app/templates/settings/appsettings.json
@@ -44,7 +44,7 @@
       "customRuntime": true,
       "path": "../",
       "command": "dotnet run --project <%= botName %>.csproj",
-      "key": "csharp-azurewebapp-v2"
+      "key": "adaptive-runtime-dotnet-webapp"
     },
     "downsampling": {
       "maxImbalanceRatio": 10,

--- a/generators/generator-microsoft-bot-conversational-core/generators/app/templates/settings/appsettings.json
+++ b/generators/generator-microsoft-bot-conversational-core/generators/app/templates/settings/appsettings.json
@@ -38,7 +38,7 @@
     "customRuntime": true,
     "path": "../",
     "command": "dotnet run --project <%= botName %>.csproj",
-    "key": "csharp-azurewebapp-v2"
+    "key": "adaptive-runtime-dotnet-webapp"
   },
   "downsampling": {
     "maxImbalanceRatio": 10

--- a/generators/generator-microsoft-bot-empty/generators/app/templates/settings/appsettings.json
+++ b/generators/generator-microsoft-bot-empty/generators/app/templates/settings/appsettings.json
@@ -55,7 +55,7 @@
     "customRuntime": true,
     "path": "../",
     "command": "dotnet run --project <%= botName %>.csproj",
-    "key": "csharp-azurewebapp-v2"
+    "key": "adaptive-runtime-dotnet-webapp"
   },
   "downsampling": {
     "maxImbalanceRatio": -1


### PR DESCRIPTION
### Purpose

Update the generators to include a new more descriptive identifier of the runtime for use by Composer.

The Composer side changes are here:
https://github.com/microsoft/BotFramework-Composer/pull/6346

### Changes
* Updates all the appsettings.json templates to reflect new identifier