### PR TITLE
fix: Make Empty Bot greeting agnostic and add unknown intent handling

### DIFF
--- a/generators/generator-bot-conversational-core/generators/app/templates/language-generation/en-us/botName.en-us.lg
+++ b/generators/generator-bot-conversational-core/generators/app/templates/language-generation/en-us/botName.en-us.lg
@@ -7,7 +7,7 @@
 ]
 
 # SendActivity_IQMEuO_text()
-- Sorry, I didn't get that
+- Sorry, I didn't get that.
 - I'm not sure I understand. Can you please try again?
 - Hmm, I don't understand. Can you try to ask me in a different way. 
 - I didn't get that. Would you mind rephrasing and try it again.

--- a/generators/generator-bot-empty/generators/app/templates/botName.dialog
+++ b/generators/generator-bot-empty/generators/app/templates/botName.dialog
@@ -1,9 +1,9 @@
 {
   "$kind": "Microsoft.AdaptiveDialog",
   "$designer": {
-      "name": "<%= botName %>",
-      "description": "",
-      "id": "A79tBe"
+    "name": "<%= botName %>",
+    "description": "",
+    "id": "A79tBe"
   },
   "autoEndDialog": true,
   "defaultResultProperty": "dialog.result",
@@ -41,6 +41,21 @@
               ]
             }
           ]
+        }
+      ]
+    },
+    {
+      "$kind": "Microsoft.OnUnknownIntent",
+      "$designer": {
+        "id": "mb2n1u"
+      },
+      "actions": [
+        {
+          "$kind": "Microsoft.SendActivity",
+          "$designer": {
+            "id": "kMjqz1"
+          },
+          "activity": "${SendActivity_kMjqz1()}"
         }
       ]
     }

--- a/generators/generator-bot-empty/generators/app/templates/language-generation/en-us/botName.en-us.lg
+++ b/generators/generator-bot-empty/generators/app/templates/language-generation/en-us/botName.en-us.lg
@@ -2,3 +2,8 @@
 
 # SendActivity_Welcome
 - ${WelcomeUser()}
+
+# SendActivity_kMjqz1()
+[Activity
+    Text = Sorry, I didn't get that.
+]

--- a/generators/generator-bot-empty/generators/app/templates/language-generation/en-us/common.en-us.lg
+++ b/generators/generator-bot-empty/generators/app/templates/language-generation/en-us/common.en-us.lg
@@ -1,2 +1,2 @@
 # WelcomeUser
-- Welcome to your bot
+- Welcome to your bot.

--- a/generators/generator-bot-empty/generators/app/templates/language-generation/en-us/common.en-us.lg
+++ b/generators/generator-bot-empty/generators/app/templates/language-generation/en-us/common.en-us.lg
@@ -1,2 +1,2 @@
 # WelcomeUser
-- Welcome to the EmptyBot sample
+- Welcome to your bot


### PR DESCRIPTION
<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
### Purpose
*What is the context of this pull request? Why is it being done?*
Close #885 

The current Empty Bot greeting has a message "Welcome to your Empty Bot sample" which was taken from prior Empty Bot templates. This is odd especially when someone gives their bot a specific name. Rather than referencing their provided name and potentially having confusing language, we will use a simple "welcome to your bot" message instead.

This also adds an unknown intent trigger to handle for anything the user says, so that if they test the empty bot alone it gives a response.
![image](https://user-images.githubusercontent.com/43043272/115073965-e72dc780-9ead-11eb-8872-c22034abe9e7.png)

Also fixed a minor punctuation in conversational core bot.