### PR TITLE
Adds error handler to conversational core

### DIFF
--- a/generators/generator-bot-conversational-core/generators/app/templates/botName.dialog
+++ b/generators/generator-bot-conversational-core/generators/app/templates/botName.dialog
@@ -1,7 +1,6 @@
 {
   "$kind": "Microsoft.AdaptiveDialog",
   "$designer": {
-    "$designer": {
       "name": "<%= botName %>",
       "description": "",
       "id": "4pM5gc"
@@ -96,9 +95,33 @@
           "activity": "${SendActivity_IQMEuO()}"
         }
       ]
+    },
+    {
+      "$kind": "Microsoft.OnError",
+      "$designer": {
+        "id": "aLQGr7"
+      },
+      "actions": [
+        {
+          "$kind": "Microsoft.SendActivity",
+          "$designer": {
+            "id": "2outgQ"
+          },
+          "activity": "${SendActivity_2outgQ()}"
+        },
+        {
+          "$kind": "Microsoft.TraceActivity",
+          "$designer": {
+            "id": "NVFqr5"
+          },
+          "name": "=turn.dialogEvent.value.className",
+          "valueType": "Exception",
+          "value": "=turn.dialogEvent.value",
+          "label": "ErrorOcurred"
+        }
+      ]
     }
   ],
-  "$schema": "https://raw.githubusercontent.com/microsoft/BotFramework-Composer/stable/Composer/packages/server/schemas/sdk.schema",
   "generator": "<%= botName %>.lg",
   "id": "<%= botName %>",
   "recognizer": "<%= botName %>.lu.qna"

--- a/generators/generator-bot-conversational-core/generators/app/templates/botName.dialog
+++ b/generators/generator-bot-conversational-core/generators/app/templates/botName.dialog
@@ -103,6 +103,17 @@
       },
       "actions": [
         {
+          "$kind": "Microsoft.TelemetryTrackEventAction",
+          "$designer": {
+            "id": "Aucn7t"
+          },
+          "eventName": "ErrorOccurred",
+          "properties": {
+            "Type": "=turn.dialogEvent.value.className",
+            "Exception": "=turn.dialogEvent.value"
+          }
+        },
+        {
           "$kind": "Microsoft.SendActivity",
           "$designer": {
             "id": "2outgQ"

--- a/generators/generator-bot-conversational-core/generators/app/templates/botName.dialog
+++ b/generators/generator-bot-conversational-core/generators/app/templates/botName.dialog
@@ -117,7 +117,7 @@
           "name": "=turn.dialogEvent.value.className",
           "valueType": "Exception",
           "value": "=turn.dialogEvent.value",
-          "label": "ErrorOcurred"
+          "label": "ErrorOccurred"
         }
       ]
     }

--- a/generators/generator-bot-conversational-core/generators/app/templates/language-generation/en-us/botName.en-us.lg
+++ b/generators/generator-bot-conversational-core/generators/app/templates/language-generation/en-us/botName.en-us.lg
@@ -11,3 +11,12 @@
 - I'm not sure I understand. Can you please try again?
 - Hmm, I don't understand. Can you try to ask me in a different way. 
 - I didn't get that. Would you mind rephrasing and try it again.
+# SendActivity_2outgQ()
+[Activity
+    Text = ${SendActivity_2outgQ_text()}
+]
+
+# SendActivity_2outgQ_text()
+- Oops, looks like I'm stuck. Can you try to ask me in a different way?
+- Looks like I'm all mixed up. Let's try asking again, but maybe rephrase your request?
+- Sorry, it looks like something went wrong. Can you please try again?


### PR DESCRIPTION
Fixes #689

This PR adds an error trigger to the root dialog and sends a friendly message and a trace with exception details to emulator (it is good to show devs where to find the exception details in memory).

It also removes the $schema property that was erroneously added to botName.dialog and removes a duplicated element from that dialog.

## Error Occurred action for telemetry

![image](https://user-images.githubusercontent.com/12264946/112673759-7d387a00-8e3b-11eb-95e0-d13fe6d65bbc.png)

## Error Occurred action for emulator trace

![image](https://user-images.githubusercontent.com/12264946/112643888-376bb980-8e1b-11eb-8078-eb3d10810b8f.png)

## Emulator output when an error occurs

![image](https://user-images.githubusercontent.com/12264946/112644228-8e718e80-8e1b-11eb-83f6-649efcd255fb.png)

## Error in telemetry

![image](https://user-images.githubusercontent.com/12264946/112673518-334f9400-8e3b-11eb-9382-644adf441319.png)
