### PR TITLE
Invoke this.modifyApplicationSettings in generator-bot-adaptive

### DIFF
--- a/generators/generator-bot-adaptive/generators/app/index.js
+++ b/generators/generator-bot-adaptive/generators/app/index.js
@@ -194,6 +194,10 @@ module.exports = class extends BaseGenerator {
       }
     }
 
+    if (this.modifyApplicationSettings) {
+      this.modifyApplicationSettings(appSettings);
+    }
+
     this.fs.writeJSON(
       this.destinationPath(
         botName,

--- a/generators/generator-bot-adaptive/generators/app/templates/assets/appsettings.json
+++ b/generators/generator-bot-adaptive/generators/app/templates/assets/appsettings.json
@@ -9,6 +9,13 @@
   "languages": [
     "en-us"
   ],
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  },
   "luFeatures": {
     "enableCompositeEntities": true,
     "enableListEntities": true,
@@ -60,13 +67,6 @@
         "instrumentationKey": "",
         "logActivities": true,
         "logPersonalInformation": false
-    }
-  },
-  "Logging": {
-      "LogLevel": {
-      "Default": "Information",
-      "Microsoft": "Warning",
-      "Microsoft.Hosting.Lifetime": "Information"
     }
   }
 }


### PR DESCRIPTION
### Purpose
Invocation to modifyApplicationSettings as part of _writeApplicationSettings within generator-bot-adaptive had been inadvertently dropped. This was impacting child generators which attempted to modify the base appsettings.

### Changes
- Add invocation of this.modifyApplicationSettings back to _writeApplicationSettings in generator-bot-adaptive.

### Tests
Manually verified.