### PR TITLE
Support overflow list dialog in Who skill

### DIFF
--- a/skills/declarative/whoSkill/whoSkill/dialogs/ListDialog/language-generation/en-us/ListDialog.en-us.lg
+++ b/skills/declarative/whoSkill/whoSkill/dialogs/ListDialog/language-generation/en-us/ListDialog.en-us.lg
@@ -1,11 +1,11 @@
 [Common](common.en-us.lg)
 [UserList](userList.en-us.lg)
 
-# ListCard(totalItemCount, pageSize, pageItems, headerIcon, headerTitle, itemTemplate, actionsTemplate, pageIndex, pageCount, scenario)
-- ${CardTemplate(ListCardHeader(headerIcon, headerTitle, totalItemCount, scenario), ListCardBody(totalItemCount, pageSize, pageItems, itemTemplate, pageIndex, pageCount), template(actionsTemplate))}
+# ListCard(totalItemCount, pageSize, pageItems, headerIcon, headerTitle, itemTemplate, actionsTemplate, pageIndex, pageCount, scenario, hasOverflowingChoices)
+- ${CardTemplate(ListCardHeader(headerIcon, headerTitle, totalItemCount, scenario, hasOverflowingChoices), ListCardBody(totalItemCount, pageSize, pageItems, itemTemplate, pageIndex, pageCount), template(actionsTemplate))}
 
-# ListCardHeader(icon, title, totalItemCount, scenario)
-- ${CardHeader(template(icon), template(title, scenario), "", concat(totalItemCount, " results"))}
+# ListCardHeader(icon, title, totalItemCount, scenario, hasOverflowingChoices)
+- ${CardHeader(template(icon), template(title, scenario, hasOverflowingChoices), "", concat(totalItemCount, " results"))}
 
 # ListCardBody(totalItemCount, pageSize, pageItems, itemTemplate, pageIndex, pageCount)
 - ${PaginatedListCardBody(totalItemCount, pageSize, foreach(pageItems, item, template(itemTemplate, item)), pageIndex, pageCount)}
@@ -27,24 +27,24 @@
 
 # ChoiceInput_Prompt_dc3QNs()
 - IF: ${$isFirstTurn == true}
-    - ${InitialChoicePrompt(dialog.Scenario, dialog.User, dialog.items)}
+    - ${InitialChoicePrompt(dialog.Scenario, dialog.User, dialog.items, dialog.HasOverflowingChoices)}
 - ELSE: 
-    - ${RepromptChoicePrompt(dialog.Scenario, dialog.User, dialog.items)}
+    - ${RepromptChoicePrompt(dialog.Scenario, dialog.User, dialog.items, dialog.HasOverflowingChoices)}
     
-# InitialChoicePrompt(Scenario, User, Items)
+# InitialChoicePrompt(Scenario, User, Items, HasOverflowingChoices)
 [Activity
     text = ${if($activePrompt != null, template($activePrompt), null)}
-    attachments = ${json(ListCard(count($items), $pageSize, $pageItems, $templates.icon, $templates.title, $templates.item, $templates.actions, $pageIndex + 1, $pageCount, Scenario))}
+    attachments = ${json(ListCard(count($items), $pageSize, $pageItems, $templates.icon, $templates.title, $templates.item, $templates.actions, $pageIndex + 1, $pageCount, Scenario, HasOverflowingChoices))}
 ]
 
-# RepromptChoicePrompt(Scenario, User, Items)
+# RepromptChoicePrompt(Scenario, User, Items, HasOverflowingChoices)
 [Activity
     deliveryMode = update
     id = ${turn.activity.replyToId}
-    attachments = ${json(ListCard(count($items), $pageSize, $pageItems, $templates.icon, $templates.title, $templates.item, $templates.actions, $pageIndex + 1, $pageCount, Scenario))}
+    attachments = ${json(ListCard(count($items), $pageSize, $pageItems, $templates.icon, $templates.title, $templates.item, $templates.actions, $pageIndex + 1, $pageCount, Scenario, HasOverflowingChoices))}
 ]
 
 # Bot.SendActivityPlus_Activity_UcmH0c()
 [Activity
-    attachments = ${json(ListCard(count($items), $pageSize, $pageItems, $templates.icon, $templates.title, $templates.item, $templates.actions, $pageIndex + 1, $pageCount, ""))}
+    attachments = ${json(ListCard(count($items), $pageSize, $pageItems, $templates.icon, $templates.title, $templates.item, $templates.actions, $pageIndex + 1, $pageCount, "", false))}
 ]

