### PR TITLE
fix: Adding README.md to included content in component packages

### DIFF
--- a/packages/Graph/Microsoft.Bot.Components.Graph.csproj
+++ b/packages/Graph/Microsoft.Bot.Components.Graph.csproj
@@ -33,6 +33,7 @@
     <Content Include="**/*.schema" />
     <Content Include="**/*.uischema" />
     <Content Include="**/*.qna" />
+    <Content Include="README.md" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/packages/HelpAndCancel/Microsoft.Bot.Components.HelpAndCancel.nuspec
+++ b/packages/HelpAndCancel/Microsoft.Bot.Components.HelpAndCancel.nuspec
@@ -19,5 +19,6 @@
 
     <files>
         <file src="exported\**\*.*" target="exported" />
+        <file src="README.md" target="" />
     </files>
 </package>

--- a/packages/Onboarding/Microsoft.Bot.Components.Onboarding.nuspec
+++ b/packages/Onboarding/Microsoft.Bot.Components.Onboarding.nuspec
@@ -19,5 +19,6 @@
 
     <files>
         <file src="exported\**\*.*" target="exported" />
+        <file src="README.md" target="" />
     </files>
 </package>

--- a/packages/Welcome/Microsoft.Bot.Components.Welcome.nuspec
+++ b/packages/Welcome/Microsoft.Bot.Components.Welcome.nuspec
@@ -19,5 +19,6 @@
 
     <files>
         <file src="exported\**\*.*" target="exported" />
+        <file src="README.md" target="" />
     </files>
 </package>


### PR DESCRIPTION
### Purpose
README.md with post-installation instructions needs to be included in all generator and component packages. The .NET component packages did not include it in their content. This change adds it to applicable packages.

### Changes
- Update Graph, HelpAndCancel, Onboarding and Welcome component packages to include README.md as part of content in .NET NuGet packages.

### Tests
Manually verified.