### PR TITLE
feat: Add OnAmbiguousIntent, OnError, and OnUnknownIntent to Assistant Core

### DIFF
--- a/generators/generator-bot-assistant-core/generators/app/templates/assistantCore.dialog
+++ b/generators/generator-bot-assistant-core/generators/app/templates/assistantCore.dialog
@@ -50,7 +50,7 @@
       "$kind": "Microsoft.OnChooseIntent",
       "$designer": {
         "id": "0h5yes",
-        "name": "OnAmbiguousIntent"
+        "name": "Duplicated intents recognized"
       },
       "actions": [
         {
@@ -203,7 +203,7 @@
       "$kind": "Microsoft.OnError",
       "$designer": {
         "id": "OCgnRt",
-        "name": "OnError"
+        "name": "Error occurred"
       },
       "actions": [
         {
@@ -225,7 +225,7 @@
       "$kind": "Microsoft.OnUnknownIntent",
       "$designer": {
         "id": "zxdGNB",
-        "name": "OnUnknownIntent"
+        "name": "Unknown intent"
       },
       "actions": [
         {

--- a/generators/generator-bot-assistant-core/generators/app/templates/assistantCore.dialog
+++ b/generators/generator-bot-assistant-core/generators/app/templates/assistantCore.dialog
@@ -198,6 +198,28 @@
           "knowledgeBaseId": "=settings.qna.knowledgebaseid"
         }
       ]
+    },
+    {
+      "$kind": "Microsoft.OnError",
+      "$designer": {
+        "id": "OCgnRt",
+        "name": "OnError"
+      },
+      "actions": [
+        {
+          "$kind": "Microsoft.SendActivity",
+          "$designer": {
+            "id": "mM3nez"
+          },
+          "activity": "${SendActivity_mM3nez()}"
+        },
+        {
+          "$kind": "Microsoft.TraceActivity",
+          "$designer": {
+            "id": "Z0xhJ8"
+          }
+        }
+      ]
     }
   ],
   "$schema": "https://raw.githubusercontent.com/microsoft/BotFramework-Composer/stable/Composer/packages/server/schemas/sdk.schema",

--- a/generators/generator-bot-assistant-core/generators/app/templates/assistantCore.dialog
+++ b/generators/generator-bot-assistant-core/generators/app/templates/assistantCore.dialog
@@ -220,6 +220,22 @@
           }
         }
       ]
+    },
+    {
+      "$kind": "Microsoft.OnUnknownIntent",
+      "$designer": {
+        "id": "zxdGNB",
+        "name": "OnUnknownIntent"
+      },
+      "actions": [
+        {
+          "$kind": "Microsoft.SendActivity",
+          "$designer": {
+            "id": "CcTxh7"
+          },
+          "activity": "${SendActivity_CcTxh7()}"
+        }
+      ]
     }
   ],
   "$schema": "https://raw.githubusercontent.com/microsoft/BotFramework-Composer/stable/Composer/packages/server/schemas/sdk.schema",

--- a/generators/generator-bot-assistant-core/generators/app/templates/assistantCore.dialog
+++ b/generators/generator-bot-assistant-core/generators/app/templates/assistantCore.dialog
@@ -45,6 +45,159 @@
           ]
         }
       ]
