### PR TITLE
Update Graph project config

### DIFF
--- a/packages/Graph/Microsoft.Bot.Components.Graph.csproj
+++ b/packages/Graph/Microsoft.Bot.Components.Graph.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
@@ -13,12 +13,13 @@
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\build\35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
     <DelaySign>true</DelaySign>
+    <ContentTargetFolders>content</ContentTargetFolders>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Graph.Beta" Version="0.39.0-preview" />
     <PackageReference Include="Microsoft.Bot.Builder.Integration.Runtime" Version="4.12.1-preview" />
-    
+
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.333">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
@@ -26,13 +27,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Content Include=".\Schemas\*.schema" CopyToOutputDirectory="always">
-      <IncludeInPackage>true</IncludeInPackage>
-      <CopyToOutput>true</CopyToOutput>
-      <BuildAction>Content</BuildAction>
-      <copyToOutput>true</copyToOutput>
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </Content>
+    <Content Include="**/*.dialog" />
+    <Content Include="**/*.lg" />
+    <Content Include="**/*.lu" />
+    <Content Include="**/*.schema" />
+    <Content Include="**/*.uischema" />
+    <Content Include="**/*.qna" />
   </ItemGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
Nuget pack duplicates the schema files by default which breaks dialog:merge

I took the pattern used by the Bot Builder Community package to resolve this issue. Worked when testing the muget package locally