### PR TITLE
Limit Graph Object Fields using Select() in People Skill

### DIFF
--- a/packages/Graph/Actions/BaseMsGraphCustomAction.cs
+++ b/packages/Graph/Actions/BaseMsGraphCustomAction.cs
@@ -23,6 +23,11 @@ namespace Microsoft.Bot.Component.Graph.Actions
     public abstract class BaseMsGraphCustomAction : Dialog
     {
         /// <summary>
+        /// Name of the id field that Graph uses to identify objects in the system.
+        /// </summary>
+        public const string DefaultIdField = "id";
+
+        /// <summary>
         /// Initializes a new instance of the <see cref="BaseMsGraphCustomAction"/> class.
         /// </summary>
         /// <param name="callerPath">Caller path.</param>

--- a/packages/Graph/Actions/User/GetDirectReports.cs
+++ b/packages/Graph/Actions/User/GetDirectReports.cs
@@ -51,7 +51,11 @@ namespace Microsoft.Bot.Component.Graph.Actions
             int maxCount = (int)parameters["MaxResults"];
 
             // Create the request first then apply the Top() after
-            IUserDirectReportsCollectionWithReferencesRequest request = client.Users[userId].DirectReports.Request();
+            // TODO: Make this SELECT() clause configurable for different column names
+            // EXPLAINER: The reason we are limiting the field is for two reasons:
+            //            1. Limit the size of the graph object payload needed to be transferred over the wire
+            //            2. Reduces the exposure of end user PII (Personally Identifiable Information) in our system for privacy reasons. It's generally good practice to use what you need.
+            IUserDirectReportsCollectionWithReferencesRequest request = client.Users[userId].DirectReports.Request().Select("id,displayName,mail,businessPhones,department,jobTitle,officeLocation");
 
             if (maxCount > 0)
             {

--- a/packages/Graph/Actions/User/GetDirectReports.cs
+++ b/packages/Graph/Actions/User/GetDirectReports.cs
@@ -44,8 +44,8 @@ namespace Microsoft.Bot.Component.Graph.Actions
         /// <summary>
         /// Gets or sets the fields to select from the Graph API.
         /// </summary>
-        [JsonProperty("FieldsToSelect")]
-        public StringExpression FieldsToSelect { get; set; }
+        [JsonProperty("PropertiesToSelect")]
+        public ArrayExpression<string> PropertiesToSelect { get; set; }
 
         /// <inheritdoc/>
         public override string DeclarativeType => GetDirectReports.GetDirectReportsDeclarativeType;
@@ -55,10 +55,10 @@ namespace Microsoft.Bot.Component.Graph.Actions
         {
             string userId = (string)parameters["UserId"];
             int maxCount = (int)parameters["MaxResults"];
-            string fieldsToSelect = (string)parameters["FieldsToSelect"];
+            string propertiesToSelect = (string)parameters["PropertiesToSelect"];
 
             // Create the request first then apply the Top() after
-            IUserDirectReportsCollectionWithReferencesRequest request = client.Users[userId].DirectReports.Request().Select(fieldsToSelect);
+            IUserDirectReportsCollectionWithReferencesRequest request = client.Users[userId].DirectReports.Request().Select(propertiesToSelect);
 
             if (maxCount > 0)
             {
@@ -88,18 +88,23 @@ namespace Microsoft.Bot.Component.Graph.Actions
             }
 
             // Select minimum of the "id" field from the object
-            string fieldsToSelect = DefaultIdField;
+            string propertiesToSelect = DefaultIdField;
 
-            if (this.FieldsToSelect != null)
+            if (this.PropertiesToSelect != null)
             {
-                fieldsToSelect = this.FieldsToSelect.GetValue(state);
+                List<string> propertiesFound = this.PropertiesToSelect.GetValue(state);
+
+                if (propertiesFound != null && propertiesFound.Count > 0)
+                {
+                    propertiesToSelect = string.Join(",", propertiesFound);
+                }
             }
 
             string userId = this.UserId.GetValue(state);
 
             parameters.Add("UserId", userId);
             parameters.Add("MaxResults", maxCount);
-            parameters.Add("FieldsToSelect", fieldsToSelect);
+            parameters.Add("PropertiesToSelect", propertiesToSelect);
         }
 
         /// <inheritdoc />

--- a/packages/Graph/Actions/User/GetManager.cs
+++ b/packages/Graph/Actions/User/GetManager.cs
@@ -37,7 +37,11 @@ namespace Microsoft.Bot.Component.Graph.Actions
         internal override async Task<DirectoryObject> CallGraphServiceWithResultAsync(IGraphServiceClient client, IReadOnlyDictionary<string, object> parameters, CancellationToken cancellationToken)
         {
             string userId = (string)parameters["UserId"];
-            DirectoryObject result = await client.Users[userId].Manager.Request().GetAsync(cancellationToken);
+            // TODO: Make this SELECT() clause configurable for different column names
+            // EXPLAINER: The reason we are limiting the field is for two reasons:
+            //            1. Limit the size of the graph object payload needed to be transferred over the wire
+            //            2. Reduces the exposure of end user PII (Personally Identifiable Information) in our system for privacy reasons. It's generally good practice to use what you need.
+            DirectoryObject result = await client.Users[userId].Manager.Request().Select("id,displayName,mail,businessPhones,department,jobTitle,officeLocation").GetAsync(cancellationToken);
 
             return result;
         }

--- a/packages/Graph/Actions/User/GetManager.cs
+++ b/packages/Graph/Actions/User/GetManager.cs
@@ -31,10 +31,10 @@ namespace Microsoft.Bot.Component.Graph.Actions
         public StringExpression UserId { get; set; }
 
         /// <summary>
-        /// Gets or sets the fields to select from the Graph API.
+        /// Gets or sets the properties to select from the Graph API.
         /// </summary>
-        [JsonProperty("FieldsToSelect")]
-        public StringExpression FieldsToSelect { get; set; }
+        [JsonProperty("PropertiesToSelect")]
+        public ArrayExpression<string> PropertiesToSelect { get; set; }
 
         /// <inheritdoc/>
         public override string DeclarativeType => GetManager.GetManagerDeclarativeType;
@@ -43,9 +43,9 @@ namespace Microsoft.Bot.Component.Graph.Actions
         internal override async Task<DirectoryObject> CallGraphServiceWithResultAsync(IGraphServiceClient client, IReadOnlyDictionary<string, object> parameters, CancellationToken cancellationToken)
         {
             string userId = (string)parameters["UserId"];
-            string fieldsToSelect = (string)parameters["FieldsToSelect"];
+            string propertiesToSelect = (string)parameters["PropertiesToSelect"];
 
-            DirectoryObject result = await client.Users[userId].Manager.Request().Select(fieldsToSelect).GetAsync(cancellationToken);
+            DirectoryObject result = await client.Users[userId].Manager.Request().Select(propertiesToSelect).GetAsync(cancellationToken);
 
             return result;
         }
@@ -59,17 +59,22 @@ namespace Microsoft.Bot.Component.Graph.Actions
             }
 
             // Select minimum of the "id" field from the object
-            string fieldsToSelect = DefaultIdField;
+            string propertiesToSelect = DefaultIdField;
 
-            if (this.FieldsToSelect != null)
+            if (this.PropertiesToSelect != null)
             {
-                fieldsToSelect = this.FieldsToSelect.GetValue(state);
+                List<string> propertiesFound = this.PropertiesToSelect.GetValue(state);
+
+                if (propertiesFound != null && propertiesFound.Count > 0)
+                {
+                    propertiesToSelect = string.Join(",", propertiesFound);
+                }
             }
 
             string userId = this.UserId.GetValue(state);
 
             parameters.Add("UserId", userId);
-            parameters.Add("FieldsToSelect", fieldsToSelect);
+            parameters.Add("PropertiesToSelect", propertiesToSelect);
         }
 
         /// <inheritdoc />

--- a/packages/Graph/Actions/User/GetPeers.cs
+++ b/packages/Graph/Actions/User/GetPeers.cs
@@ -42,6 +42,12 @@ namespace Microsoft.Bot.Component.Graph.Actions
         [JsonProperty("UserId")]
         public StringExpression UserId { get; set; }
 
+        /// <summary>
+        /// Gets or sets the fields to select from the Graph API.
+        /// </summary>
+        [JsonProperty("FieldsToSelect")]
+        public StringExpression FieldsToSelect { get; set; }
+
         /// <inheritdoc/>
         public override string DeclarativeType => GetPeers.GetPeersDeclarativeType;
 
@@ -81,10 +87,19 @@ namespace Microsoft.Bot.Component.Graph.Actions
                 maxCount = this.MaxCount.GetValue(state);
             }
 
+            // Select minimum of the "id" field from the object
+            string fieldsToSelect = DefaultIdField;
+
+            if (this.FieldsToSelect != null)
+            {
+                fieldsToSelect = this.FieldsToSelect.GetValue(state);
+            }
+
             string userId = this.UserId.GetValue(state);
 
             parameters.Add("UserId", userId);
             parameters.Add("MaxResults", maxCount);
+            parameters.Add("FieldsToSelect", fieldsToSelect);
         }
 
         /// <inheritdoc />

--- a/packages/Graph/Actions/User/GetPeers.cs
+++ b/packages/Graph/Actions/User/GetPeers.cs
@@ -43,10 +43,10 @@ namespace Microsoft.Bot.Component.Graph.Actions
         public StringExpression UserId { get; set; }
 
         /// <summary>
-        /// Gets or sets the fields to select from the Graph API.
+        /// Gets or sets the properties to select from the Graph API.
         /// </summary>