+    },
+    {
+      "$kind": "Microsoft.OnChooseIntent",
+      "$designer": {
+        "id": "0h5yes",
+        "name": "OnAmbiguousIntent"
+      },
+      "actions": [
+        {
+          "$kind": "Microsoft.SetProperties",
+          "$designer": {
+            "id": "lAFi1s"
+          },
+          "assignments": [
+            {
+              "value": "=turn.recognized.candidates[0]",
+              "property": "dialog.luisResult"
+            },
+            {
+              "property": "dialog.qnaResult",
+              "value": "=turn.recognized.candidates[1]"
+            }
+          ]
+        },
+        {
+          "$kind": "Microsoft.IfCondition",
+          "$designer": {
+            "id": "vv9yvW"
+          },
+          "condition": "dialog.luisResult.score >= 0.9 && dialog.qnaResult.score <= 0.5",
+          "actions": [
+            {
+              "$kind": "Microsoft.EmitEvent",
+              "$designer": {
+                "id": "SMpOe6"
+              },
+              "eventName": "recognizedIntent",
+              "eventValue": "=dialog.luisResult.result"
+            },
+            {
+              "$kind": "Microsoft.BreakLoop",
+              "$designer": {
+                "id": "UJeBBn"
+              }
+            }
+          ]
+        },
+        {
+          "$kind": "Microsoft.IfCondition",
+          "$designer": {
+            "id": "hDxpFZ"
+          },
+          "condition": "dialog.luisResult.score <= 0.5 && dialog.qnaResult.score >= 0.9",
+          "actions": [
+            {
+              "$kind": "Microsoft.EmitEvent",
+              "$designer": {
+                "id": "fDazh8"
+              },
+              "eventName": "recognizedIntent",
+              "eventValue": "=dialog.qnaResult.result"
+            },
+            {
+              "$kind": "Microsoft.BreakLoop",
+              "$designer": {
+                "id": "4AsMKR"
+              }
+            }
+          ]
+        },
+        {
+          "$kind": "Microsoft.IfCondition",
+          "$designer": {
+            "id": "HxkqOS"
+          },
+          "condition": "dialog.qnaResult.score <= 0.05",
+          "actions": [
+            {
+              "$kind": "Microsoft.EmitEvent",
+              "$designer": {
+                "id": "Ufksdj"
+              },
+              "eventName": "recognizedIntent",
+              "eventValue": "=dialog.luisResult.result"
+            },
+            {
+              "$kind": "Microsoft.BreakLoop",
+              "$designer": {
+                "id": "hqGPbG"
+              }
+            }
+          ],
+          "top": 3,
+          "cardNoMatchResponse": "Thanks for the feedback.",
+          "cardNoMatchText": "None of the above."
+        },
+        {
+          "$kind": "Microsoft.TextInput",
+          "$designer": {
+            "id": "5hAGxJ"
+          },
+          "maxTurnCount": 3,
+          "alwaysPrompt": true,
+          "allowInterruptions": false,
+          "prompt": "${TextInput_Prompt_gWdJbl()}",
+          "property": "turn.intentChoice",
+          "value": "=@userChosenIntent",
+          "top": 3,
+          "cardNoMatchResponse": "Thanks for the feedback.",
+          "cardNoMatchText": "None of the above.",
+          "activeLearningCardTitle": "Did you mean:",
+          "threshold": 0.3,
+          "noAnswer": "Sorry, I did not find an answer.",
+          "hostname": "=settings.qna.hostname",
+          "endpointKey": "=settings.qna.endpointkey",
+          "knowledgeBaseId": "=settings.qna.knowledgebaseid"
+        },
+        {
+          "$kind": "Microsoft.IfCondition",
+          "$designer": {
+            "id": "LY8OIx"
+          },
+          "condition": "turn.intentChoice != 'none'",
+          "actions": [
+            {
+              "$kind": "Microsoft.EmitEvent",
+              "$designer": {
+                "id": "NFQuNh"
+              },
+              "eventName": "recognizedIntent",
+              "eventValue": "=dialog[turn.intentChoice].result"
+            }
+          ],
+          "elseActions": [
+            {
+              "$kind": "Microsoft.SendActivity",
+              "$designer": {
+                "id": "APpO0t"
+              },
+              "activity": "${SendActivity_WTfZCN()}"
+            }
+          ],
+          "top": 3,
+          "cardNoMatchResponse": "Thanks for the feedback.",
+          "cardNoMatchText": "None of the above.",
+          "activeLearningCardTitle": "Did you mean:",
+          "threshold": 0.3,
+          "noAnswer": "Sorry, I did not find an answer.",
+          "hostname": "=settings.qna.hostname",
+          "endpointKey": "=settings.qna.endpointkey",
+          "knowledgeBaseId": "=settings.qna.knowledgebaseid"
+        }
+      ]
     }
   ],
   "$schema": "https://raw.githubusercontent.com/microsoft/BotFramework-Composer/stable/Composer/packages/server/schemas/sdk.schema",

