### PR TITLE
fix: settingsIncludePath in @microsoft/generator-bot-adaptive handles undefined

### DIFF
--- a/generators/generator-bot-adaptive/generators/app/index.js
+++ b/generators/generator-bot-adaptive/generators/app/index.js
@@ -108,10 +108,10 @@ module.exports = class extends BaseGenerator {
         ? `"${this.applicationSettingsDirectory}"`
         : defaultSettingsDirectory;
 
-    const settingsIncludePath = path.join(
-      this.applicationSettingsDirectory,
-      path.sep
-    );
+    const settingsIncludePath =
+      this.applicationSettingsDirectory != null
+        ? path.join(this.applicationSettingsDirectory, path.sep)
+        : '';
 
     this.fs.copyTpl(
       this.templatePath(platform, integration),


### PR DESCRIPTION
### Purpose
If the adaptive generator is run via CLI directly, it throws due to unhandled exception where this.applicationSettingsDirectory is undefined. This change handles this cleanly.

### Changes
- Update _copyPlatformTemplate to handle if this.applicationSettingsDirectory is not set and default to empty string.

### Tests
Manually verified.