-        [JsonProperty("FieldsToSelect")]
-        public StringExpression FieldsToSelect { get; set; }
+        [JsonProperty("PropertiesToSelect")]
+        public ArrayExpression<string> PropertiesToSelect { get; set; }
 
         /// <inheritdoc/>
         public override string DeclarativeType => GetPeers.GetPeersDeclarativeType;
@@ -63,7 +63,7 @@ namespace Microsoft.Bot.Component.Graph.Actions
             {
                 { "UserId", manager.Id },
                 { "MaxResults", parameters["MaxResults"] },
-                { "FieldsToSelect", parameters["FieldsToSelect"] },
+                { "PropertiesToSelect", parameters["PropertiesToSelect"] },
             };
 
             GetDirectReports directReportActions = new GetDirectReports();
@@ -89,18 +89,23 @@ namespace Microsoft.Bot.Component.Graph.Actions
             }
 
             // Select minimum of the "id" field from the object
-            string fieldsToSelect = DefaultIdField;
+            string propertiesToSelect = DefaultIdField;
 
-            if (this.FieldsToSelect != null)
+            if (this.PropertiesToSelect != null)
             {
-                fieldsToSelect = this.FieldsToSelect.GetValue(state);
+                List<string> propertiesFound = this.PropertiesToSelect.GetValue(state);
+
+                if (propertiesFound != null && propertiesFound.Count > 0)
+                {
+                    propertiesToSelect = string.Join(",", propertiesFound);
+                }
             }
 
             string userId = this.UserId.GetValue(state);
 
             parameters.Add("UserId", userId);
             parameters.Add("MaxResults", maxCount);
-            parameters.Add("FieldsToSelect", fieldsToSelect);
+            parameters.Add("PropertiesToSelect", propertiesToSelect);
         }
 
         /// <inheritdoc />

--- a/packages/Graph/Actions/User/GetPeers.cs
+++ b/packages/Graph/Actions/User/GetPeers.cs
@@ -63,6 +63,7 @@ namespace Microsoft.Bot.Component.Graph.Actions
             {
                 { "UserId", manager.Id },
                 { "MaxResults", parameters["MaxResults"] },
+                { "FieldsToSelect", parameters["FieldsToSelect"] },
             };
 
             GetDirectReports directReportActions = new GetDirectReports();

--- a/packages/Graph/Actions/User/GetUserProfile.cs
+++ b/packages/Graph/Actions/User/GetUserProfile.cs
@@ -30,6 +30,12 @@ namespace Microsoft.Bot.Component.Graph.Actions
         [JsonProperty("UserId")]
         public StringExpression UserId { get; set; }
 
+        /// <summary>
+        /// Gets or sets the fields to select from the Graph API.
+        /// </summary>
+        [JsonProperty("FieldsToSelect")]
+        public StringExpression FieldsToSelect { get; set; }
+
         /// <inheritdoc/>
         public override string DeclarativeType => GetUserProfile.GetUserProfileDeclarativeType;
 
@@ -55,9 +61,18 @@ namespace Microsoft.Bot.Component.Graph.Actions
                 throw new ArgumentNullException(nameof(this.UserId));
             }
 
+            // Select minimum of the "id" field from the object
+            string fieldsToSelect = DefaultIdField;
+
+            if (this.FieldsToSelect != null)
+            {
+                fieldsToSelect = this.FieldsToSelect.GetValue(state);
+            }
+
             string userId = this.UserId.GetValue(state);
 
             parameters.Add("UserId", userId);
+            parameters.Add("FieldsToSelect", fieldsToSelect);
         }
     }
 }

--- a/packages/Graph/Actions/User/GetUserProfile.cs
+++ b/packages/Graph/Actions/User/GetUserProfile.cs
@@ -43,12 +43,13 @@ namespace Microsoft.Bot.Component.Graph.Actions
         internal override async Task<User> CallGraphServiceWithResultAsync(IGraphServiceClient client, IReadOnlyDictionary<string, object> parameters, CancellationToken cancellationToken)
         {
             string userId = (string)parameters["UserId"];
+            string fieldsToSelect = (string)parameters["FieldsToSelect"];
 
             // TODO: Make this SELECT() clause configurable for different column names
             // EXPLAINER: The reason we are limiting the field is for two reasons:
             //            1. Limit the size of the graph object payload needed to be transferred over the wire
             //            2. Reduces the exposure of end user PII (Personally Identifiable Information) in our system for privacy reasons. It's generally good practice to use what you need.
-            User result = await client.Users[userId].Request().Select("id,displayName,mail,officeLocation,businessPhones,jobTitle,department").GetAsync();
+            User result = await client.Users[userId].Request().Select(fieldsToSelect).GetAsync();
 
             return result;
         }

--- a/packages/Graph/Actions/User/GetUserProfile.cs
+++ b/packages/Graph/Actions/User/GetUserProfile.cs
@@ -45,10 +45,6 @@ namespace Microsoft.Bot.Component.Graph.Actions
             string userId = (string)parameters["UserId"];
             string propertiesToSelect = (string)parameters["PropertiesToSelect"];
 
-            // TODO: Make this SELECT() clause configurable for different column names
-            // EXPLAINER: The reason we are limiting the field is for two reasons:
-            //            1. Limit the size of the graph object payload needed to be transferred over the wire
-            //            2. Reduces the exposure of end user PII (Personally Identifiable Information) in our system for privacy reasons. It's generally good practice to use what you need.
             User result = await client.Users[userId].Request().Select(propertiesToSelect).GetAsync();
 
             return result;

--- a/packages/Graph/Actions/User/GetUserProfile.cs
+++ b/packages/Graph/Actions/User/GetUserProfile.cs
@@ -37,7 +37,12 @@ namespace Microsoft.Bot.Component.Graph.Actions
         internal override async Task<User> CallGraphServiceWithResultAsync(IGraphServiceClient client, IReadOnlyDictionary<string, object> parameters, CancellationToken cancellationToken)
         {
             string userId = (string)parameters["UserId"];
-            User result = await client.Users[userId].Request().GetAsync();
+
+            // TODO: Make this SELECT() clause configurable for different column names
+            // EXPLAINER: The reason we are limiting the field is for two reasons:
+            //            1. Limit the size of the graph object payload needed to be transferred over the wire
+            //            2. Reduces the exposure of end user PII (Personally Identifiable Information) in our system for privacy reasons. It's generally good practice to use what you need.
+            User result = await client.Users[userId].Request().Select("id,displayName,mail,officeLocation,businessPhones,jobTitle,department").GetAsync();
 
             return result;
         }

--- a/packages/Graph/Actions/User/GetUsers.cs
+++ b/packages/Graph/Actions/User/GetUsers.cs
@@ -42,10 +42,10 @@ namespace Microsoft.Bot.Component.Graph.Actions
         public IntExpression MaxCountProperty { get; set; }
 
         /// <summary>
-        /// Gets or sets the fields to select from the Graph API.
+        /// Gets or sets the properties to select from the Graph API.
         /// </summary>
-        [JsonProperty("FieldsToSelect")]
-        public StringExpression FieldsToSelect { get; set; }
+        [JsonProperty("PropertiesToSelect")]
+        public ArrayExpression<string> PropertiesToSelect { get; set; }
 
         /// <inheritdoc/>
         public override string DeclarativeType => GetUsers.FindUsersDeclarativeType;
@@ -55,11 +55,11 @@ namespace Microsoft.Bot.Component.Graph.Actions
         {
             string nameToSearch = (string)parameters["NameToSearch"];
             int maxCount = (int)parameters["MaxResults"];
-            string fieldsToSelect = (string)parameters["FieldsToSelect"];
+            string propertiesToSelect = (string)parameters["PropertiesToSelect"];
 
             string filterClause = $"startsWith(displayName, '{nameToSearch}') or startsWith(surname, '{nameToSearch}') or startsWith(givenname, '{nameToSearch}')";
 
-            IGraphServiceUsersCollectionRequest request = client.Users.Request().Filter(filterClause).Select(fieldsToSelect);
+            IGraphServiceUsersCollectionRequest request = client.Users.Request().Filter(filterClause).Select(propertiesToSelect);
 
             // Apply the Top() filter if there is a value to apply
             if (maxCount > 0)
@@ -88,16 +88,21 @@ namespace Microsoft.Bot.Component.Graph.Actions
             }
 
             // Select minimum of the "id" field from the object
-            string fieldsToSelect = DefaultIdField;
+            string propertiesToSelect = DefaultIdField;
 
-            if (this.FieldsToSelect != null)
+            if (this.PropertiesToSelect != null)
             {
-                fieldsToSelect = this.FieldsToSelect.GetValue(state);
+                List<string> propertiesFound = this.PropertiesToSelect.GetValue(state);
+
+                if (propertiesFound != null && propertiesFound.Count > 0)
+                {
+                    propertiesToSelect = string.Join(",", propertiesFound);
+                }
             }
 
             parameters.Add("NameToSearch", nameToSearch);
             parameters.Add("MaxResults", maxCount);
-            parameters.Add("FieldsToSelect", fieldsToSelect);
+            parameters.Add("PropertiesToSelect", propertiesToSelect);
         }
     }
 }