--- a/generators/generator-bot-assistant-core/generators/app/templates/language-generation/en-us/assistantCore.en-us.lg
+++ b/generators/generator-bot-assistant-core/generators/app/templates/language-generation/en-us/assistantCore.en-us.lg
@@ -31,3 +31,11 @@
 - Hmm, I don't understand. Can you try to ask me in a different way?
 - I didn't get that. Would you mind rephrasing and try it again?
 - Unfortunately I misunderstood, please try again.
+
+# TextInput_Prompt_nrleRD()
+[Activity
+    Attachments = ${json(AdaptiveCardJson())}
+]
+
+# SendActivity_L8AquD()
+- Sure, no worries.

--- a/generators/generator-bot-assistant-core/generators/app/templates/language-generation/en-us/assistantCore.en-us.lg
+++ b/generators/generator-bot-assistant-core/generators/app/templates/language-generation/en-us/assistantCore.en-us.lg
@@ -19,4 +19,15 @@
 # SendActivity_mM3nez_text()
 - Oops, looks like I'm stuck. Can you try to ask me in a different way?
 - Looks like I'm all mixed up. Let's try asking again, but maybe rephrase your request?
-- Sorry, it looks like something went wrong. Can you try asking in a different way?
+- Sorry, it looks like something went wrong. Can you please try again?
+
+# SendActivity_CcTxh7()
+[Activity
+    Text = ${SendActivity_CcTxh7_text()}
+]
+
+# SendActivity_CcTxh7_text()
+- I'm not sure I understand. Can you please try again?
+- Hmm, I don't understand. Can you try to ask me in a different way?
+- I didn't get that. Would you mind rephrasing and try it again?
+- Unfortunately I misunderstood, please try again.

--- a/generators/generator-bot-assistant-core/generators/app/templates/language-generation/en-us/assistantCore.en-us.lg
+++ b/generators/generator-bot-assistant-core/generators/app/templates/language-generation/en-us/assistantCore.en-us.lg
@@ -10,3 +10,13 @@
 
 # SendActivity_WTfZCN()
 - Sure, no worries.
+
+# SendActivity_mM3nez()
+[Activity
+    Text = ${SendActivity_mM3nez_text()}
+]
+
+# SendActivity_mM3nez_text()
+- Oops, looks like I'm stuck. Can you try to ask me in a different way?
+- Looks like I'm all mixed up. Let's try asking again, but maybe rephrase your request?
+- Sorry, it looks like something went wrong. Can you try asking in a different way?

--- a/generators/generator-bot-assistant-core/generators/app/templates/language-generation/en-us/assistantCore.en-us.lg
+++ b/generators/generator-bot-assistant-core/generators/app/templates/language-generation/en-us/assistantCore.en-us.lg
@@ -2,3 +2,11 @@
 
 # SendActivity_Welcome
 - ${WelcomeUser()}
+
+# TextInput_Prompt_gWdJbl()
+[Activity
+    Attachments = ${json(AdaptiveCardJson())}
+]
+
+# SendActivity_WTfZCN()
+- Sure, no worries.

--- a/generators/generator-bot-assistant-core/generators/app/templates/language-generation/en-us/common.en-us.lg
+++ b/generators/generator-bot-assistant-core/generators/app/templates/language-generation/en-us/common.en-us.lg
@@ -1,2 +1,73 @@
 # WelcomeUser
 - Welcome to the Assistant Core sample
