### PR TITLE
Make appsettings for Pbx projects stick for adaptive runtime

### DIFF
--- a/skills/declarative/Calendar/Calendar/.gitignore
+++ b/skills/declarative/Calendar/Calendar/.gitignore
@@ -1,2 +1,2 @@
-# prevent appsettings.json get checked in
-**/appsettings.json
+# Don't check in any files that are generated
+**/generated/**

--- a/skills/declarative/Calendar/Calendar/settings/appsettings.json
+++ b/skills/declarative/Calendar/Calendar/settings/appsettings.json
@@ -1,75 +1,81 @@
 {
-  "feature": {
-    "UseShowTypingMiddleware": true,
-    "UseInspectionMiddleware": false,
-    "RemoveRecipientMention": false,
-    "UseSetSpeakMiddleware": true
-  },
-  "MicrosoftAppId": "",
-  "cosmosDb": {
-    "authKey": "",
-    "containerId": "botstate-container",
-    "cosmosDBEndpoint": "",
-    "databaseId": "botstate-db"
-  },
-  "applicationInsights": {
-    "InstrumentationKey": ""
-  },
-  "blobStorage": {
-    "connectionString": "",
-    "container": "transcripts"
-  },
-  "speech": {
-    "voiceFontName": "en-US-AriaNeural",
-    "fallbackToTextForSpeechIfEmpty": true
-  },
-  "luis": {
-    "name": "Calendar",
-    "authoringEndpoint": "",
-    "endpoint": "",
-    "authoringRegion": "westus",
-    "defaultLanguage": "en-us",
-    "environment": "composer",
-    "directVersionPublish": true
-  },
-  "luFeatures": {
-    "enablePattern": true,
-    "enableMLEntities": true,
-    "enableListEntities": true,
-    "enableCompositeEntities": true,
-    "enablePrebuiltEntities": true,
-    "enableRegexEntities": true,
-    "enablePhraseLists": true
-  },
-  "publishTargets": [],
-  "qna": {
-    "knowledgebaseid": "",
-    "hostname": "",
-    "qnaRegion": "westus"
-  },
-  "telemetry": {
-    "logPersonalInformation": false,
-    "logActivities": true
-  },
-  "runtime": {
-    "customRuntime": true,
-    "path": "../",
-    "command": "dotnet run --project Calendar.csproj",
-    "key": "adaptive-runtime-dotnet-webapp"
-  },
+  "customFunctions": [],
+  "defaultLanguage": "en-us",
+  "defaultLocale": "en-US",
   "downsampling": {
     "maxImbalanceRatio": -1
   },
-  "skillConfiguration": {
-    "isSkill": true,
-    "allowedCallers": []
-  },
-  "skill": {},
-  "defaultLanguage": "en-us",
+  "importedLibraries": [],
   "languages": [
     "en-us"
   ],
-  "customFunctions": [],
-  "importedLibraries": [],
-  "skillHostEndpoint": ""
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  },
+  "luFeatures": {
+    "enableCompositeEntities": true,
+    "enableListEntities": true,
+    "enableMLEntities": true,
+    "enablePattern": true,
+    "enablePhraseLists": true,
+    "enablePrebuiltEntities": true,
+    "enableRegexEntities": true
+  },
+  "luis": {
+    "authoringEndpoint": "",
+    "authoringRegion": "",
+    "defaultLanguage": "en-us",
+    "endpoint": "",
+    "environment": "composer",
+    "name": "Calendar"
+  },
+  "MicrosoftAppId": "",
+  "publishTargets": [],
+  "qna": {
+    "hostname": "",
+    "knowledgebaseid": "",
+    "qnaRegion": "westus"
+  },
+  "runtime": {
+    "command": "dotnet run --project Calendar.csproj",
+    "customRuntime": true,
+    "key": "adaptive-runtime-dotnet-webapp",
+    "path": "../"
+  },
+  "runtimeSettings": {
+    "adapters": [],
+    "features": {
+      "removeRecipientMentions": false,
+      "showTyping": false,
+      "traceTranscript": false,
+      "useInspection": false,
+      "setSpeak": {
+        "voiceFontName": "en-US-AriaNeural",
+        "fallbackToTextForSpeechIfEmpty": true
+      }
+    },
+    "components": [
+      {
+        "name": "Microsoft.Bot.Components.Graph",
+        "settingsPrefix": "Microsoft.Bot.Components.Graph"
+      }
+    ],
+    "skills": {
+      "allowedCallers": []
+    },
+    "storage": "",
+    "telemetry": {
+      "instrumentationKey": "",
+      "logActivities": true,
+      "logPersonalInformation": false
+    }
+  },
+  "oauthConnectionName": "",
+  "defaultValue": {
+    "duration": 30
+  }
 }

--- a/skills/declarative/Calendar/Calendar/settings/appsettings.json
+++ b/skills/declarative/Calendar/Calendar/settings/appsettings.json
@@ -1,0 +1,75 @@
+{
+  "feature": {
+    "UseShowTypingMiddleware": true,
+    "UseInspectionMiddleware": false,
+    "RemoveRecipientMention": false,
+    "UseSetSpeakMiddleware": true
+  },
+  "MicrosoftAppId": "",
+  "cosmosDb": {
+    "authKey": "",
+    "containerId": "botstate-container",
+    "cosmosDBEndpoint": "",
+    "databaseId": "botstate-db"
+  },
+  "applicationInsights": {
+    "InstrumentationKey": ""
+  },
+  "blobStorage": {
+    "connectionString": "",
+    "container": "transcripts"
+  },
+  "speech": {
+    "voiceFontName": "en-US-AriaNeural",
+    "fallbackToTextForSpeechIfEmpty": true
+  },
+  "luis": {
+    "name": "Calendar",
+    "authoringEndpoint": "",
+    "endpoint": "",
+    "authoringRegion": "westus",
+    "defaultLanguage": "en-us",
+    "environment": "composer",
+    "directVersionPublish": true
+  },
+  "luFeatures": {
+    "enablePattern": true,
+    "enableMLEntities": true,
+    "enableListEntities": true,
+    "enableCompositeEntities": true,
+    "enablePrebuiltEntities": true,
+    "enableRegexEntities": true,
+    "enablePhraseLists": true
+  },
+  "publishTargets": [],
+  "qna": {
+    "knowledgebaseid": "",
+    "hostname": "",
+    "qnaRegion": "westus"
+  },
+  "telemetry": {
+    "logPersonalInformation": false,
+    "logActivities": true
+  },
+  "runtime": {
+    "customRuntime": true,
+    "path": "../",
+    "command": "dotnet run --project Calendar.csproj",
+    "key": "adaptive-runtime-dotnet-webapp"
+  },
+  "downsampling": {
+    "maxImbalanceRatio": -1
+  },
+  "skillConfiguration": {
+    "isSkill": true,
+    "allowedCallers": []
+  },
+  "skill": {},
+  "defaultLanguage": "en-us",
+  "languages": [
+    "en-us"
+  ],
+  "customFunctions": [],
+  "importedLibraries": [],
+  "skillHostEndpoint": "http://localhost:3980/api/skills"
+}

--- a/skills/declarative/Calendar/Calendar/settings/appsettings.json
+++ b/skills/declarative/Calendar/Calendar/settings/appsettings.json
@@ -71,5 +71,5 @@
   ],
   "customFunctions": [],
   "importedLibraries": [],
-  "skillHostEndpoint": "http://localhost:3980/api/skills"
+  "skillHostEndpoint": ""
 }

--- a/skills/declarative/whoSkill/whoSkill/.gitignore
+++ b/skills/declarative/whoSkill/whoSkill/.gitignore
@@ -1,3 +1,2 @@
-# prevent appsettings.json get checked in
-**/appsettings.json
+# Don't check in any files that are generated
 **/generated/**

--- a/skills/declarative/whoSkill/whoSkill/settings/appsettings.json
+++ b/skills/declarative/whoSkill/whoSkill/settings/appsettings.json
@@ -1,5 +1,53 @@
 {
+  "customFunctions": [],
+  "defaultLanguage": "en-us",
+  "defaultLocale": "en-US",
+  "downsampling": {
+    "maxImbalanceRatio": -1
+  },
+  "importedLibraries": [],
+  "languages": [
+    "en-us"
+  ],
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  },
+  "luFeatures": {
+    "enableCompositeEntities": true,
+    "enableListEntities": true,
+    "enableMLEntities": true,
+    "enablePattern": true,
+    "enablePhraseLists": true,
+    "enablePrebuiltEntities": true,
+    "enableRegexEntities": true
+  },
+  "luis": {
+    "authoringEndpoint": "",
+    "authoringRegion": "westus",
+    "defaultLanguage": "en-us",
+    "endpoint": "",
+    "environment": "composer",
+    "name": "People"
+  },
+  "MicrosoftAppId": "",
+  "publishTargets": [],
+  "qna": {
+    "hostname": "",
+    "knowledgebaseid": "",
+    "qnaRegion": "westus"
+  },
+  "runtime": {
+    "command": "dotnet run --project whoSkill.csproj",
+    "customRuntime": true,
+    "key": "adaptive-runtime-dotnet-webapp",
+    "path": "../"
+  },
   "runtimeSettings": {
+    "adapters": [],
     "features": {
       "removeRecipientMentions": false,
       "showTyping": false,
@@ -10,7 +58,12 @@
         "fallbackToTextForSpeechIfEmpty": true
       }
     },
-    "components": [],
+    "components": [
+      {
+        "name": "Microsoft.Bot.Components.Graph",
+        "settingsPrefix": "Microsoft.Bot.Components.Graph"
+      }
+    ],
     "skills": {
       "allowedCallers": []
     },
@@ -21,73 +74,5 @@
       "logPersonalInformation": false
     }
   },
-  "feature": {
-    "UseShowTypingMiddleware": false,
-    "UseInspectionMiddleware": false,
-    "RemoveRecipientMention": false,
-    "UseSetSpeakMiddleware": true
-  },
-  "MicrosoftAppId": "",
-  "cosmosDb": {
-    "authKey": "",
-    "containerId": "botstate-container",
-    "cosmosDBEndpoint": "",
-    "databaseId": "botstate-db"
-  },
-  "applicationInsights": {
-    "InstrumentationKey": ""
-  },
-  "blobStorage": {
-    "connectionString": "",
-    "container": "transcripts"
-  },
-  "speech": {
-    "voiceFontName": "en-US-AriaNeural",
-    "fallbackToTextForSpeechIfEmpty": true
-  },
-  "luis": {
-    "name": "whoSkill",
-    "authoringEndpoint": "",
-    "endpoint": "",
-    "authoringRegion": "westus",
-    "defaultLanguage": "en-us",
-    "environment": "composer",
-    "directVersionPublish": true
-  },
-  "luFeatures": {
-    "enablePattern": true,
-    "enableMLEntities": true,
-    "enableListEntities": true,
-    "enableCompositeEntities": true,
-    "enablePrebuiltEntities": true,
-    "enableRegexEntities": true,
-    "enablePhraseLists": true
-  },
-  "publishTargets": [],
-  "qna": {
-    "knowledgebaseid": "",
-    "hostname": "",
-    "qnaRegion": "westus"
-  },
-  "telemetry": {
-    "logPersonalInformation": false,
-    "logActivities": true
-  },
-  "runtime": {
-    "customRuntime": true,
-    "path": "../",
-    "command": "dotnet run --project whoSkill.csproj",
-    "key": "adaptive-runtime-dotnet-webapp"
-  },
-  "downsampling": {
-    "maxImbalanceRatio": -1
-  },
-  "skill": {},
-  "defaultLanguage": "en-us",
-  "languages": [
-    "en-us"
-  ],
-  "customFunctions": [],
-  "importedLibraries": [],
-  "skillHostEndpoint": ""
+  "oauthConnectionName": ""
 }

--- a/skills/declarative/whoSkill/whoSkill/settings/appsettings.json
+++ b/skills/declarative/whoSkill/whoSkill/settings/appsettings.json
@@ -1,0 +1,92 @@
+{
+  "runtimeSettings": {
+    "features": {
+      "removeRecipientMentions": false,
+      "showTyping": false,
+      "traceTranscript": false,
+      "useInspection": false,
+      "setSpeak": {
+        "voiceFontName": "en-US-AriaNeural",
+        "fallbackToTextForSpeechIfEmpty": true
+      }
+    },
+    "components": [],
+    "skills": {
+      "allowedCallers": []
+    },
+    "storage": "",
+    "telemetry": {
+      "instrumentationKey": "",
+      "logActivities": true,
+      "logPersonalInformation": false
+    }
+  },
+  "feature": {
+    "UseShowTypingMiddleware": false,
+    "UseInspectionMiddleware": false,
+    "RemoveRecipientMention": false,
+    "UseSetSpeakMiddleware": true
+  },
+  "MicrosoftAppId": "",
+  "cosmosDb": {
+    "authKey": "",
+    "containerId": "botstate-container",
+    "cosmosDBEndpoint": "",
+    "databaseId": "botstate-db"
+  },
+  "applicationInsights": {
+    "InstrumentationKey": ""
+  },
+  "blobStorage": {
+    "connectionString": "",
+    "container": "transcripts"
+  },
+  "speech": {
+    "voiceFontName": "en-US-AriaNeural",
+    "fallbackToTextForSpeechIfEmpty": true
+  },
+  "luis": {
+    "name": "whoSkill",
+    "authoringEndpoint": "",
+    "endpoint": "",
+    "authoringRegion": "westus",
+    "defaultLanguage": "en-us",
+    "environment": "composer",
+    "directVersionPublish": true
+  },
+  "luFeatures": {
+    "enablePattern": true,
+    "enableMLEntities": true,
+    "enableListEntities": true,
+    "enableCompositeEntities": true,
+    "enablePrebuiltEntities": true,
+    "enableRegexEntities": true,
+    "enablePhraseLists": true
+  },
+  "publishTargets": [],
+  "qna": {
+    "knowledgebaseid": "",
+    "hostname": "",
+    "qnaRegion": "westus"
+  },
+  "telemetry": {
+    "logPersonalInformation": false,
+    "logActivities": true
+  },
+  "runtime": {
+    "customRuntime": true,
+    "path": "../",
+    "command": "dotnet run --project whoSkill.csproj",
+    "key": "adaptive-runtime-dotnet-webapp"
+  },
+  "downsampling": {
+    "maxImbalanceRatio": -1
+  },
+  "skill": {},
+  "defaultLanguage": "en-us",
+  "languages": [
+    "en-us"
+  ],
+  "customFunctions": [],
+  "importedLibraries": []
+}

--- a/skills/declarative/whoSkill/whoSkill/settings/appsettings.json
+++ b/skills/declarative/whoSkill/whoSkill/settings/appsettings.json
@@ -88,5 +88,6 @@
     "en-us"
   ],
   "customFunctions": [],
-  "importedLibraries": []
+  "importedLibraries": [],
+  "skillHostEndpoint": ""
 }


### PR DESCRIPTION
<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
### Purpose
The default app settings in our project currently do not start properly under composer for adaptive runtime as it is not configured properly to hint and thus falling into the old custom azurewebapps runtime.

This change is to make the adaptive runtime setting stick in the appsettings.

### Changes
- Update gitignore to not ignore appsettings
- Update appsettings to use adaptive runtime for runtime setting

### Tests
Manually tested

### Feature Plan
None

### Checklist

#### General
- [x] I have commented my code, particularly in hard-to-understand areas	
- [x] I have added or updated the appropriate tests	
- [x] I have updated related documentation
