### PR TITLE
fix: Remove downsampling settings

### DIFF
--- a/generators/generator-bot-adaptive/generators/app/templates/assets/appsettings.json
+++ b/generators/generator-bot-adaptive/generators/app/templates/assets/appsettings.json
@@ -2,9 +2,6 @@
   "customFunctions": [],
   "defaultLanguage": "en-us",
   "defaultLocale": "en-us",
-  "downsampling": {
-    "maxImbalanceRatio": -1
-  },
   "importedLibraries": [],
   "languages": [
     "en-us"


### PR DESCRIPTION
### Purpose
After confirming with the Composer team, downsampling settings are deprecated. Removing from scaffolded appsettings.json.

### Changes
- Removing downsampling settings from appsettings.json in Adaptive generator templates.

### Tests
N/A