### PR TITLE
fix: consolidate package properties

### DIFF
--- a/packages/AdaptiveCards/Microsoft.Bot.Components.AdaptiveCards.csproj
+++ b/packages/AdaptiveCards/Microsoft.Bot.Components.AdaptiveCards.csproj
@@ -14,7 +14,7 @@
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\build\35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
     <DelaySign>true</DelaySign>
-    <PackageTags>msbot-action;msbot-trigger</PackageTags>
+    <PackageTags>msbot-component;msbot-action;msbot-trigger</PackageTags>
     <ContentTargetFolders>content</ContentTargetFolders>
   </PropertyGroup>
 

--- a/packages/Directory.Build.props
+++ b/packages/Directory.Build.props
@@ -17,7 +17,6 @@
     <PackageLicenseUrl>https://github.com/Microsoft/BotBuilder/blob/master/LICENSE</PackageLicenseUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <LicenseUrl>https://github.com/Microsoft/BotBuilder-dotnet/blob/master/LICENSE</LicenseUrl>
-    <PackageTags>msbot-component</PackageTags>
     <RepositoryType />
     <NeutralLanguage>en-US</NeutralLanguage>
     <!--

--- a/packages/Directory.Build.props
+++ b/packages/Directory.Build.props
@@ -16,7 +16,6 @@
     <PackageIconUrl>https://raw.githubusercontent.com/microsoft/botframework-sdk/master/icon.png</PackageIconUrl>
     <PackageLicenseUrl>https://github.com/Microsoft/BotBuilder/blob/master/LICENSE</PackageLicenseUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <RepositoryUrl>https://github.com/Microsoft/botbuilder-components</RepositoryUrl>
     <LicenseUrl>https://github.com/Microsoft/BotBuilder-dotnet/blob/master/LICENSE</LicenseUrl>
     <PackageTags>msbot-component</PackageTags>
     <RepositoryType />

--- a/packages/Graph/Microsoft.Bot.Components.Graph.csproj
+++ b/packages/Graph/Microsoft.Bot.Components.Graph.csproj
@@ -10,7 +10,7 @@
     <VersionPrefix>1.0.0</VersionPrefix>
     <Description>Plugin component for MSGraph custom action</Description>
     <Summary>Plugin component for MSGraph custom action.</Summary>
-    <RepositoryUrl>https://github.com/Microsoft/botbuilder-components/tree/main/packages/Graph/README.md</RepositoryUrl>
+    <RepositoryUrl>https://github.com/Microsoft/botbuilder-components/tree/main/packages/Graph</RepositoryUrl>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\build\35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
     <DelaySign>true</DelaySign>

--- a/packages/Graph/Microsoft.Bot.Components.Graph.csproj
+++ b/packages/Graph/Microsoft.Bot.Components.Graph.csproj
@@ -10,6 +10,7 @@
     <VersionPrefix>1.0.0</VersionPrefix>
     <Description>Plugin component for MSGraph custom action</Description>
     <Summary>Plugin component for MSGraph custom action.</Summary>
+    <RepositoryUrl>https://github.com/Microsoft/botbuilder-components/packages/Graph/README.md</RepositoryUrl>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\build\35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
     <DelaySign>true</DelaySign>

--- a/packages/Graph/Microsoft.Bot.Components.Graph.csproj
+++ b/packages/Graph/Microsoft.Bot.Components.Graph.csproj
@@ -15,6 +15,7 @@
     <AssemblyOriginatorKeyFile>..\..\build\35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
     <DelaySign>true</DelaySign>
     <ContentTargetFolders>content</ContentTargetFolders>
+    <PackageTags>msbot-component;msbot-action</PackageTags>
   </PropertyGroup>
 
   <ItemGroup>

--- a/packages/Graph/Microsoft.Bot.Components.Graph.csproj
+++ b/packages/Graph/Microsoft.Bot.Components.Graph.csproj
@@ -10,7 +10,7 @@
     <VersionPrefix>1.0.0</VersionPrefix>
     <Description>Plugin component for MSGraph custom action</Description>
     <Summary>Plugin component for MSGraph custom action.</Summary>
