### PR TITLE
Fixes cancel intent and other conversational-core updates

### DIFF
--- a/generators/generator-microsoft-bot-adaptive/generators/app/templates/dotnet/webapp/Startup.cs
+++ b/generators/generator-microsoft-bot-adaptive/generators/app/templates/dotnet/webapp/Startup.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.Bot.Builder.Integration.Runtime.Extensions;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 
 namespace <%= botName %>
 {

--- a/generators/generator-microsoft-bot-conversational-core/generators/app/index.js
+++ b/generators/generator-microsoft-bot-conversational-core/generators/app/index.js
@@ -25,7 +25,7 @@ module.exports = class extends Generator {
           },
           {
             name: 'Microsoft.Bot.Components.Welcome',
-            version: '1.0.0-preview.20210317.04ac656',
+            version: '1.0.0-preview.20210318.fd6fdd4',
           },
         ],
         applicationSettingsDirectory: 'settings',

--- a/generators/generator-microsoft-bot-conversational-core/generators/app/index.js
+++ b/generators/generator-microsoft-bot-conversational-core/generators/app/index.js
@@ -21,11 +21,11 @@ module.exports = class extends Generator {
         packageReferences: [
           {
             name: 'Microsoft.Bot.Components.HelpAndCancel',
-            version: '1.0.0-preview.20210310.8ee9434',
+            version: '1.0.0-preview.20210317.08f5da3',
           },
           {
             name: 'Microsoft.Bot.Components.Welcome',
-            version: '1.0.0-preview.20210310.8ee9434',
+            version: '1.0.0-preview.20210317.04ac656',
           },
         ],
         applicationSettingsDirectory: 'settings',

--- a/generators/generator-microsoft-bot-conversational-core/generators/app/templates/conversational-core.dialog
+++ b/generators/generator-microsoft-bot-conversational-core/generators/app/templates/conversational-core.dialog
@@ -1,11 +1,9 @@
 {
   "$kind": "Microsoft.AdaptiveDialog",
   "$designer": {
-    "$designer": {
       "name": "conversational-core",
       "description": "",
-      "id": "GnxrCe"
-    }
+      "id": "4pM5gc"
   },
   "autoEndDialog": true,
   "defaultResultProperty": "dialog.result",
@@ -17,50 +15,88 @@
       },
       "actions": [
         {
-          "$kind": "Microsoft.BeginDialog",
+          "$kind": "Microsoft.Foreach",
           "$designer": {
-            "id": "5j4Wnj"
+            "id": "518944",
+            "name": "Loop: for each item"
           },
-          "activityProcessed": false,
-          "dialog": "Welcome"
+          "itemsProperty": "turn.Activity.membersAdded",
+          "actions": [
+            {
+              "$kind": "Microsoft.IfCondition",
+              "$designer": {
+                "id": "641773",
+                "name": "Branch: if/else"
+              },
+              "condition": "string(dialog.foreach.value.id) != string(turn.Activity.Recipient.id)",
+              "actions": [
+                {
+                  "$kind": "Microsoft.BeginDialog",
+                  "$designer": {
+                    "id": "PlH6iz"
+                  },
+                  "activityProcessed": true,
+                  "dialog": "WelcomeDialog"
+                }
+              ]
+            }
+          ]
         }
       ]
     },
     {
       "$kind": "Microsoft.OnIntent",
       "$designer": {
-        "id": "2cYhnM",
-        "name": "HelpAndCancel"
+        "id": "9wETGs",
+        "name": "Help"
       },
-      "intent": "HelpAndCancel",
+      "intent": "Help",
       "actions": [
         {
           "$kind": "Microsoft.BeginDialog",
           "$designer": {
-            "id": "2XIjZK"
+            "id": "B0NP8m"
           },
-          "activityProcessed": false,
-          "dialog": "HelpAndCancel"
+          "activityProcessed": true,
+          "dialog": "HelpDialog"
         }
       ]
     },
     {
+      "$kind": "Microsoft.OnIntent",
+      "$designer": {
+        "id": "e1i6lY",
+        "name": "Cancel"
+      },
+      "intent": "Cancel",
+      "actions": [
+        {
+          "$kind": "Microsoft.BeginDialog",
+          "$designer": {
+            "id": "FDsuIq"
+          },
+          "activityProcessed": true,
+          "dialog": "CancelDialog"
+        }
+      ],
+      "condition": "=turn.recognized.score > 0.9"
+    },
+    {
       "$kind": "Microsoft.OnUnknownIntent",
       "$designer": {
-        "id": "AIwlw6"
+        "id": "FOxcnx"
       },
       "actions": [
         {
           "$kind": "Microsoft.SendActivity",
           "$designer": {
-            "id": "z0X16k"
+            "id": "IQMEuO"
           },
-          "activity": "${SendActivity_z0X16k()}"
+          "activity": "${SendActivity_IQMEuO()}"
         }
       ]
     }
   ],
