### PR TITLE
Assistant Core: Add OnChooseIntent and FeedbackDialog updates

### DIFF
--- a/generators/generator-bot-assistant-core/generators/app/templates/botName.dialog
+++ b/generators/generator-bot-assistant-core/generators/app/templates/botName.dialog
@@ -240,6 +240,42 @@
       ]
     },
     {
+      "$kind": "Microsoft.OnError",
+      "$designer": {
+        "id": "aLQGr7"
+      },
+      "actions": [
+        {
+          "$kind": "Microsoft.TelemetryTrackEventAction",
+          "$designer": {
+            "id": "Aucn7t"
+          },
+          "eventName": "ErrorOccurred",
+          "properties": {
+            "Type": "=turn.dialogEvent.value.className",
+            "Exception": "=turn.dialogEvent.value"
+          }
+        },
+        {
+          "$kind": "Microsoft.SendActivity",
+          "$designer": {
+            "id": "2outgQ"
+          },
+          "activity": "${SendActivity_2outgQ()}"
+        },
+        {
+          "$kind": "Microsoft.TraceActivity",
+          "$designer": {
+            "id": "NVFqr5"
+          },
+          "name": "=turn.dialogEvent.value.className",
+          "valueType": "Exception",
+          "value": "=turn.dialogEvent.value",
+          "label": "ErrorOccurred"
+        }
+      ]
+    },
+    {
       "$kind": "Microsoft.OnIntent",
       "$designer": {
         "id": "pRdAAf",

--- a/generators/generator-bot-assistant-core/generators/app/templates/botName.dialog
+++ b/generators/generator-bot-assistant-core/generators/app/templates/botName.dialog
@@ -88,6 +88,158 @@
       ]
     },
     {
+      "$kind": "Microsoft.OnChooseIntent",
+      "$designer": {
+        "id": "YDQnEj"
+      },
+      "actions": [
+        {
+          "$kind": "Microsoft.SetProperties",
+          "$designer": {
+            "id": "LMu0fC"
+          },
+          "assignments": [
+            {
+              "value": "=turn.recognized.candidates[0]",
+              "property": "dialog.luisResult"
+            },
+            {
+              "property": "dialog.qnaResult",
+              "value": "=turn.recognized.candidates[1]"
+            }
+          ]
+        },
+        {
+          "$kind": "Microsoft.IfCondition",
+          "$designer": {
+            "id": "1flIQn"
+          },
+          "condition": "dialog.luisResult.score >= 0.9 && dialog.qnaResult.score <= 0.5",
+          "actions": [
+            {
+              "$kind": "Microsoft.EmitEvent",
+              "$designer": {
+                "id": "86jqYT"
+              },
+              "eventName": "recognizedIntent",
+              "eventValue": "=dialog.luisResult.result"
+            },
+            {
+              "$kind": "Microsoft.BreakLoop",
+              "$designer": {
+                "id": "YOHNju"
+              }
+            }
+          ]
+        },
+        {
+          "$kind": "Microsoft.IfCondition",
+          "$designer": {
+            "id": "1n7wbU"
+          },
+          "condition": "dialog.luisResult.score <= 0.5 && dialog.qnaResult.score >= 0.9",
+          "actions": [
+            {
+              "$kind": "Microsoft.EmitEvent",
+              "$designer": {
+                "id": "NAyC56"
+              },
+              "eventName": "recognizedIntent",
+              "eventValue": "=dialog.qnaResult.result"
+            },
+            {
+              "$kind": "Microsoft.BreakLoop",
+              "$designer": {
+                "id": "3fxdQ1"
+              }
+            }
+          ]
+        },
+        {
+          "$kind": "Microsoft.IfCondition",
+          "$designer": {
+            "id": "cRerUu"
+          },
+          "condition": "dialog.qnaResult.score <= 0.05",
+          "actions": [
+            {
+              "$kind": "Microsoft.EmitEvent",
+              "$designer": {
+                "id": "rVjgzi"
+              },
+              "eventName": "recognizedIntent",
+              "eventValue": "=dialog.luisResult.result"
+            },
+            {
+              "$kind": "Microsoft.BreakLoop",
+              "$designer": {
+                "id": "iP9W7S"
+              }
+            }
+          ],
+          "top": 3,
+          "cardNoMatchResponse": "Thanks for the feedback.",
+          "cardNoMatchText": "None of the above."
+        },
+        {
+          "$kind": "Microsoft.TextInput",
+          "$designer": {
+            "id": "YQSOpf"
+          },
+          "maxTurnCount": 3,
+          "alwaysPrompt": true,
+          "allowInterruptions": false,
+          "property": "turn.intentChoice",
+          "value": "=@userChosenIntent",
+          "top": 3,
+          "cardNoMatchResponse": "Thanks for the feedback.",
+          "cardNoMatchText": "None of the above.",
+          "activeLearningCardTitle": "Did you mean:",
+          "threshold": 0.3,
+          "noAnswer": "Sorry, I did not find an answer.",
+          "hostname": "=settings.qna.hostname",
+          "endpointKey": "=settings.qna.endpointkey",
+          "knowledgeBaseId": "=settings.qna.knowledgebaseid",
+          "prompt": "${TextInput_Prompt_YQSOpf()}"
+        },
+        {
+          "$kind": "Microsoft.IfCondition",
+          "$designer": {
+            "id": "Xh7TIa"
+          },
+          "condition": "turn.intentChoice != 'none'",
+          "actions": [
+            {
+              "$kind": "Microsoft.EmitEvent",
+              "$designer": {
+                "id": "HUqDv8"
+              },
+              "eventName": "recognizedIntent",
+              "eventValue": "=dialog[turn.intentChoice].result"
+            }
+          ],
+          "elseActions": [
+            {
+              "$kind": "Microsoft.SendActivity",
+              "$designer": {
+                "id": "ufxNYo"
+              },
+              "activity": "${SendActivity_ufxNYo()}"
+            }
+          ],
+          "top": 3,
+          "cardNoMatchResponse": "Thanks for the feedback.",
+          "cardNoMatchText": "None of the above.",
+          "activeLearningCardTitle": "Did you mean:",
+          "threshold": 0.3,
+          "noAnswer": "Sorry, I did not find an answer.",
+          "hostname": "=settings.qna.hostname",
+          "endpointKey": "=settings.qna.endpointkey",
+          "knowledgeBaseId": "=settings.qna.knowledgebaseid"
+        }
+      ]
+    },
+    {
       "$kind": "Microsoft.OnIntent",
       "$designer": {
         "id": "pRdAAf",

--- a/generators/generator-bot-assistant-core/generators/app/templates/dialogs/FeedbackDialog/language-generation/en-us/FeedbackDialog.en-us.lg
+++ b/generators/generator-bot-assistant-core/generators/app/templates/dialogs/FeedbackDialog/language-generation/en-us/FeedbackDialog.en-us.lg
@@ -183,13 +183,16 @@
 ]
 
 # SendActivity_639pkl_text()
-- Got it, thanks for the feedback.
-- Understood, thanks for the feedback.
+- Thank you for this feedback.
+- Thanks for your feedback.
+- Thank you, I've captured your feedback.
+
 # SendActivity_YBCkGQ()
 [Activity
     Text = ${SendActivity_YBCkGQ_text()}
 ]
 
 # SendActivity_YBCkGQ_text()
-- Got it, thanks for the feedback.
-- Understood, thanks for providing feedback.
+- Thank you for this feedback.
+- Thanks for your feedback.
+- Thank you, I've captured your feedback.

--- a/generators/generator-bot-assistant-core/generators/app/templates/language-generation/en-us/botName.en-us.lg
+++ b/generators/generator-bot-assistant-core/generators/app/templates/language-generation/en-us/botName.en-us.lg
@@ -96,3 +96,13 @@
 [Activity
     Text = Sure, no worries.
 ]
+
+# SendActivity_2outgQ()
+[Activity
+    Text = ${SendActivity_2outgQ_text()}
+]
+
+# SendActivity_2outgQ_text()
+- Oops, looks like I'm stuck. Can you try to ask me in a different way?
+- Looks like I'm all mixed up. Let's try asking again, but maybe rephrase your request?
+- Sorry, it looks like something went wrong. Can you please try again?

--- a/generators/generator-bot-assistant-core/generators/app/templates/language-generation/en-us/botName.en-us.lg
+++ b/generators/generator-bot-assistant-core/generators/app/templates/language-generation/en-us/botName.en-us.lg
@@ -76,3 +76,23 @@
   text = ${WelcomeNewUser()}
   buttons = ${BotTourEventAction()}
 ]