-    <RepositoryUrl>https://github.com/Microsoft/botbuilder-components/packages/Graph/README.md</RepositoryUrl>
+    <RepositoryUrl>https://github.com/Microsoft/botbuilder-components/tree/main/packages/Graph/README.md</RepositoryUrl>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\build\35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>
     <DelaySign>true</DelaySign>

--- a/packages/HelpAndCancel/Microsoft.Bot.Components.HelpAndCancel.nuspec
+++ b/packages/HelpAndCancel/Microsoft.Bot.Components.HelpAndCancel.nuspec
@@ -8,7 +8,7 @@
         <copyright>© Microsoft Corporation. All rights reserved.</copyright>
         <licenseUrl>https://github.com/Microsoft/BotBuilder/blob/master/LICENSE</licenseUrl>
         <requireLicenseAcceptance>true</requireLicenseAcceptance>
-        <projectUrl>https://github.com/Microsoft/botframework-components/packages/HelpAndCancel/README.md</projectUrl>
+        <projectUrl>https://github.com/Microsoft/botframework-components/tree/main/packages/HelpAndCancel/README.md</projectUrl>
         <releaseNotes>First version of HelpAndCancel package</releaseNotes>
         <description>Dialogs to provide help and cancel utterance handling</description>
         <tags>msbot-component msbot-content conversationalcore helpintent cancelintent preview</tags>

--- a/packages/HelpAndCancel/Microsoft.Bot.Components.HelpAndCancel.nuspec
+++ b/packages/HelpAndCancel/Microsoft.Bot.Components.HelpAndCancel.nuspec
@@ -8,7 +8,7 @@
         <copyright>© Microsoft Corporation. All rights reserved.</copyright>
         <licenseUrl>https://github.com/Microsoft/BotBuilder/blob/master/LICENSE</licenseUrl>
         <requireLicenseAcceptance>true</requireLicenseAcceptance>
-        <projectUrl>https://github.com/Microsoft/botframework-components</projectUrl>
+        <projectUrl>https://github.com/Microsoft/botframework-components/packages/HelpAndCancel/README.md</projectUrl>
         <releaseNotes>First version of HelpAndCancel package</releaseNotes>
         <description>Dialogs to provide help and cancel utterance handling</description>
         <tags>msbot-component msbot-content conversationalcore helpintent cancelintent preview</tags>

--- a/packages/HelpAndCancel/Microsoft.Bot.Components.HelpAndCancel.nuspec
+++ b/packages/HelpAndCancel/Microsoft.Bot.Components.HelpAndCancel.nuspec
@@ -8,7 +8,7 @@
         <copyright>© Microsoft Corporation. All rights reserved.</copyright>
         <licenseUrl>https://github.com/Microsoft/BotBuilder/blob/master/LICENSE</licenseUrl>
         <requireLicenseAcceptance>true</requireLicenseAcceptance>
-        <projectUrl>https://github.com/Microsoft/botframework-components/tree/main/packages/HelpAndCancel/README.md</projectUrl>
+        <projectUrl>https://github.com/Microsoft/botframework-components/tree/main/packages/HelpAndCancel</projectUrl>
         <releaseNotes>First version of HelpAndCancel package</releaseNotes>
         <description>Dialogs to provide help and cancel utterance handling</description>
         <tags>msbot-component msbot-content conversationalcore helpintent cancelintent preview</tags>

--- a/packages/HelpAndCancel/package.json
+++ b/packages/HelpAndCancel/package.json
@@ -15,7 +15,7 @@
   "files": [
     "exported"
   ],
