### PR TITLE
fix: Updating defaultLocale value in appsettings.json to 'en-us'

### DIFF
--- a/generators/generator-bot-adaptive/generators/app/templates/assets/appsettings.json
+++ b/generators/generator-bot-adaptive/generators/app/templates/assets/appsettings.json
@@ -1,7 +1,7 @@
 {
   "customFunctions": [],
   "defaultLanguage": "en-us",
-  "defaultLocale": "en-US",
+  "defaultLocale": "en-us",
   "downsampling": {
     "maxImbalanceRatio": -1
   },

--- a/generators/generator-bot-template-generator/app/templates/generators/app/templates/settings/appsettings.json
+++ b/generators/generator-bot-template-generator/app/templates/generators/app/templates/settings/appsettings.json
@@ -1,7 +1,7 @@
 {
   "MicrosoftAppPassword": "",
   "MicrosoftAppId": "",
-  "defaultLocale": "en-US",
+  "defaultLocale": "en-us",
   "runtimeSettings": {
     "features": {
       "removeRecipientMentions": false,


### PR DESCRIPTION
### Purpose
Fixes #892.

Due to https://github.com/microsoft/botbuilder-dotnet/issues/5479, defaultLocale must be changed to 'en-us' in order to ensure it matches the casing specified in the recognizer files, otherwise it is unable to select the correct recognizer for incoming requests.

### Changes
- Updating defaultLocale value in appsettings.json to 'en-us'.

### Tests
Manual verification.