+
+# AdaptiveCardJson()
+-```
+{
+      "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+      "version": "1.0",
+      "type": "AdaptiveCard",
+      "speak": "",
+      "body": [
+          {
+              "type": "TextBlock",
+              "text": "${whichOneDidYouMean()}",
+              "weight": "Bolder"
+          },
+          {
+              "type": "TextBlock",
+              "text": "${pickOne()}",
+              "separator": "true"
+          },
+          {
+              "type": "Input.ChoiceSet",
+              "placeholder": "Placeholder text",
+              "id": "userChosenIntent",
+              "choices": [
+                           {
+                               "title": "${getIntentReadBack()}",
+                               "value": "luisResult"
+                           },
+                           {
+                               "title": "${getAnswerReadBack()}",
+                               "value": "qnaResult"
+                           },
+                           {
+                               "title": "None of the above",
+                               "value": "none"
+                           }
+             ],
+             "style": "expanded",
+             "value": "luis"
+         },
+         {
+             "type": "ActionSet",
+             "actions": [
+                {
+                     "type": "Action.Submit",
+                     "title": "Submit",
+                     "data": {
+                   "intent": "chooseIntentCardResponse"
+                }
+         }
+       ]
+     }
+    ]
+}```
+# whichOneDidYouMean()
+- I'm not sure which one you mean.
+- Hmmm, I find that to be ambiguous.
+
+# pickOne()
+- Can you pick one ?
+- Can you help clarify by choosing one ?
+
+# getAnswerReadBack()
+- See an answer from the Knowledge Base
+
+# getIntentReadBack()
+- SWITCH : ${toLower(dialog.luisResult.intent)}
+- CASE : ${'GetUserProfile'}
+  - Start filling in your profile(GetUserProfile intent)
+- DEFAULT :
+  - ${dialog.luisResult.intent}

--- a/generators/generator-bot-assistant-core/generators/app/templates/recognizers/assistantCore.en-us.lu.dialog
+++ b/generators/generator-bot-assistant-core/generators/app/templates/recognizers/assistantCore.en-us.lu.dialog
@@ -1,0 +1,8 @@
+{
+  "$kind": "Microsoft.LuisRecognizer",
+  "id": "LUIS_assistantCore",
+  "applicationId": "=settings.luis.assistantCore_en_us_lu.appId",
+  "version": "=settings.luis.assistantCore_en_us_lu.version",
+  "endpoint": "=settings.luis.endpoint",
+  "endpointKey": "=settings.luis.endpointKey"
+}

--- a/generators/generator-bot-assistant-core/generators/app/templates/recognizers/assistantCore.lu.dialog
+++ b/generators/generator-bot-assistant-core/generators/app/templates/recognizers/assistantCore.lu.dialog
@@ -1,0 +1,5 @@
+{
+  "$kind": "Microsoft.MultiLanguageRecognizer",
+  "id": "LUIS_assistantCore",
+  "recognizers": {}
+}

--- a/generators/generator-bot-assistant-core/generators/app/templates/recognizers/assistantCore.lu.qna.dialog
+++ b/generators/generator-bot-assistant-core/generators/app/templates/recognizers/assistantCore.lu.qna.dialog
@@ -1,0 +1,4 @@
+{
+  "$kind": "Microsoft.CrossTrainedRecognizerSet",
+  "recognizers": []
+}


### PR DESCRIPTION
<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
### Purpose
Adding stubs for disambiguation, error handling, and unknown intent handling to the Assistant Core generator.

### Changes
- Added `Microsoft.OnChooseIntent` trigger and prepackaged dialog for disambiguation #737. Orchestrator will test against as they work on their related bugs.
![image](https://user-images.githubusercontent.com/43043272/111399533-cbeb5480-8682-11eb-9124-98c07f795bff.png)

- Added `Microsoft.OnError` trigger sending a friendly response back to user and trace event per #689, will keep this in sync with Conversation Core template. The runtime should handle logging to a logging provider per the [OnTurnError in CoreBotAdapter](https://github.com/microsoft/botbuilder-dotnet/blob/514abdf64602f333c62033a67904d2e026458d5a/libraries/integration/Microsoft.Bot.Builder.Integration.Runtime/CoreBotAdapter.cs#L53), but this needs further validation when there is a component in this template that can error. I have previous notes on this that were stored on an issue in a deleted repo.
![image](https://user-images.githubusercontent.com/43043272/111399514-c42bb000-8682-11eb-9990-f02c99d263ec.png)

- Added `Microsoft.OnUnknownIntent` with the same content used in Conversation Core. This will likely be integrated with the Chit Chat personality from #736, but needs more investigation from Orchestrator. 
![image](https://user-images.githubusercontent.com/43043272/111399503-bf66fc00-8682-11eb-8329-6126c145ebcd.png)