-  "homepage": "https://github.com/Microsoft/botframework-components/tree/main/packages/HelpAndCancel/README.md",
+  "homepage": "https://github.com/Microsoft/botframework-components/tree/main/packages/HelpAndCancel",
   "repository": {
     "type": "git",
     "url": "https://github.com/Microsoft/botframework-components.git"

--- a/packages/HelpAndCancel/package.json
+++ b/packages/HelpAndCancel/package.json
@@ -15,6 +15,7 @@
   "files": [
     "exported"
   ],
+  "homepage": "https://github.com/Microsoft/botframework-components/packages/HelpAndCancel/README.md",
   "repository": {
     "type": "git",
     "url": "https://github.com/Microsoft/botframework-components.git"

--- a/packages/HelpAndCancel/package.json
+++ b/packages/HelpAndCancel/package.json
@@ -15,7 +15,7 @@
   "files": [
     "exported"
   ],
-  "homepage": "https://github.com/Microsoft/botframework-components/packages/HelpAndCancel/README.md",
+  "homepage": "https://github.com/Microsoft/botframework-components/tree/main/packages/HelpAndCancel/README.md",
   "repository": {
     "type": "git",
     "url": "https://github.com/Microsoft/botframework-components.git"

--- a/packages/Teams/Microsoft.Bot.Components.Teams.csproj
+++ b/packages/Teams/Microsoft.Bot.Components.Teams.csproj
@@ -14,7 +14,7 @@
     <PackageId>Microsoft.Bot.Components.Teams</PackageId>
     <Description>This library implements .NET support for adaptive dialogs with Microsoft Teams</Description>
     <Summary>This library implements .NET support for adaptive dialogs with Microsoft Teams</Summary>
-    <RepositoryUrl>https://github.com/Microsoft/botbuilder-components/tree/main/packages/Teams/README.md</RepositoryUrl>
+    <RepositoryUrl>https://github.com/Microsoft/botbuilder-components/tree/main/packages/Teams</RepositoryUrl>
     <ContentTargetFolders>content</ContentTargetFolders>
     <PackageTags>msbot-component;msbot-action;msbot-trigger</PackageTags>
   </PropertyGroup>

--- a/packages/Teams/Microsoft.Bot.Components.Teams.csproj
+++ b/packages/Teams/Microsoft.Bot.Components.Teams.csproj
@@ -14,6 +14,7 @@
     <PackageId>Microsoft.Bot.Components.Teams</PackageId>
     <Description>This library implements .NET support for adaptive dialogs with Microsoft Teams</Description>
     <Summary>This library implements .NET support for adaptive dialogs with Microsoft Teams</Summary>
+    <RepositoryUrl>https://github.com/Microsoft/botbuilder-components/packages/Teams/README.md</RepositoryUrl>
     <ContentTargetFolders>content</ContentTargetFolders>
     <PackageTags>msbot-action;msbot-trigger</PackageTags>
   </PropertyGroup>

--- a/packages/Teams/Microsoft.Bot.Components.Teams.csproj
+++ b/packages/Teams/Microsoft.Bot.Components.Teams.csproj
@@ -16,7 +16,7 @@
     <Summary>This library implements .NET support for adaptive dialogs with Microsoft Teams</Summary>
     <RepositoryUrl>https://github.com/Microsoft/botbuilder-components/packages/Teams/README.md</RepositoryUrl>
     <ContentTargetFolders>content</ContentTargetFolders>
-    <PackageTags>msbot-action;msbot-trigger</PackageTags>
+    <PackageTags>msbot-component;msbot-action;msbot-trigger</PackageTags>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/packages/Teams/Microsoft.Bot.Components.Teams.csproj
+++ b/packages/Teams/Microsoft.Bot.Components.Teams.csproj
@@ -14,7 +14,7 @@
     <PackageId>Microsoft.Bot.Components.Teams</PackageId>
     <Description>This library implements .NET support for adaptive dialogs with Microsoft Teams</Description>
     <Summary>This library implements .NET support for adaptive dialogs with Microsoft Teams</Summary>
-    <RepositoryUrl>https://github.com/Microsoft/botbuilder-components/packages/Teams/README.md</RepositoryUrl>
+    <RepositoryUrl>https://github.com/Microsoft/botbuilder-components/tree/main/packages/Teams/README.md</RepositoryUrl>
     <ContentTargetFolders>content</ContentTargetFolders>
     <PackageTags>msbot-component;msbot-action;msbot-trigger</PackageTags>
   </PropertyGroup>

--- a/packages/Welcome/Microsoft.Bot.Components.Welcome.nuspec
+++ b/packages/Welcome/Microsoft.Bot.Components.Welcome.nuspec
@@ -8,7 +8,7 @@
         <copyright>© Microsoft Corporation. All rights reserved.</copyright>
         <licenseUrl>https://github.com/Microsoft/BotBuilder/blob/master/LICENSE</licenseUrl>
         <requireLicenseAcceptance>true</requireLicenseAcceptance>
-        <projectUrl>https://github.com/Microsoft/botframework-components/packages/Welcome/README.md</projectUrl>
+        <projectUrl>https://github.com/Microsoft/botframework-components/tree/main/packages/Welcome/README.md</projectUrl>
         <releaseNotes>First version of welcome package</releaseNotes>
         <description>An Adaptive Dialog for greeting new and returning users</description>
         <tags>msbot-component msbot-content conversationalcore welcome preview</tags>

--- a/packages/Welcome/Microsoft.Bot.Components.Welcome.nuspec
+++ b/packages/Welcome/Microsoft.Bot.Components.Welcome.nuspec
@@ -8,7 +8,7 @@
         <copyright>© Microsoft Corporation. All rights reserved.</copyright>
         <licenseUrl>https://github.com/Microsoft/BotBuilder/blob/master/LICENSE</licenseUrl>
         <requireLicenseAcceptance>true</requireLicenseAcceptance>
-        <projectUrl>https://github.com/Microsoft/botframework-components</projectUrl>
+        <projectUrl>https://github.com/Microsoft/botframework-components/packages/Welcome/README.md</projectUrl>
         <releaseNotes>First version of welcome package</releaseNotes>
         <description>An Adaptive Dialog for greeting new and returning users</description>
         <tags>msbot-component msbot-content conversationalcore welcome preview</tags>

--- a/packages/Welcome/Microsoft.Bot.Components.Welcome.nuspec
+++ b/packages/Welcome/Microsoft.Bot.Components.Welcome.nuspec
@@ -8,7 +8,7 @@
         <copyright>© Microsoft Corporation. All rights reserved.</copyright>
         <licenseUrl>https://github.com/Microsoft/BotBuilder/blob/master/LICENSE</licenseUrl>
         <requireLicenseAcceptance>true</requireLicenseAcceptance>
-        <projectUrl>https://github.com/Microsoft/botframework-components/tree/main/packages/Welcome/README.md</projectUrl>
+        <projectUrl>https://github.com/Microsoft/botframework-components/tree/main/packages/Welcome</projectUrl>
         <releaseNotes>First version of welcome package</releaseNotes>
         <description>An Adaptive Dialog for greeting new and returning users</description>
         <tags>msbot-component msbot-content conversationalcore welcome preview</tags>

--- a/packages/Welcome/package.json
+++ b/packages/Welcome/package.json
@@ -15,7 +15,7 @@
   "files": [
     "exported"
   ],
-  "homepage": "https://github.com/Microsoft/botframework-components/tree/main/packages/Welcome/README.md",
+  "homepage": "https://github.com/Microsoft/botframework-components/tree/main/packages/Welcome",
   "repository": {
     "type": "git",
     "url": "https://github.com/Microsoft/botframework-components.git"

--- a/packages/Welcome/package.json
+++ b/packages/Welcome/package.json
@@ -15,6 +15,7 @@
   "files": [
     "exported"
   ],
+  "homepage": "https://github.com/Microsoft/botframework-components/packages/Welcome/README.md",
   "repository": {
     "type": "git",
     "url": "https://github.com/Microsoft/botframework-components.git"

--- a/packages/Welcome/package.json
+++ b/packages/Welcome/package.json
@@ -15,7 +15,7 @@
   "files": [
     "exported"
   ],
-  "homepage": "https://github.com/Microsoft/botframework-components/packages/Welcome/README.md",
+  "homepage": "https://github.com/Microsoft/botframework-components/tree/main/packages/Welcome/README.md",
   "repository": {
     "type": "git",
     "url": "https://github.com/Microsoft/botframework-components.git"


### PR DESCRIPTION
<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
### Purpose
*What is the context of this pull request? Why is it being done?*
Close #880

#### NuGet
There are a couple of items in the directory.build.props that are included in packaging that are better served being in the project files themselves. The RepositoryUrl should point to each package's own README as that is what is linked under "View Documentation" in Composer, while the PackageTags should be provided in project files themselves (build properties takes precedence over project properties).

#### NPM
Added "homepage" property to package.json files that point to the package READMEs.

### Feature Plan
The Teams README is missing, this is requested in #877.