--- a/packages/Graph/Actions/User/GetUsers.cs
+++ b/packages/Graph/Actions/User/GetUsers.cs
@@ -55,10 +55,11 @@ namespace Microsoft.Bot.Component.Graph.Actions
         {
             string nameToSearch = (string)parameters["NameToSearch"];
             int maxCount = (int)parameters["MaxResults"];
+            string fieldsToSelect = (string)parameters["FieldsToSelect"];
 
             string filterClause = $"startsWith(displayName, '{nameToSearch}') or startsWith(surname, '{nameToSearch}') or startsWith(givenname, '{nameToSearch}')";
 
-            IGraphServiceUsersCollectionRequest request = client.Users.Request().Filter(filterClause).Select("id,displayName,mail,officeLocation,businessPhones,jobTitle,department");
+            IGraphServiceUsersCollectionRequest request = client.Users.Request().Filter(filterClause).Select(fieldsToSelect);
 
             // Apply the Top() filter if there is a value to apply
             if (maxCount > 0)

--- a/packages/Graph/Actions/User/GetUsers.cs
+++ b/packages/Graph/Actions/User/GetUsers.cs
@@ -41,6 +41,12 @@ namespace Microsoft.Bot.Component.Graph.Actions
         [JsonProperty("MaxCount")]
         public IntExpression MaxCountProperty { get; set; }
 
+        /// <summary>
+        /// Gets or sets the fields to select from the Graph API.
+        /// </summary>
+        [JsonProperty("FieldsToSelect")]
+        public StringExpression FieldsToSelect { get; set; }
+
         /// <inheritdoc/>
         public override string DeclarativeType => GetUsers.FindUsersDeclarativeType;
 
@@ -80,8 +86,17 @@ namespace Microsoft.Bot.Component.Graph.Actions
                 maxCount = this.MaxCountProperty.GetValue(state);
             }
 
+            // Select minimum of the "id" field from the object
+            string fieldsToSelect = DefaultIdField;
+
+            if (this.FieldsToSelect != null)
+            {
+                fieldsToSelect = this.FieldsToSelect.GetValue(state);
+            }
+
             parameters.Add("NameToSearch", nameToSearch);
             parameters.Add("MaxResults", maxCount);
+            parameters.Add("FieldsToSelect", fieldsToSelect);
         }
     }
 }

--- a/packages/Graph/Actions/User/GetUsers.cs
+++ b/packages/Graph/Actions/User/GetUsers.cs
@@ -52,7 +52,7 @@ namespace Microsoft.Bot.Component.Graph.Actions
 
             string filterClause = $"startsWith(displayName, '{nameToSearch}') or startsWith(surname, '{nameToSearch}') or startsWith(givenname, '{nameToSearch}')";
 
-            IGraphServiceUsersCollectionRequest request = client.Users.Request().Filter(filterClause);
+            IGraphServiceUsersCollectionRequest request = client.Users.Request().Filter(filterClause).Select("id,displayName,mail,officeLocation,businessPhones,jobTitle,department");
 
             // Apply the Top() filter if there is a value to apply
             if (maxCount > 0)

--- a/packages/Graph/Schemas/Microsoft.Graph.User.GetDirectReports.schema
+++ b/packages/Graph/Schemas/Microsoft.Graph.User.GetDirectReports.schema
@@ -39,9 +39,10 @@
     "fieldsToSelect": {
       "$ref": "schema:#/definitions/stringExpression",
       "title": "Fields To Select",
-      "description": "The fields of from the graph API to select. By default, if not provided only the ID will be returned for the object.",
+      "description": "The fields of from the graph API to select. By default, if not provided only the ID will be returned for the object. You can find more about the fields in https://docs.microsoft.com/en-us/graph/api/resources/user?view=graph-rest-1.0#properties.",
       "examples": [
-        "dialog.fieldsToSelect"
+        "dialog.fieldsToSelect",
+        "id, displayName, mail, officeLocation, jobTitle"
       ]
     },
     "userId": {

--- a/packages/Graph/Schemas/Microsoft.Graph.User.GetDirectReports.schema
+++ b/packages/Graph/Schemas/Microsoft.Graph.User.GetDirectReports.schema
@@ -36,14 +36,18 @@
         "dialog.worksWithMe.maxResults"
       ]
     },
-    "fieldsToSelect": {
-      "$ref": "schema:#/definitions/stringExpression",
+    "propertiesToSelect": {
+      "$ref": "schema:#/definitions/arrayExpression",
       "title": "Fields To Select",
-      "description": "The fields of from the graph API to select. By default, if not provided only the ID will be returned for the object. You can find more about the fields in https://docs.microsoft.com/en-us/graph/api/resources/user?view=graph-rest-1.0#properties.",
+      "description": "The properties of from the graph API to select. By default, if not provided only the ID will be returned for the object. You can find more about the fields in https://docs.microsoft.com/en-us/graph/api/resources/user?view=graph-rest-1.0#properties.",
       "examples": [
-        "dialog.fieldsToSelect",
         "id, displayName, mail, officeLocation, jobTitle"
-      ]
+      ],
+      "items": {
+        "type": "string",
+        "title": "Property",
+        "description": "Property name from the User object to select in Graph API."
+      }
     },
     "userId": {
       "$ref": "schema:#/definitions/stringExpression",

--- a/packages/Graph/Schemas/Microsoft.Graph.User.GetDirectReports.schema
+++ b/packages/Graph/Schemas/Microsoft.Graph.User.GetDirectReports.schema
@@ -38,7 +38,7 @@
     },
     "propertiesToSelect": {
       "$ref": "schema:#/definitions/arrayExpression",
-      "title": "Fields To Select",
+      "title": "User Properties To Select",
       "description": "The properties of from the graph API to select. By default, if not provided only the ID will be returned for the object. You can find more about the fields in https://docs.microsoft.com/en-us/graph/api/resources/user?view=graph-rest-1.0#properties.",
       "examples": [
         "id, displayName, mail, officeLocation, jobTitle"

--- a/packages/Graph/Schemas/Microsoft.Graph.User.GetDirectReports.schema
+++ b/packages/Graph/Schemas/Microsoft.Graph.User.GetDirectReports.schema
@@ -36,6 +36,14 @@
         "dialog.worksWithMe.maxResults"
       ]
     },
+    "fieldsToSelect": {
+      "$ref": "schema:#/definitions/stringExpression",
+      "title": "Fields To Select",
+      "description": "The fields of from the graph API to select. By default, if not provided only the ID will be returned for the object.",
+      "examples": [
+        "dialog.fieldsToSelect"
+      ]
+    },
     "userId": {
       "$ref": "schema:#/definitions/stringExpression",
       "title": "User ID",

--- a/packages/Graph/Schemas/Microsoft.Graph.User.GetManager.schema
+++ b/packages/Graph/Schemas/Microsoft.Graph.User.GetManager.schema
@@ -31,9 +31,10 @@
     "fieldsToSelect": {
       "$ref": "schema:#/definitions/stringExpression",
       "title": "Fields To Select",
-      "description": "The fields of from the graph API to select. By default, if not provided only the ID will be returned for the object.",
+      "description": "The fields of from the graph API to select. By default, if not provided only the ID will be returned for the object. You can find more about the fields in https://docs.microsoft.com/en-us/graph/api/resources/user?view=graph-rest-1.0#properties.",
       "examples": [
-        "dialog.fieldsToSelect"
+        "dialog.fieldsToSelect",
+        "id, displayName, mail, officeLocation, jobTitle"
       ]
     },
     "userId": {

--- a/packages/Graph/Schemas/Microsoft.Graph.User.GetManager.schema
+++ b/packages/Graph/Schemas/Microsoft.Graph.User.GetManager.schema
@@ -28,14 +28,18 @@
         "user.token.token"
       ]
     },
-    "fieldsToSelect": {
-      "$ref": "schema:#/definitions/stringExpression",
+    "propertiesToSelect": {
+      "$ref": "schema:#/definitions/arrayExpression",
       "title": "Fields To Select",
-      "description": "The fields of from the graph API to select. By default, if not provided only the ID will be returned for the object. You can find more about the fields in https://docs.microsoft.com/en-us/graph/api/resources/user?view=graph-rest-1.0#properties.",
+      "description": "The properties of from the graph API to select. By default, if not provided only the ID will be returned for the object. You can find more about the fields in https://docs.microsoft.com/en-us/graph/api/resources/user?view=graph-rest-1.0#properties.",
       "examples": [
-        "dialog.fieldsToSelect",
         "id, displayName, mail, officeLocation, jobTitle"
-      ]
+      ],
+      "items": {
+        "type": "string",
+        "title": "Property",
+        "description": "Property name from the User object to select in Graph API."
+      }
     },
     "userId": {
       "$ref": "schema:#/definitions/stringExpression",

--- a/packages/Graph/Schemas/Microsoft.Graph.User.GetManager.schema
+++ b/packages/Graph/Schemas/Microsoft.Graph.User.GetManager.schema
@@ -28,6 +28,14 @@
         "user.token.token"
       ]
     },
+    "fieldsToSelect": {
+      "$ref": "schema:#/definitions/stringExpression",
+      "title": "Fields To Select",
+      "description": "The fields of from the graph API to select. By default, if not provided only the ID will be returned for the object.",
+      "examples": [
+        "dialog.fieldsToSelect"
+      ]
+    },
     "userId": {
       "$ref": "schema:#/definitions/stringExpression",
       "title": "User ID",

--- a/packages/Graph/Schemas/Microsoft.Graph.User.GetManager.schema
+++ b/packages/Graph/Schemas/Microsoft.Graph.User.GetManager.schema
@@ -30,7 +30,7 @@
     },
     "propertiesToSelect": {
       "$ref": "schema:#/definitions/arrayExpression",
-      "title": "Fields To Select",
+      "title": "User Properties To Select",
       "description": "The properties of from the graph API to select. By default, if not provided only the ID will be returned for the object. You can find more about the fields in https://docs.microsoft.com/en-us/graph/api/resources/user?view=graph-rest-1.0#properties.",
       "examples": [
         "id, displayName, mail, officeLocation, jobTitle"

--- a/packages/Graph/Schemas/Microsoft.Graph.User.GetPeers.schema
+++ b/packages/Graph/Schemas/Microsoft.Graph.User.GetPeers.schema
@@ -36,14 +36,18 @@
         "dialog.peers.maxResults"
       ]
     },