-  "$schema": "https://raw.githubusercontent.com/microsoft/BotFramework-Composer/stable/Composer/packages/server/schemas/sdk.schema",
   "generator": "conversational-core.lg",
   "id": "conversational-core",
   "recognizer": "conversational-core.lu.qna"

--- a/generators/generator-microsoft-bot-conversational-core/generators/app/templates/language-generation/en-us/conversational-core.en-us.lg
+++ b/generators/generator-microsoft-bot-conversational-core/generators/app/templates/language-generation/en-us/conversational-core.en-us.lg
@@ -1,8 +1,13 @@
 [import](common.lg)
 
 
-# SendActivity_z0X16k()
+# SendActivity_IQMEuO()
+[Activity
+    Text = ${SendActivity_IQMEuO_text()}
+]
+
+# SendActivity_IQMEuO_text()
+- Sorry, I didn't get that
 - I'm not sure I understand. Can you please try again?
-- Hmm, I don't understand. Can you try to ask me in a different way. 			
+- Hmm, I don't understand. Can you try to ask me in a different way. 
 - I didn't get that. Would you mind rephrasing and try it again.
-- Unfortunately I misunderstood, please try again.

--- a/generators/generator-microsoft-bot-conversational-core/generators/app/templates/language-understanding/en-us/conversational-core.en-us.lu
+++ b/generators/generator-microsoft-bot-conversational-core/generators/app/templates/language-understanding/en-us/conversational-core.en-us.lu
@@ -1,50 +1,23 @@
 
-# HelpAndCancel
-- any help
-- can you help
-- can you help me
-- give me some help
+# Help
 - help
-- how can i get it
-- how to do it
+- what can you do?
+- can you help me
 - i need help
-- i need some assist
-- i need some help
-- is there any help
-- open help
-- please help
-- some help
-- who can help me
+- i need some assistance
+# Cancel
 - cancel
-- cancel app
-- cancel cancel
-- cancel it
-- cancel never mind
-- cancel that
-- canceled
-- cancelled
-- do nothing
-- don't do that
-- don't do that anymore
-- forget about it
-- go away
-- just cancel
-- just cancel it
-- nerver mind
-- never mind
-- never mind cancel
-- never mind cancel that
-- no cancel
-- no cancel cancel
-- no cancel it
-- no cancel that
-- no never mind
-- no no cancel
-- no no cancel it
-- nothing never mind
-- nothing please
-- oh cancel
-- oh don't do that
-- please do nothing
 - quit
-- sorry, don't do it
+- abort
+- exit
+- never mind
+- forget about it
+# None
+- where is my car?
+- I want to order a pizza
+- place an item on hold
+- Is it going to rain?
+- turn on the lights
+- check my account balance
+- do unicorns really exist
+- duck


### PR DESCRIPTION
Fixes #683 

## Changes summary
* Added missing using for Microsoft.Extensions.Hosting in adaptive startup.cs
* Tuned up the LUIS model for convcore by removing some utterances and adding some utterances to the none
* Updated convcore references to use the latest welcome and help and cancel packages and wired up the dialogs to the root dialog
* Removed extra #designer element in conversational-core.dialog
* Removed reference to SDK schema from conversational-core.dialog (this is not needed)
* Added condition to the cancel intent to only trigger on 90% certainty. 
* Updated SendActivity calls to use the Response Editor format

**Note:** the luis model has too few utterances and it has no real end user intents, we should let the devs know if the documentation about the need to tune the LUIS model and make sure the know about the none intent too. 

Here are a screenshots of the resulting project:

## Root dialog
![image](https://user-images.githubusercontent.com/12264946/111630780-170f7f80-87c9-11eb-80e1-a197478fb899.png)
 
## Cancel intent with score condition
![image](https://user-images.githubusercontent.com/12264946/111631145-72da0880-87c9-11eb-9349-cab6a0825bc7.png)

## Added none intent for training:
![image](https://user-images.githubusercontent.com/12264946/111631313-9ef58980-87c9-11eb-883e-dd405ff8ae2b.png)

