### PR TITLE
Adaptive generator: add reference to luis + qna for r14 legacy story

### DIFF
--- a/generators/generator-bot-adaptive/generators/app/templates/dotnet/functions/botName.csproj
+++ b/generators/generator-bot-adaptive/generators/app/templates/dotnet/functions/botName.csproj
@@ -12,9 +12,9 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.10" />
     <PackageReference Include="Microsoft.AspNetCore.OData" Version="7.5.2" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime" Version="4.13.0" />
     <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.13.0" />
     <PackageReference Include="Microsoft.Bot.Builder.AI.QnA" Version="4.13.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime" Version="4.13.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="3.1.8" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.7" /><%- packageReferences %>
   </ItemGroup>

--- a/generators/generator-bot-adaptive/generators/app/templates/dotnet/functions/botName.csproj
+++ b/generators/generator-bot-adaptive/generators/app/templates/dotnet/functions/botName.csproj
@@ -13,6 +13,8 @@
     <PackageReference Include="Microsoft.AspNetCore.OData" Version="7.5.2" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
     <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime" Version="4.13.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.13.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.AI.QnA" Version="4.13.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="3.1.8" />
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.7" /><%- packageReferences %>
   </ItemGroup>

--- a/generators/generator-bot-adaptive/generators/app/templates/dotnet/webapp/botName.csproj
+++ b/generators/generator-bot-adaptive/generators/app/templates/dotnet/webapp/botName.csproj
@@ -11,6 +11,8 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.8" />
+    <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.13.0" />
+    <PackageReference Include="Microsoft.Bot.Builder.AI.QnA" Version="4.13.0" />
     <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime" Version="4.13.0" /><%- packageReferences %>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Currently the runtime has a set of built-in components that cannot be removed and are statically registered. Many of these make sense even in the super long term such as AdaptiveDialogs or BotBuilder. However, other of the core components that we've always registered are Luis and QnA. With the new component model, in R14 we would want to remove Luis and QnA and have them be only registered as components by the generators that need them. This will decouple the runtime from LUIS + QnA and also allow users to not have dependencies they won't want.
 
This change prepares the terrain for that to reduce breaking changes and need for migrations in R13 generators when upgrading to r14.