-    "fieldsToSelect": {
-      "$ref": "schema:#/definitions/stringExpression",
+    "propertiesToSelect": {
+      "$ref": "schema:#/definitions/arrayExpression",
       "title": "Fields To Select",
-      "description": "The fields of from the graph API to select. By default, if not provided only the ID will be returned for the object. You can find more about the fields in https://docs.microsoft.com/en-us/graph/api/resources/user?view=graph-rest-1.0#properties.",
+      "description": "The properties of from the graph API to select. By default, if not provided only the ID will be returned for the object. You can find more about the fields in https://docs.microsoft.com/en-us/graph/api/resources/user?view=graph-rest-1.0#properties.",
       "examples": [
-        "dialog.fieldsToSelect",
         "id, displayName, mail, officeLocation, jobTitle"
-      ]
+      ],
+      "items": {
+        "type": "string",
+        "title": "Property",
+        "description": "Property name from the User object to select in Graph API."
+      }
     },
     "userId": {
       "$ref": "schema:#/definitions/stringExpression",

--- a/packages/Graph/Schemas/Microsoft.Graph.User.GetPeers.schema
+++ b/packages/Graph/Schemas/Microsoft.Graph.User.GetPeers.schema
@@ -39,9 +39,10 @@
     "fieldsToSelect": {
       "$ref": "schema:#/definitions/stringExpression",
       "title": "Fields To Select",
-      "description": "The fields of from the graph API to select. By default, if not provided only the ID will be returned for the object.",
+      "description": "The fields of from the graph API to select. By default, if not provided only the ID will be returned for the object. You can find more about the fields in https://docs.microsoft.com/en-us/graph/api/resources/user?view=graph-rest-1.0#properties.",
       "examples": [
-        "dialog.fieldsToSelect"
+        "dialog.fieldsToSelect",
+        "id, displayName, mail, officeLocation, jobTitle"
       ]
     },
     "userId": {

--- a/packages/Graph/Schemas/Microsoft.Graph.User.GetPeers.schema
+++ b/packages/Graph/Schemas/Microsoft.Graph.User.GetPeers.schema
@@ -38,7 +38,7 @@
     },
     "propertiesToSelect": {
       "$ref": "schema:#/definitions/arrayExpression",
-      "title": "Fields To Select",
+      "title": "User Properties To Select",
       "description": "The properties of from the graph API to select. By default, if not provided only the ID will be returned for the object. You can find more about the fields in https://docs.microsoft.com/en-us/graph/api/resources/user?view=graph-rest-1.0#properties.",
       "examples": [
         "id, displayName, mail, officeLocation, jobTitle"

--- a/packages/Graph/Schemas/Microsoft.Graph.User.GetPeers.schema
+++ b/packages/Graph/Schemas/Microsoft.Graph.User.GetPeers.schema
@@ -36,6 +36,14 @@
         "dialog.peers.maxResults"
       ]
     },
+    "fieldsToSelect": {
+      "$ref": "schema:#/definitions/stringExpression",
+      "title": "Fields To Select",
+      "description": "The fields of from the graph API to select. By default, if not provided only the ID will be returned for the object.",
+      "examples": [
+        "dialog.fieldsToSelect"
+      ]
+    },
     "userId": {
       "$ref": "schema:#/definitions/stringExpression",
       "title": "User ID",

--- a/packages/Graph/Schemas/Microsoft.Graph.User.GetUserProfile.schema
+++ b/packages/Graph/Schemas/Microsoft.Graph.User.GetUserProfile.schema
@@ -31,9 +31,10 @@
     "fieldsToSelect": {
       "$ref": "schema:#/definitions/stringExpression",
       "title": "Fields To Select",
-      "description": "The fields of from the graph API to select. By default, if not provided only the ID will be returned for the object.",
+      "description": "The fields of from the graph API to select. By default, if not provided only the ID will be returned for the object. You can find more about the fields in https://docs.microsoft.com/en-us/graph/api/resources/user?view=graph-rest-1.0#properties.",
       "examples": [
-        "dialog.fieldsToSelect"
+        "dialog.fieldsToSelect",
+        "id, displayName, mail, officeLocation, jobTitle"
       ]
     },
     "userId": {

--- a/packages/Graph/Schemas/Microsoft.Graph.User.GetUserProfile.schema
+++ b/packages/Graph/Schemas/Microsoft.Graph.User.GetUserProfile.schema
@@ -28,14 +28,18 @@
         "user.token.token"
       ]
     },
-    "fieldsToSelect": {
-      "$ref": "schema:#/definitions/stringExpression",
+    "propertiesToSelect": {
+      "$ref": "schema:#/definitions/arrayExpression",
       "title": "Fields To Select",
-      "description": "The fields of from the graph API to select. By default, if not provided only the ID will be returned for the object. You can find more about the fields in https://docs.microsoft.com/en-us/graph/api/resources/user?view=graph-rest-1.0#properties.",
+      "description": "The properties of from the graph API to select. By default, if not provided only the ID will be returned for the object. You can find more about the fields in https://docs.microsoft.com/en-us/graph/api/resources/user?view=graph-rest-1.0#properties.",
       "examples": [
-        "dialog.fieldsToSelect",
         "id, displayName, mail, officeLocation, jobTitle"
-      ]
+      ],
+      "items": {
+        "type": "string",
+        "title": "Property",
+        "description": "Property name from the User object to select in Graph API."
+      }
     },
     "userId": {
       "$ref": "schema:#/definitions/stringExpression",

--- a/packages/Graph/Schemas/Microsoft.Graph.User.GetUserProfile.schema
+++ b/packages/Graph/Schemas/Microsoft.Graph.User.GetUserProfile.schema
@@ -28,6 +28,14 @@
         "user.token.token"
       ]
     },
+    "fieldsToSelect": {
+      "$ref": "schema:#/definitions/stringExpression",
+      "title": "Fields To Select",
+      "description": "The fields of from the graph API to select. By default, if not provided only the ID will be returned for the object.",
+      "examples": [
+        "dialog.fieldsToSelect"
+      ]
+    },
     "userId": {
       "$ref": "schema:#/definitions/stringExpression",
       "title": "User ID",

--- a/packages/Graph/Schemas/Microsoft.Graph.User.GetUserProfile.schema
+++ b/packages/Graph/Schemas/Microsoft.Graph.User.GetUserProfile.schema
@@ -30,7 +30,7 @@
     },
     "propertiesToSelect": {
       "$ref": "schema:#/definitions/arrayExpression",
-      "title": "Fields To Select",
+      "title": "User Properties To Select",
       "description": "The properties of from the graph API to select. By default, if not provided only the ID will be returned for the object. You can find more about the fields in https://docs.microsoft.com/en-us/graph/api/resources/user?view=graph-rest-1.0#properties.",
       "examples": [
         "id, displayName, mail, officeLocation, jobTitle"

--- a/packages/Graph/Schemas/Microsoft.Graph.User.GetUsers.schema
+++ b/packages/Graph/Schemas/Microsoft.Graph.User.GetUsers.schema
@@ -36,6 +36,14 @@
         "dialog.worksWithMe.maxResults"
       ]
     },
+    "fieldsToSelect": {
+      "$ref": "schema:#/definitions/stringExpression",
+      "title": "Fields To Select",
+      "description": "The fields of from the graph API to select. By default, if not provided only the ID will be returned for the object.",
+      "examples": [
+        "dialog.fieldsToSelect"
+      ]
+    },
     "nameToSearchFor": {
       "$ref": "schema:#/definitions/stringExpression",
       "title": "Search Name",

--- a/packages/Graph/Schemas/Microsoft.Graph.User.GetUsers.schema
+++ b/packages/Graph/Schemas/Microsoft.Graph.User.GetUsers.schema
@@ -39,9 +39,10 @@
     "fieldsToSelect": {
       "$ref": "schema:#/definitions/stringExpression",
       "title": "Fields To Select",
-      "description": "The fields of from the graph API to select. By default, if not provided only the ID will be returned for the object.",
+      "description": "The fields of from the graph API to select. By default, if not provided only the ID will be returned for the object. You can find more about the fields in https://docs.microsoft.com/en-us/graph/api/resources/user?view=graph-rest-1.0#properties.",
       "examples": [
-        "dialog.fieldsToSelect"
+        "dialog.fieldsToSelect",
+        "id, displayName, mail, officeLocation, jobTitle"
       ]
     },
     "nameToSearchFor": {

--- a/packages/Graph/Schemas/Microsoft.Graph.User.GetUsers.schema
+++ b/packages/Graph/Schemas/Microsoft.Graph.User.GetUsers.schema
@@ -38,7 +38,7 @@
     },
     "propertiesToSelect": {
       "$ref": "schema:#/definitions/arrayExpression",
-      "title": "Graph API User Properties To Select",
+      "title": "User Properties To Select",
       "description": "The properties of from the graph API to select. By default, if not provided only the ID will be returned for the object. You can find more about the fields in https://docs.microsoft.com/en-us/graph/api/resources/user?view=graph-rest-1.0#properties.",
       "examples": [
         "id, displayName, mail, officeLocation, jobTitle"

--- a/packages/Graph/Schemas/Microsoft.Graph.User.GetUsers.schema
+++ b/packages/Graph/Schemas/Microsoft.Graph.User.GetUsers.schema
@@ -36,22 +36,26 @@
         "dialog.worksWithMe.maxResults"
       ]
     },
-    "fieldsToSelect": {
-      "$ref": "schema:#/definitions/stringExpression",
-      "title": "Fields To Select",
-      "description": "The fields of from the graph API to select. By default, if not provided only the ID will be returned for the object. You can find more about the fields in https://docs.microsoft.com/en-us/graph/api/resources/user?view=graph-rest-1.0#properties.",
+    "propertiesToSelect": {
+      "$ref": "schema:#/definitions/arrayExpression",
+      "title": "Graph API User Properties To Select",
+      "description": "The properties of from the graph API to select. By default, if not provided only the ID will be returned for the object. You can find more about the fields in https://docs.microsoft.com/en-us/graph/api/resources/user?view=graph-rest-1.0#properties.",
       "examples": [
-        "dialog.fieldsToSelect",
         "id, displayName, mail, officeLocation, jobTitle"
-      ]
-    },
-    "nameToSearchFor": {
-      "$ref": "schema:#/definitions/stringExpression",
-      "title": "Search Name",
-      "description": "Name of the user",
-      "examples": [
-        "dialog.user.name"
-      ]
+      ],
+      "items": {
+        "type": "string",
+        "title": "Property",
+        "description": "Property name from the User object to select in Graph API."
+        }
+      },
+      "nameToSearchFor": {
+        "$ref": "schema:#/definitions/stringExpression",
+        "title": "Search Name",
+        "description": "Name of the user",
+        "examples": [
+          "dialog.user.name"
+        ]
+      }
     }