--- a/skills/declarative/whoSkill/whoSkill/dialogs/UserListDialog/UserListDialog.dialog
+++ b/skills/declarative/whoSkill/whoSkill/dialogs/UserListDialog/UserListDialog.dialog
@@ -32,6 +32,42 @@
               "condition": "= count($UserList) > 1 || (count($UserList) == 1 && $AutoChooseFirst == \"false\")",
               "actions": [
                 {
+                  "$kind": "Microsoft.IfCondition",
+                  "$designer": {
+                    "id": "HVAJ57"
+                  },
+                  "condition": "=count($UserList) > 15",
+                  "actions": [
+                    {
+                      "$kind": "Microsoft.SetProperty",
+                      "$designer": {
+                        "id": "rdyKuK"
+                      },
+                      "property": "$HasOverflowingResult",
+                      "value": true
+                    },
+                    {
+                      "$kind": "Microsoft.EditArray",
+                      "$designer": {
+                        "id": "A3mnR9"
+                      },
+                      "changeType": "pop",
+                      "itemsProperty": "$UserList",
+                      "resultProperty": "$UserPopped"
+                    }
+                  ],
+                  "elseActions": [
+                    {
+                      "$kind": "Microsoft.SetProperty",
+                      "$designer": {
+                        "id": "pf8h1d"
+                      },
+                      "property": "$HasOverflowingResult",
+                      "value": false
+                    }
+                  ]
+                },
+                {
                   "$kind": "Microsoft.EmitEvent",
                   "$designer": {
                     "id": "DLV52r"
@@ -76,6 +112,10 @@
                     {
                       "property": "$listOptions.User",
                       "value": "=$User"
+                    },
+                    {
+                      "property": "$listOptions.HasOverflowingResult",
+                      "value": "=$HasOverflowingResult"
                     }
                   ]
                 },

--- a/skills/declarative/whoSkill/whoSkill/language-generation/en-us/userList.en-us.lg
+++ b/skills/declarative/whoSkill/whoSkill/language-generation/en-us/userList.en-us.lg
@@ -27,7 +27,7 @@
 - CASE: ${"DirectReports"}
     - There are ${TotalCount} people that are part of **${User.displayName}**'s team.
 - CASE: ${"PersonSearch"}
-    - Hello
+    - ${MultiplePersonSearchResult(User, HasOverflowingResult)}
 - DEFAULT:
     - I found multiple results:
 

--- a/skills/declarative/whoSkill/whoSkill/language-generation/en-us/userList.en-us.lg
+++ b/skills/declarative/whoSkill/whoSkill/language-generation/en-us/userList.en-us.lg
@@ -1,9 +1,9 @@
 [Common](common.en-us.lg)
 [Actions](actions.en-us.lg)
 
-# UserListPrompt(Scenario, User, Items)
+#UserListPrompt(Scenario, User, Items, HasOverflowingResult)
 - IF: ${count(Items) > 1}
-    - ${MultipleResultFound(Scenario, count(Items), User)}
+    - ${MultipleResultFound(Scenario, count(Items), User, HasOverflowingResult)}
 - ELSE:
     - ${SingleResultFound(Scenario, User)}
 
@@ -18,7 +18,7 @@
 - DEFAULT:
     - I found one result:
 
-#MultipleResultFound(Scenario, TotalCount, User)
+#MultipleResultFound(Scenario, TotalCount, User, HasOverflowingResult)
 - SWITCH: ${Scenario}
 - CASE: ${"Collaborator"}
     - I found ${TotalCount} collegues that collaborates with **${User.displayName}**.
@@ -27,9 +27,15 @@
 - CASE: ${"DirectReports"}
     - There are ${TotalCount} people that are part of **${User.displayName}**'s team.
 - CASE: ${"PersonSearch"}
-    - I found multiple matches for **${User}**. Please pick one:
+    - Hello
 - DEFAULT:
     - I found multiple results:
+
+#MultiplePersonSearchResult(User, HasOverflowingResult)
+- IF: ${HasOverflowingResult == true}
+    - I found many matches for **${User}**.
+- ELSE:
+    - I found multiple matches for **${User}**. Please pick one:
 
 # UserListShowMorePrompt()
 - How about these options?


### PR DESCRIPTION
<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
### Purpose
Allow Who skill to ask for additional input if the result count is more than 15 when searching up someone.

### Changes
- Update LG to support conditionally displaying overflowing notice
- Update dialog to pass isOverflowing parameter
- Update dialog to get up to 16 profiles from user search instead of just 15 to signal overflowing

### Tests
*Is this covered by existing tests or new ones? If no, why not?*

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*

### Checklist

#### General
- [ ] I have commented my code, particularly in hard-to-understand areas	
- [ ] I have added or updated the appropriate tests	
- [ ] I have updated related documentation
