### PR TITLE
feat: Include .onnx and .txt content in build output

### DIFF
--- a/generators/generator-microsoft-bot-adaptive/generators/app/templates/dotnet/functions/botName.csproj
+++ b/generators/generator-microsoft-bot-adaptive/generators/app/templates/dotnet/functions/botName.csproj
@@ -12,7 +12,7 @@
       <ExcludeFromSingleFile>true</ExcludeFromSingleFile>
       <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
     </Content>
-    <Content Include="**/*.blu;**/*.dialog;**/*.lg;**/*.lu;**/*.qna" Exclude="$(BaseOutputPath)/**;$(BaseIntermediateOutputPath)/**">
+    <Content Include="**/*.blu;**/*.dialog;**/*.lg;**/*.lu;**/*.onnx;**/*.qna;**/*.txt" Exclude="$(BaseOutputPath)/**;$(BaseIntermediateOutputPath)/**">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>

--- a/generators/generator-microsoft-bot-adaptive/generators/app/templates/dotnet/webapp/botName.csproj
+++ b/generators/generator-microsoft-bot-adaptive/generators/app/templates/dotnet/webapp/botName.csproj
@@ -5,7 +5,7 @@
     <AspNetCoreHostingModel>OutOfProcess</AspNetCoreHostingModel>
   </PropertyGroup>
   <ItemGroup>
-    <Content Include="**/*.blu;**/*.dialog;**/*.lg;**/*.lu;**/*.qna" Exclude="$(BaseOutputPath)/**;$(BaseIntermediateOutputPath)/**">
+    <Content Include="**/*.blu;**/*.dialog;**/*.lg;**/*.lu;**/*.onnx;**/*.qna;**/*.txt" Exclude="$(BaseOutputPath)/**;$(BaseIntermediateOutputPath)/**">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>


### PR DESCRIPTION
### Purpose
Fixes https://github.com/microsoft/botframework-components/issues/675.

Updating .csproj templates in @microsoft/generator-microsoft-bot-adaptive to include .onnx and .txt files in build output to support Orchestrator.

### Changes
- Updating .csproj templates in @microsoft/generator-microsoft-bot-adaptive to include .onnx and .txt files in build output to support Orchestrator.

### Tests
Manually verified.