-  }
 }

--- a/skills/declarative/tests/whoSkill/WhoSkillTestBase.cs
+++ b/skills/declarative/tests/whoSkill/WhoSkillTestBase.cs
@@ -39,6 +39,7 @@ namespace Microsoft.Bot.Dialogs.Tests.WhoSkill
             this.testGraphClient = new Mock<IGraphServiceClient>();
             this.TestUsers = new List<User>();
 
+            this.SetupMe();
             this.SetupSearch();
 
             MSGraphClient.RegisterTestInstance(this.testGraphClient.Object);
@@ -84,6 +85,7 @@ namespace Microsoft.Bot.Dialogs.Tests.WhoSkill
 
             var userRequest = new Mock<IUserRequest>();
             userRequest.Setup(req => req.GetAsync()).ReturnsAsync(profile);
+            userRequest.Setup(req => req.Select(It.IsAny<string>())).Returns(userRequest.Object);
             userRequestBuilder.Setup(req => req.Request()).Returns(userRequest.Object);
 
             // Attach manager
@@ -98,6 +100,8 @@ namespace Microsoft.Bot.Dialogs.Tests.WhoSkill
                 // Simulate manager not found
                 managerDirectoryRequest.Setup(req => req.GetAsync(It.IsAny<CancellationToken>())).ThrowsAsync(new ServiceException(new Error(), null, System.Net.HttpStatusCode.NotFound));
             }
+
+            managerDirectoryRequest.Setup(req => req.Select(It.IsAny<string>())).Returns(managerDirectoryRequest.Object);
 
             var managerDirectoryRequestBuilder = new Mock<IDirectoryObjectWithReferenceRequestBuilder>();
             managerDirectoryRequestBuilder.Setup(req => req.Request()).Returns(managerDirectoryRequest.Object);
@@ -119,6 +123,7 @@ namespace Microsoft.Bot.Dialogs.Tests.WhoSkill
             }
 
             directReportsDirectoryRequest.Setup(req => req.Top(It.IsAny<int>())).Returns(directReportsDirectoryRequest.Object);
+            directReportsDirectoryRequest.Setup(req => req.Select(It.IsAny<string>())).Returns(directReportsDirectoryRequest.Object);
 
             var directReportsDirectoryRequestBuilder = new Mock<IUserDirectReportsCollectionWithReferencesRequestBuilder>();
             directReportsDirectoryRequestBuilder.Setup(req => req.Request()).Returns(directReportsDirectoryRequest.Object);
@@ -157,6 +162,19 @@ namespace Microsoft.Bot.Dialogs.Tests.WhoSkill
             this.testGraphClient.SetupGet(client => client.Users[profile.Id]).Returns(userRequestBuilder.Object);
         }
 
+        private void SetupMe()
+        {
+            User me = this.AddUserProfile("Test User", "testuser@contoso.com", "123-123-1234", "Moon", "Astronaut", false);
+
+            Mock<IUserRequest> userRequest = new Mock<IUserRequest>();
+            userRequest.Setup(req => req.GetAsync(It.IsAny<CancellationToken>())).ReturnsAsync(me);
+
+            Mock<IUserRequestBuilder> userRequestBuilder = new Mock<IUserRequestBuilder>();
+            userRequestBuilder.Setup(req => req.Request()).Returns(userRequest.Object);
+
+            this.testGraphClient.SetupGet(client => client.Me).Returns(userRequestBuilder.Object);
+        }
+
         /// <summary>
         /// Sets up the search scenario
         /// </summary>
@@ -168,6 +186,7 @@ namespace Microsoft.Bot.Dialogs.Tests.WhoSkill
             var usersSearchRequest = new Mock<IGraphServiceUsersCollectionRequest>();
             usersSearchRequest.Setup(req => req.Top(It.IsAny<int>())).Returns(usersSearchRequest.Object);
             usersSearchRequest.Setup(req => req.Filter(It.IsAny<string>())).Returns(usersSearchRequest.Object);
+            usersSearchRequest.Setup(req => req.Select(It.IsAny<string>())).Returns(usersSearchRequest.Object);
             usersSearchRequest.Setup(req => req.GetAsync(It.IsAny<CancellationToken>())).ReturnsAsync(usersSearchResultPage.Object);
 
             var usersSearchRequestBuilder = new Mock<IGraphServiceUsersCollectionRequestBuilder>();

--- a/skills/declarative/tests/whoSkill/WhoSkillTestBase.cs
+++ b/skills/declarative/tests/whoSkill/WhoSkillTestBase.cs
@@ -162,6 +162,9 @@ namespace Microsoft.Bot.Dialogs.Tests.WhoSkill
             this.testGraphClient.SetupGet(client => client.Users[profile.Id]).Returns(userRequestBuilder.Object);
         }
 
+        /// <summary>
+        /// Setup the "Me" call to get user profile after authentication
+        /// </summary>
         private void SetupMe()
         {
             User me = this.AddUserProfile("Test User", "testuser@contoso.com", "123-123-1234", "Moon", "Astronaut", false);

--- a/skills/declarative/whoSkill/whoSkill.sln
+++ b/skills/declarative/whoSkill/whoSkill.sln
@@ -6,6 +6,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "whoSkill", "whoSkill\whoSki
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Components.Graph", "..\..\..\packages\Graph\Microsoft.Bot.Components.Graph.csproj", "{D6C573B9-7439-4444-9DB2-E4E2A9F6D126}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Dialogs.Tests.WhoSkill", "..\tests\whoSkill\Microsoft.Bot.Dialogs.Tests.WhoSkill.csproj", "{074C9866-C5B6-4728-99E4-76B5DDEB9631}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Dialogs.Tests.Common", "..\tests\common\Microsoft.Bot.Dialogs.Tests.Common.csproj", "{D0B26020-2612-4534-93D8-BF8A84695B57}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -20,6 +24,14 @@ Global
 		{D6C573B9-7439-4444-9DB2-E4E2A9F6D126}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D6C573B9-7439-4444-9DB2-E4E2A9F6D126}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D6C573B9-7439-4444-9DB2-E4E2A9F6D126}.Release|Any CPU.Build.0 = Release|Any CPU
+		{074C9866-C5B6-4728-99E4-76B5DDEB9631}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{074C9866-C5B6-4728-99E4-76B5DDEB9631}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{074C9866-C5B6-4728-99E4-76B5DDEB9631}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{074C9866-C5B6-4728-99E4-76B5DDEB9631}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D0B26020-2612-4534-93D8-BF8A84695B57}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D0B26020-2612-4534-93D8-BF8A84695B57}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D0B26020-2612-4534-93D8-BF8A84695B57}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D0B26020-2612-4534-93D8-BF8A84695B57}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/skills/declarative/whoSkill/whoSkill/Controllers/BotController.cs
+++ b/skills/declarative/whoSkill/whoSkill/Controllers/BotController.cs
@@ -4,10 +4,12 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Bot.Builder;
-using Microsoft.Bot.Builder.Integration.AspNet.Core;
 using Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.Settings;
+using Microsoft.Bot.Builder.Integration.AspNet.Core;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
 