+
+# TextInput_Prompt_XRSIOS()
+[Activity
+    Attachments = ${json(AdaptiveCardJson())}
+]
+
+# SendActivity_Z8FHjj()
+- Sure, no worries.
+
+# TextInput_Prompt_YQSOpf()
+[Activity
+    Attachments = ${TextInput_Prompt_YQSOpf_attachment_Yixa1e()}
+]
+
+# TextInput_Prompt_YQSOpf_attachment_Yixa1e()
+- $json{AdaptiveCardJson()}
+# SendActivity_ufxNYo()
+[Activity
+    Text = Sure, no worries.
+]


### PR DESCRIPTION
<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
### Purpose
*What is the context of this pull request? Why is it being done?*
#500 Items in Assistant Core template
#737 Enable "Duplicated intents recognized" trigger to enable disambiguation
#738 Update LG for FeedbackDialog

### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*
- Disambiguation: The "duplicated intents recognized" trigger is installed via a template factory in Composer, so the dialog is already preconfigured with LG. This is assumed to work out of the box with the SDK and there are follow up items on Orchestrator to ensure it works as expected.
![image](https://user-images.githubusercontent.com/43043272/112891478-0a264200-908d-11eb-8afc-c5d071759284.png)

- Feedback: Added variations to responses in FeedbackDialog
![image](https://user-images.githubusercontent.com/43043272/112891443-01ce0700-908d-11eb-91df-b16f7df76de3.png)