-namespace whoSkill.Controllers
+namespace whoSkill
 {
     // This ASP Controller is created to handle a request. Dependency Injection will provide the Adapter and IBot
     // implementation at runtime. Multiple different IBot implementations running at different endpoints can be
@@ -17,17 +19,23 @@ namespace whoSkill.Controllers
     {
         private readonly Dictionary<string, IBotFrameworkHttpAdapter> _adapters = new Dictionary<string, IBotFrameworkHttpAdapter>();
         private readonly IBot _bot;
+        private readonly ILogger<BotController> _logger;
 
         public BotController(
+            IConfiguration configuration,
             IEnumerable<IBotFrameworkHttpAdapter> adapters,
-            IEnumerable<AdapterSettings> adapterSettings,
-            IBot bot)
+            IBot bot,
+            ILogger<BotController> logger)
         {
             _bot = bot ?? throw new ArgumentNullException(nameof(bot));
+            _logger = logger;
+
+            var adapterSettings = configuration.GetSection(AdapterSettings.AdapterSettingsKey).Get<List<AdapterSettings>>() ?? new List<AdapterSettings>();
+            adapterSettings.Add(AdapterSettings.CoreBotAdapterSettings);
 
             foreach (var adapter in adapters ?? throw new ArgumentNullException(nameof(adapters)))
             {
-                var settings = adapterSettings.FirstOrDefault(s => s.Enabled && s.Name == adapter.GetType().FullName);
+                var settings = adapterSettings.FirstOrDefault(s => s.Enabled && s.Type == adapter.GetType().FullName);
 
                 if (settings != null)
                 {
@@ -43,17 +51,24 @@ namespace whoSkill.Controllers
         {
             if (string.IsNullOrEmpty(route))
             {
+                _logger.LogError($"PostAsync: No route provided.");
                 throw new ArgumentNullException(nameof(route));
             }
 
             if (_adapters.TryGetValue(route, out IBotFrameworkHttpAdapter adapter))
             {
+                if (_logger.IsEnabled(LogLevel.Debug))
+                {
+                    _logger.LogInformation($"PostAsync: routed '{route}' to {adapter.GetType().Name}");
+                }
+
                 // Delegate the processing of the HTTP POST to the appropriate adapter.
                 // The adapter will invoke the bot.
                 await adapter.ProcessAsync(Request, Response, _bot).ConfigureAwait(false);
             }
             else
             {
+                _logger.LogError($"PostAsync: No adapter registered and enabled for route {route}.");
                 throw new KeyNotFoundException($"No adapter registered and enabled for route {route}.");
             }
         }

--- a/skills/declarative/whoSkill/whoSkill/Controllers/SkillController.cs
+++ b/skills/declarative/whoSkill/whoSkill/Controllers/SkillController.cs
@@ -3,33 +3,40 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Builder.Integration.AspNet.Core;
-using Microsoft.Bot.Builder.Skills;
 using Microsoft.Bot.Schema;
+using Microsoft.Extensions.Logging;
 
-namespace whoSkill.Controllers
+namespace whoSkill
 {
     /// <summary>
     /// A controller that handles skill replies to the bot.
-    /// This example uses the <see cref="SkillHandler"/> that is registered as a <see cref="ChannelServiceHandler"/> in startup.cs.
     /// </summary>
     [ApiController]
     [Route("api/skills")]
     public class SkillController : ChannelServiceController
     {
-        public SkillController(ChannelServiceHandler handler)
+        private readonly ILogger<SkillController> _logger;
+
+        public SkillController(ChannelServiceHandlerBase handler, ILogger<SkillController> logger)
             : base(handler)
         {
+            _logger = logger;
         }
 
         public override Task<IActionResult> ReplyToActivityAsync(string conversationId, string activityId, Activity activity)
         {
             try
             {
+                if (_logger.IsEnabled(LogLevel.Debug))
+                {
+                    _logger.LogDebug($"ReplyToActivityAsync: conversationId={conversationId}, activityId={activityId}");
+                }
+
                 return base.ReplyToActivityAsync(conversationId, activityId, activity);
             }
             catch (Exception ex)
             {
-                Console.WriteLine(ex);
+                _logger.LogError(ex, $"ReplyToActivityAsync: {ex}");
                 throw;
             }
         }
@@ -38,11 +45,16 @@ namespace whoSkill.Controllers
         {
             try
             {
+                if (_logger.IsEnabled(LogLevel.Debug))
+                {
+                    _logger.LogDebug($"SendToConversationAsync: conversationId={conversationId}");
+                }
+
                 return base.SendToConversationAsync(conversationId, activity);
             }
             catch (Exception ex)
             {
-                Console.WriteLine(ex);
+                _logger.LogError(ex, $"SendToConversationAsync: {ex}");
                 throw;
             }
         }

--- a/skills/declarative/whoSkill/whoSkill/Program.cs
+++ b/skills/declarative/whoSkill/whoSkill/Program.cs
@@ -17,8 +17,8 @@ namespace whoSkill
             Host.CreateDefaultBuilder(args)
                 .ConfigureAppConfiguration((hostingContext, builder) =>
                 {
-                    string applicationRoot = AppDomain.CurrentDomain.BaseDirectory;
-                    string settingsDirectory = "settings";
+                    var applicationRoot = AppDomain.CurrentDomain.BaseDirectory;
+                    var settingsDirectory = "settings";
 
                     builder.AddBotRuntimeConfiguration(applicationRoot, settingsDirectory);
 

--- a/skills/declarative/whoSkill/whoSkill/Startup.cs
+++ b/skills/declarative/whoSkill/whoSkill/Startup.cs
@@ -1,11 +1,9 @@
-using System.Linq;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.Bot.Builder;
-using Microsoft.Bot.Builder.Integration.AspNet.Core;
 using Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.Extensions;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
 
 namespace whoSkill
 {
@@ -13,7 +11,7 @@ namespace whoSkill
     {
         public Startup(IConfiguration configuration)
         {
-            this.Configuration = configuration;
+            Configuration = configuration;
         }
 
         public IConfiguration Configuration { get; }
@@ -22,36 +20,25 @@ namespace whoSkill
         public void ConfigureServices(IServiceCollection services)
         {
             services.AddControllers().AddNewtonsoftJson();
-            services.AddBotRuntime(this.Configuration);
-
-            // The workaround below will be removed with next SDK patch, when this bug fix gets released: https://github.com/microsoft/botbuilder-dotnet/issues/5239
-            // In the meantime, we're guaranteed to have CoreAdapter registered as IBotFrameworkHttpAdapter, so look it up and register it as BotAdapter.
-            RegisterCoreBotAdapter(services);
+            services.AddBotRuntime(Configuration);
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-#pragma warning disable CA1801 // Review unused parameters
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
-#pragma warning restore CA1801 // Review unused parameters
         {
+            if (env.IsDevelopment())
+            {
+                app.UseDeveloperExceptionPage();
+            }
+
             app.UseDefaultFiles();
             app.UseStaticFiles();
             app.UseWebSockets();
-            app.UseRouting()
-               .UseEndpoints(endpoints =>
-               {
-                   endpoints.MapControllers();
-               });
-        }
-
-        private static void RegisterCoreBotAdapter(IServiceCollection services)
-        {
-            const string coreBotAdapterName = "CoreBotAdapter";
-
-            services.AddSingleton(sp =>
+            app.UseRouting();
+            app.UseAuthorization();
+            app.UseEndpoints(endpoints =>
             {
-                var adapters = sp.GetServices<IBotFrameworkHttpAdapter>();
-                return (BotAdapter)adapters.Single(a => typeof(BotAdapter).IsAssignableFrom(a.GetType()) && a.GetType().Name.Contains(coreBotAdapterName));
+                endpoints.MapControllers();
             });
         }
     }

--- a/skills/declarative/whoSkill/whoSkill/dialogs/WhoIsDirectReportDialog/WhoIsDirectReportDialog.dialog
+++ b/skills/declarative/whoSkill/whoSkill/dialogs/WhoIsDirectReportDialog/WhoIsDirectReportDialog.dialog
@@ -40,7 +40,8 @@
               },
               "resultProperty": "$UserFound",
               "token": "=user.token.token",
-              "userId": "=$UserFound"
+              "userId": "=$UserFound",
+              "fieldsToSelect": "id,displayName,mail,businessPhones,department,jobTitle,officeLocation"
             }
           ],
           "actions": [
@@ -98,7 +99,8 @@
           "resultProperty": "$Result",
           "token": "=user.token.token",
           "userId": "=$UserFound.Id",
-          "maxCount": 15
+          "maxCount": 15,
+          "fieldsToSelect": "id,displayName,mail,businessPhones,department,jobTitle,officeLocation"
         },
         {
           "$kind": "Microsoft.BeginDialog",

--- a/skills/declarative/whoSkill/whoSkill/dialogs/WhoIsDirectReportDialog/WhoIsDirectReportDialog.dialog
+++ b/skills/declarative/whoSkill/whoSkill/dialogs/WhoIsDirectReportDialog/WhoIsDirectReportDialog.dialog
@@ -41,7 +41,15 @@
               "resultProperty": "$UserFound",
               "token": "=user.token.token",
               "userId": "=$UserFound",
-              "fieldsToSelect": "id,displayName,mail,businessPhones,department,jobTitle,officeLocation"
+              "propertiesToSelect": [
+                "id",
+                "displayName",
+                "mail",
+                "businessPhones",
+                "department",
+                "jobTitle",
+                "officeLocation"
+              ]
             }
           ],
           "actions": [
@@ -100,7 +108,15 @@
           "token": "=user.token.token",
           "userId": "=$UserFound.Id",
           "maxCount": 15,
-          "fieldsToSelect": "id,displayName,mail,businessPhones,department,jobTitle,officeLocation"
+          "propertiesToSelect": [
+            "id",
+            "displayName",
+            "mail",
+            "businessPhones",
+            "department",
+            "jobTitle",
+            "officeLocation"
+          ]
         },
         {
           "$kind": "Microsoft.BeginDialog",

--- a/skills/declarative/whoSkill/whoSkill/dialogs/WhoIsManagerDialog/WhoIsManagerDialog.dialog
+++ b/skills/declarative/whoSkill/whoSkill/dialogs/WhoIsManagerDialog/WhoIsManagerDialog.dialog
@@ -55,7 +55,15 @@
               "resultProperty": "$UserFound",
               "token": "=user.token.token",
               "userId": "=$UserFound",
-              "fieldsToSelect": "id,displayName,mail,businessPhones,department,jobTitle,officeLocation"
+              "propertiesToSelect": [
+                "id",
+                "displayName",
+                "mail",
+                "businessPhones",
+                "department",
+                "jobTitle",
+                "officeLocation"
+              ]
             }
           ]
         },
@@ -99,7 +107,15 @@
           "resultProperty": "$Result",
           "token": "=user.token.token",
           "userId": "=$UserFound.id",
-          "fieldsToSelect": "id,displayName,mail,businessPhones,department,jobTitle,officeLocation"
+          "propertiesToSelect": [
+            "id",
+            "displayName",
+            "mail",
+            "businessPhones",
+            "department",
+            "jobTitle",
+            "officeLocation"
+          ]
         },
         {
           "$kind": "Microsoft.IfCondition",

--- a/skills/declarative/whoSkill/whoSkill/dialogs/WhoIsManagerDialog/WhoIsManagerDialog.dialog
+++ b/skills/declarative/whoSkill/whoSkill/dialogs/WhoIsManagerDialog/WhoIsManagerDialog.dialog
@@ -54,7 +54,8 @@
               },
               "resultProperty": "$UserFound",
               "token": "=user.token.token",
-              "userId": "=$UserFound"
+              "userId": "=$UserFound",
+              "fieldsToSelect": "id,displayName,mail,businessPhones,department,jobTitle,officeLocation"
             }
           ]
         },
@@ -97,7 +98,8 @@
           },
           "resultProperty": "$Result",
           "token": "=user.token.token",
-          "userId": "=$UserFound.id"
+          "userId": "=$UserFound.id",
+          "fieldsToSelect": "id,displayName,mail,businessPhones,department,jobTitle,officeLocation"
         },
         {
           "$kind": "Microsoft.IfCondition",

--- a/skills/declarative/whoSkill/whoSkill/dialogs/WhoIsPeerDialog/WhoIsPeerDialog.dialog
+++ b/skills/declarative/whoSkill/whoSkill/dialogs/WhoIsPeerDialog/WhoIsPeerDialog.dialog
@@ -39,7 +39,15 @@
               "resultProperty": "$UserFound",
               "token": "=user.token.token",
               "userId": "=$UserFound",
-              "fieldsToSelect": "id,displayName,mail,businessPhones,department,jobTitle,officeLocation"
+              "propertiesToSelect": [
+                "id",
+                "displayName",
+                "mail",
+                "businessPhones",
+                "department",
+                "jobTitle",
+                "officeLocation"
+              ]
             }
           ],
           "actions": [
@@ -98,7 +106,15 @@
           "token": "=user.token.token",
           "userId": "=$UserFound.Id",
           "maxCount": 15,
-          "fieldsToSelect": "id,displayName,mail,businessPhones,department,jobTitle,officeLocation"
+          "propertiesToSelect": [
+            "id",
+            "displayName",
+            "mail",
+            "businessPhones",
+            "department",
+            "jobTitle",
+            "officeLocation"
+          ]
         },
         {
           "$kind": "Microsoft.BeginDialog",

--- a/skills/declarative/whoSkill/whoSkill/dialogs/WhoIsPeerDialog/WhoIsPeerDialog.dialog
+++ b/skills/declarative/whoSkill/whoSkill/dialogs/WhoIsPeerDialog/WhoIsPeerDialog.dialog
@@ -38,7 +38,8 @@
               },
               "resultProperty": "$UserFound",
               "token": "=user.token.token",
-              "userId": "=$UserFound"
+              "userId": "=$UserFound",
+              "fieldsToSelect": "id,displayName,mail,businessPhones,department,jobTitle,officeLocation"
             }
           ],
           "actions": [
@@ -96,7 +97,8 @@
           "resultProperty": "dialog.Result",
           "token": "=user.token.token",
           "userId": "=$UserFound.Id",
-          "maxCount": 15
+          "maxCount": 15,
+          "fieldsToSelect": "id,displayName,mail,businessPhones,department,jobTitle,officeLocation"
         },
         {
           "$kind": "Microsoft.BeginDialog",

--- a/skills/declarative/whoSkill/whoSkill/dialogs/WhoIsPersonDialog/WhoIsPersonDialog.dialog
+++ b/skills/declarative/whoSkill/whoSkill/dialogs/WhoIsPersonDialog/WhoIsPersonDialog.dialog
@@ -99,7 +99,15 @@
               "token": "=user.token.token",
               "userId": "=$UserFound.Id",
               "resultProperty": "dialog.Result",
-              "fieldsToSelect": "id,displayName,mail,businessPhones,department,jobTitle,officeLocation"
+              "propertiesToSelect": [
+                "id",
+                "displayName",
+                "mail",
+                "businessPhones",
+                "department",
+                "jobTitle",
+                "officeLocation"
+              ]
             },
             {
               "$kind": "Microsoft.TraceActivity",

--- a/skills/declarative/whoSkill/whoSkill/dialogs/WhoIsPersonDialog/WhoIsPersonDialog.dialog
+++ b/skills/declarative/whoSkill/whoSkill/dialogs/WhoIsPersonDialog/WhoIsPersonDialog.dialog
@@ -98,7 +98,8 @@
               },
               "token": "=user.token.token",
               "userId": "=$UserFound.Id",
-              "resultProperty": "dialog.Result"
+              "resultProperty": "dialog.Result",
+              "fieldsToSelect": "id,displayName,mail,businessPhones,department,jobTitle,officeLocation"
             },
             {
               "$kind": "Microsoft.TraceActivity",

--- a/skills/declarative/whoSkill/whoSkill/dialogs/WhoWorksWithMeDialog/WhoWorksWithMeDialog.dialog
+++ b/skills/declarative/whoSkill/whoSkill/dialogs/WhoWorksWithMeDialog/WhoWorksWithMeDialog.dialog
@@ -55,7 +55,15 @@
               "resultProperty": "$UserFound",
               "token": "=user.token.token",
               "userId": "=$UserFound",
-              "fieldsToSelect": "id,displayName,mail,businessPhones,department,jobTitle,officeLocation"
+              "propertiesToSelect": [
+                "id",
+                "displayName",
+                "mail",
+                "businessPhones",
+                "department",
+                "jobTitle",
+                "officeLocation"
+              ]
             }
           ]
         },

--- a/skills/declarative/whoSkill/whoSkill/dialogs/WhoWorksWithMeDialog/WhoWorksWithMeDialog.dialog
+++ b/skills/declarative/whoSkill/whoSkill/dialogs/WhoWorksWithMeDialog/WhoWorksWithMeDialog.dialog
@@ -54,7 +54,8 @@
               },
               "resultProperty": "$UserFound",
               "token": "=user.token.token",
-              "userId": "=$UserFound"
+              "userId": "=$UserFound",
+              "fieldsToSelect": "id,displayName,mail,businessPhones,department,jobTitle,officeLocation"
             }
           ]
         },

--- a/skills/declarative/whoSkill/whoSkill/schemas/sdk.schema
+++ b/skills/declarative/whoSkill/whoSkill/schemas/sdk.schema
@@ -4864,6 +4864,14 @@
             "dialog.peers.maxResults"
           ]
         },
+        "fieldsToSelect": {
+          "$ref": "#/definitions/stringExpression",
+          "title": "Fields To Select",
+          "description": "The fields of from the graph API to select. By default, if not provided only the ID will be returned for the object.",
+          "examples": [
+            "dialog.fieldsToSelect"
+          ]
+        },
         "userId": {
           "$ref": "#/definitions/stringExpression",
           "title": "User ID",

--- a/skills/declarative/whoSkill/whoSkill/schemas/sdk.schema
+++ b/skills/declarative/whoSkill/whoSkill/schemas/sdk.schema
@@ -4722,6 +4722,14 @@
             "dialog.worksWithMe.maxResults"
           ]
         },
+        "fieldsToSelect": {
+          "$ref": "#/definitions/stringExpression",
+          "title": "Fields To Select",
+          "description": "The fields of from the graph API to select. By default, if not provided only the ID will be returned for the object.",
+          "examples": [
+            "dialog.fieldsToSelect"
+          ]
+        },
         "userId": {
           "$ref": "#/definitions/stringExpression",
           "title": "User ID",
@@ -4779,6 +4787,14 @@
           "description": "Microsoft Graph API authentication token.",
           "examples": [
             "user.token.token"
+          ]
+        },
+        "fieldsToSelect": {
+          "$ref": "#/definitions/stringExpression",
+          "title": "Fields To Select",
+          "description": "The fields of from the graph API to select. By default, if not provided only the ID will be returned for the object.",
+          "examples": [
+            "dialog.fieldsToSelect"
           ]
         },
         "userId": {
@@ -4957,6 +4973,14 @@
             "user.token.token"
           ]
         },
+        "fieldsToSelect": {
+          "$ref": "#/definitions/stringExpression",
+          "title": "Fields To Select",
+          "description": "The fields of from the graph API to select. By default, if not provided only the ID will be returned for the object.",
+          "examples": [
+            "dialog.fieldsToSelect"
+          ]
+        },
         "userId": {
           "$ref": "#/definitions/stringExpression",
           "title": "User ID",
@@ -5022,6 +5046,14 @@
           "description": "Max number of results to return",
           "examples": [
             "dialog.worksWithMe.maxResults"
+          ]
+        },
+        "fieldsToSelect": {
+          "$ref": "#/definitions/stringExpression",
+          "title": "Fields To Select",
+          "description": "The fields of from the graph API to select. By default, if not provided only the ID will be returned for the object.",
+          "examples": [
+            "dialog.fieldsToSelect"
           ]
         },
         "nameToSearchFor": {

--- a/skills/declarative/whoSkill/whoSkill/schemas/sdk.schema
+++ b/skills/declarative/whoSkill/whoSkill/schemas/sdk.schema
@@ -4722,14 +4722,18 @@
             "dialog.worksWithMe.maxResults"
           ]
         },
-        "fieldsToSelect": {
-          "$ref": "#/definitions/stringExpression",
-          "title": "Fields To Select",
-          "description": "The fields of from the graph API to select. By default, if not provided only the ID will be returned for the object. You can find more about the fields in https://docs.microsoft.com/en-us/graph/api/resources/user?view=graph-rest-1.0#properties.",
+        "propertiesToSelect": {
+          "$ref": "#/definitions/arrayExpression",
+          "title": "User Properties To Select",
+          "description": "The properties of from the graph API to select. By default, if not provided only the ID will be returned for the object. You can find more about the fields in https://docs.microsoft.com/en-us/graph/api/resources/user?view=graph-rest-1.0#properties.",
           "examples": [
-            "dialog.fieldsToSelect",
             "id, displayName, mail, officeLocation, jobTitle"
-          ]
+          ],
+          "items": {
+            "type": "string",
+            "title": "Property",
+            "description": "Property name from the User object to select in Graph API."
+          }
         },
         "userId": {
           "$ref": "#/definitions/stringExpression",
@@ -4790,14 +4794,18 @@
             "user.token.token"
           ]
         },
-        "fieldsToSelect": {
-          "$ref": "#/definitions/stringExpression",
-          "title": "Fields To Select",
-          "description": "The fields of from the graph API to select. By default, if not provided only the ID will be returned for the object. You can find more about the fields in https://docs.microsoft.com/en-us/graph/api/resources/user?view=graph-rest-1.0#properties.",
+        "propertiesToSelect": {
+          "$ref": "#/definitions/arrayExpression",
+          "title": "User Properties To Select",
+          "description": "The properties of from the graph API to select. By default, if not provided only the ID will be returned for the object. You can find more about the fields in https://docs.microsoft.com/en-us/graph/api/resources/user?view=graph-rest-1.0#properties.",
           "examples": [
-            "dialog.fieldsToSelect",
             "id, displayName, mail, officeLocation, jobTitle"
-          ]
+          ],
+          "items": {
+            "type": "string",
+            "title": "Property",
+            "description": "Property name from the User object to select in Graph API."
+          }
         },
         "userId": {
           "$ref": "#/definitions/stringExpression",
@@ -4866,14 +4874,18 @@
             "dialog.peers.maxResults"
           ]
         },
-        "fieldsToSelect": {
-          "$ref": "#/definitions/stringExpression",
-          "title": "Fields To Select",
-          "description": "The fields of from the graph API to select. By default, if not provided only the ID will be returned for the object. You can find more about the fields in https://docs.microsoft.com/en-us/graph/api/resources/user?view=graph-rest-1.0#properties.",
+        "propertiesToSelect": {
+          "$ref": "#/definitions/arrayExpression",
+          "title": "User Properties To Select",
+          "description": "The properties of from the graph API to select. By default, if not provided only the ID will be returned for the object. You can find more about the fields in https://docs.microsoft.com/en-us/graph/api/resources/user?view=graph-rest-1.0#properties.",
           "examples": [
-            "dialog.fieldsToSelect",
             "id, displayName, mail, officeLocation, jobTitle"
-          ]
+          ],
+          "items": {
+            "type": "string",
+            "title": "Property",
+            "description": "Property name from the User object to select in Graph API."
+          }
         },
         "userId": {
           "$ref": "#/definitions/stringExpression",
@@ -4984,14 +4996,18 @@
             "user.token.token"
           ]
         },
-        "fieldsToSelect": {
-          "$ref": "#/definitions/stringExpression",
-          "title": "Fields To Select",
-          "description": "The fields of from the graph API to select. By default, if not provided only the ID will be returned for the object. You can find more about the fields in https://docs.microsoft.com/en-us/graph/api/resources/user?view=graph-rest-1.0#properties.",
+        "propertiesToSelect": {
+          "$ref": "#/definitions/arrayExpression",
+          "title": "User Properties To Select",
+          "description": "The properties of from the graph API to select. By default, if not provided only the ID will be returned for the object. You can find more about the fields in https://docs.microsoft.com/en-us/graph/api/resources/user?view=graph-rest-1.0#properties.",
           "examples": [
-            "dialog.fieldsToSelect",
             "id, displayName, mail, officeLocation, jobTitle"
-          ]
+          ],
+          "items": {
+            "type": "string",
+            "title": "Property",
+            "description": "Property name from the User object to select in Graph API."
+          }
         },
         "userId": {
           "$ref": "#/definitions/stringExpression",
@@ -5060,14 +5076,18 @@
             "dialog.worksWithMe.maxResults"
           ]
         },
-        "fieldsToSelect": {
-          "$ref": "#/definitions/stringExpression",
-          "title": "Fields To Select",
-          "description": "The fields of from the graph API to select. By default, if not provided only the ID will be returned for the object. You can find more about the fields in https://docs.microsoft.com/en-us/graph/api/resources/user?view=graph-rest-1.0#properties.",
+        "propertiesToSelect": {
+          "$ref": "#/definitions/arrayExpression",
+          "title": "User Properties To Select",
+          "description": "The properties of from the graph API to select. By default, if not provided only the ID will be returned for the object. You can find more about the fields in https://docs.microsoft.com/en-us/graph/api/resources/user?view=graph-rest-1.0#properties.",
           "examples": [
-            "dialog.fieldsToSelect",
             "id, displayName, mail, officeLocation, jobTitle"
-          ]
+          ],
+          "items": {
+            "type": "string",
+            "title": "Property",
+            "description": "Property name from the User object to select in Graph API."
+          }
         },
         "nameToSearchFor": {
           "$ref": "#/definitions/stringExpression",

--- a/skills/declarative/whoSkill/whoSkill/schemas/sdk.schema
+++ b/skills/declarative/whoSkill/whoSkill/schemas/sdk.schema
@@ -4725,9 +4725,10 @@
         "fieldsToSelect": {
           "$ref": "#/definitions/stringExpression",
           "title": "Fields To Select",
-          "description": "The fields of from the graph API to select. By default, if not provided only the ID will be returned for the object.",
+          "description": "The fields of from the graph API to select. By default, if not provided only the ID will be returned for the object. You can find more about the fields in https://docs.microsoft.com/en-us/graph/api/resources/user?view=graph-rest-1.0#properties.",
           "examples": [
-            "dialog.fieldsToSelect"
+            "dialog.fieldsToSelect",
+            "id, displayName, mail, officeLocation, jobTitle"
           ]
         },
         "userId": {
@@ -4792,9 +4793,10 @@
         "fieldsToSelect": {
           "$ref": "#/definitions/stringExpression",
           "title": "Fields To Select",
-          "description": "The fields of from the graph API to select. By default, if not provided only the ID will be returned for the object.",
+          "description": "The fields of from the graph API to select. By default, if not provided only the ID will be returned for the object. You can find more about the fields in https://docs.microsoft.com/en-us/graph/api/resources/user?view=graph-rest-1.0#properties.",
           "examples": [
-            "dialog.fieldsToSelect"
+            "dialog.fieldsToSelect",
+            "id, displayName, mail, officeLocation, jobTitle"
           ]
         },
         "userId": {
@@ -4867,9 +4869,10 @@
         "fieldsToSelect": {
           "$ref": "#/definitions/stringExpression",
           "title": "Fields To Select",
-          "description": "The fields of from the graph API to select. By default, if not provided only the ID will be returned for the object.",
+          "description": "The fields of from the graph API to select. By default, if not provided only the ID will be returned for the object. You can find more about the fields in https://docs.microsoft.com/en-us/graph/api/resources/user?view=graph-rest-1.0#properties.",
           "examples": [
-            "dialog.fieldsToSelect"
+            "dialog.fieldsToSelect",
+            "id, displayName, mail, officeLocation, jobTitle"
           ]
         },
         "userId": {
@@ -4984,9 +4987,10 @@
         "fieldsToSelect": {
           "$ref": "#/definitions/stringExpression",
           "title": "Fields To Select",
-          "description": "The fields of from the graph API to select. By default, if not provided only the ID will be returned for the object.",
+          "description": "The fields of from the graph API to select. By default, if not provided only the ID will be returned for the object. You can find more about the fields in https://docs.microsoft.com/en-us/graph/api/resources/user?view=graph-rest-1.0#properties.",
           "examples": [
-            "dialog.fieldsToSelect"
+            "dialog.fieldsToSelect",
+            "id, displayName, mail, officeLocation, jobTitle"
           ]
         },
         "userId": {
@@ -5059,9 +5063,10 @@
         "fieldsToSelect": {
           "$ref": "#/definitions/stringExpression",
           "title": "Fields To Select",
-          "description": "The fields of from the graph API to select. By default, if not provided only the ID will be returned for the object.",
+          "description": "The fields of from the graph API to select. By default, if not provided only the ID will be returned for the object. You can find more about the fields in https://docs.microsoft.com/en-us/graph/api/resources/user?view=graph-rest-1.0#properties.",
           "examples": [
-            "dialog.fieldsToSelect"
+            "dialog.fieldsToSelect",
+            "id, displayName, mail, officeLocation, jobTitle"
           ]
         },
         "nameToSearchFor": {


### PR DESCRIPTION
<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
### Purpose
Limit the amount of data being retrieved in the People Skill-related Graph calls. This serves two purposes:
1. Limit the size of the payload we have to transfer across the wire
2. Limit unnecessary PII data exposure on behalf of end user

This change also updates the People skill to use the RC2 style bot app initialization.

### Changes
Switch to using explicit SELECT() clause in the Graph API to return only relevant information.

### Tests
Existing unit tests

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*

Ideally the "select()" statement's list of columns are configurable. I think there could be some more thoughts put into it, like we can probably ask the bot custom action to add a parameter for "fields" required. That can be the next step but this is bare minimum.

### Checklist

#### General
- [x] I have commented my code, particularly in hard-to-understand areas	
- [x] I have added or updated the appropriate tests	
- [x] I have updated related documentation
