### PR TITLE
refactor: simplify LG template usage across templates and packages

### DIFF
--- a/generators/generator-bot-assistant-core/generators/app/templates/botName.dialog
+++ b/generators/generator-bot-assistant-core/generators/app/templates/botName.dialog
@@ -42,7 +42,7 @@
                       "$designer": {
                         "id": "yXbfKT"
                       },
-                      "activity": "${SendActivity_WelcomeReturningUser()}"
+                      "activity": "${SendActivity_GreetingReturningUser()}"
                     }
                   ],
                   "elseActions": [
@@ -51,7 +51,7 @@
                       "$designer": {
                         "id": "XZRD8m"
                       },
-                      "activity": "${SendActivity_WelcomeNewUser()}"
+                      "activity": "${SendActivity_GreetingNewUser()}"
                     },
                     {
                       "$kind": "Microsoft.SetProperty",

--- a/generators/generator-bot-assistant-core/generators/app/templates/botName.dialog
+++ b/generators/generator-bot-assistant-core/generators/app/templates/botName.dialog
@@ -40,18 +40,18 @@
                     {
                       "$kind": "Microsoft.SendActivity",
                       "$designer": {
-                        "id": "yXbfKT"
+                        "id": "WelcomeReturningUser"
                       },
-                      "activity": "${SendActivity_yXbfKT()}"
+                      "activity": "${SendActivity_WelcomeReturningUser()}"
                     }
                   ],
                   "elseActions": [
                     {
                       "$kind": "Microsoft.SendActivity",
                       "$designer": {
-                        "id": "XZRD8m"
+                        "id": "WelcomeNewUser"
                       },
-                      "activity": "${SendActivity_XZRD8m()}"
+                      "activity": "${SendActivity_WelcomeNewUser()}"
                     },
                     {
                       "$kind": "Microsoft.SetProperty",

--- a/generators/generator-bot-assistant-core/generators/app/templates/botName.dialog
+++ b/generators/generator-bot-assistant-core/generators/app/templates/botName.dialog
@@ -40,7 +40,7 @@
                     {
                       "$kind": "Microsoft.SendActivity",
                       "$designer": {
-                        "id": "WelcomeReturningUser"
+                        "id": "yXbfKT"
                       },
                       "activity": "${SendActivity_WelcomeReturningUser()}"
                     }
@@ -49,7 +49,7 @@
                     {
                       "$kind": "Microsoft.SendActivity",
                       "$designer": {
-                        "id": "WelcomeNewUser"
+                        "id": "XZRD8m"
                       },
                       "activity": "${SendActivity_WelcomeNewUser()}"
                     },

--- a/generators/generator-bot-assistant-core/generators/app/templates/botName.dialog
+++ b/generators/generator-bot-assistant-core/generators/app/templates/botName.dialog
@@ -280,7 +280,7 @@
           "$designer": {
             "id": "2outgQ"
           },
-          "activity": "${SendActivity_2outgQ()}"
+          "activity": "${SendActivity_ErrorOccured()}"
         },
         {
           "$kind": "Microsoft.TraceActivity",

--- a/generators/generator-bot-assistant-core/generators/app/templates/dialogs/BotTourDialog/BotTourDialog.dialog
+++ b/generators/generator-bot-assistant-core/generators/app/templates/dialogs/BotTourDialog/BotTourDialog.dialog
@@ -29,9 +29,9 @@
       "$kind": "Microsoft.OnIntent",
       "$designer": {
         "id": "pzuSn9",
-        "name": "FocusCard"
+        "name": "DetailsCard"
       },
-      "intent": "FocusCard",
+      "intent": "DetailsCard",
       "actions": [
         {
           "$kind": "Microsoft.SendActivity",

--- a/generators/generator-bot-assistant-core/generators/app/templates/dialogs/BotTourDialog/BotTourDialog.dialog
+++ b/generators/generator-bot-assistant-core/generators/app/templates/dialogs/BotTourDialog/BotTourDialog.dialog
@@ -19,9 +19,9 @@
         {
           "$kind": "Microsoft.SendActivity",
           "$designer": {
-            "id": "YRvoei"
+            "id": "BotTourOverview"
           },
-          "activity": "${SendActivity_YRvoei()}"
+          "activity": "${SendActivity_BotTourOverview()}"
         }
       ]
     },
@@ -36,9 +36,9 @@
         {
           "$kind": "Microsoft.SendActivity",
           "$designer": {
-            "id": "Z5JucQ"
+            "id": "BotTourFocus"
           },
-          "activity": "${SendActivity_Z5JucQ()}"
+          "activity": "${SendActivity_BotTourFocus()}"
         },
         {
           "$kind": "Microsoft.EndDialog",

--- a/generators/generator-bot-assistant-core/generators/app/templates/dialogs/BotTourDialog/BotTourDialog.dialog
+++ b/generators/generator-bot-assistant-core/generators/app/templates/dialogs/BotTourDialog/BotTourDialog.dialog
@@ -38,7 +38,7 @@
           "$designer": {
             "id": "Z5JucQ"
           },
-          "activity": "${SendActivity_BotTourFocus()}"
+          "activity": "${SendActivity_BotTourDetails()}"
         },
         {
           "$kind": "Microsoft.EndDialog",

--- a/generators/generator-bot-assistant-core/generators/app/templates/dialogs/BotTourDialog/BotTourDialog.dialog
+++ b/generators/generator-bot-assistant-core/generators/app/templates/dialogs/BotTourDialog/BotTourDialog.dialog
@@ -19,7 +19,7 @@
         {
           "$kind": "Microsoft.SendActivity",
           "$designer": {
-            "id": "BotTourOverview"
+            "id": "YRvoei"
           },
           "activity": "${SendActivity_BotTourOverview()}"
         }
@@ -36,7 +36,7 @@
         {
           "$kind": "Microsoft.SendActivity",
           "$designer": {
-            "id": "BotTourFocus"
+            "id": "Z5JucQ"
           },
           "activity": "${SendActivity_BotTourFocus()}"
         },

--- a/generators/generator-bot-assistant-core/generators/app/templates/dialogs/BotTourDialog/language-generation/en-us/BotTourDialog.en-us.lg
+++ b/generators/generator-bot-assistant-core/generators/app/templates/dialogs/BotTourDialog/language-generation/en-us/BotTourDialog.en-us.lg
@@ -2,19 +2,19 @@
 
 # SendActivity_BotTourOverview()
 [Activity
-    Attachments = ${SendActivity_BotTourOverview_attachment_WGITEE()}
+    Attachments = ${SendActivity_BotTourOverview_attachment_AdaptiveCard()}
 ]
 
-# SendActivity_BotTourOverview_attachment_WGITEE()
+# SendActivity_BotTourOverview_attachment_AdaptiveCard()
 > OverviewCard
 - ```${json(CardTemplate(BotTourHeader(), ExpandableListCardBody(createArray(BotTourOption(BotTourContentTextOne()),BotTourOption(BotTourContentTextTwo()),BotTourOption(BotTourContentTextThree())), 5), ''))}```
 
-# SendActivity_BotTourFocus()
+# SendActivity_BotTourDetails()
 [Activity
-    Attachments = ${SendActivity_BotTourFocus_attachment_cKtuIu()}
+    Attachments = ${SendActivity_BotTourDetails_attachment_AdaptiveCard()}
 ]
 
-# SendActivity_BotTourFocus_attachment_cKtuIu()
+# SendActivity_BotTourDetails_attachment_AdaptiveCard()
 > DetailsCard
 - ```${json(CardTemplate(BotTourDetailsCardHeader(),BotTourDetailsCardBody(), BotTourDetailsCardActions()))}```
 

--- a/generators/generator-bot-assistant-core/generators/app/templates/dialogs/BotTourDialog/language-generation/en-us/BotTourDialog.en-us.lg
+++ b/generators/generator-bot-assistant-core/generators/app/templates/dialogs/BotTourDialog/language-generation/en-us/BotTourDialog.en-us.lg
@@ -1,20 +1,20 @@
 [import](common.lg)
 
-# SendActivity_BotTourChevronCard()
+# SendActivity_BotTourOverview()
 [Activity
-    Attachments = ${SendActivity_BotTourChevronCard_attachment_WGITEE()}
+    Attachments = ${SendActivity_BotTourOverview_attachment_WGITEE()}
 ]
 
-# SendActivity_BotTourChevronCard_attachment_WGITEE()
+# SendActivity_BotTourOverview_attachment_WGITEE()
 > ChevronCard
 - ```${json(CardTemplate(BotTourHeader(), ExpandableListCardBody(createArray(BotTourOption(BotTourContentTextOne()),BotTourOption(BotTourContentTextTwo()),BotTourOption(BotTourContentTextThree())), 5), ''))}```
 
-# SendActivity_BotTourFocusCard()
+# SendActivity_BotTourFocus()
 [Activity
-    Attachments = ${SendActivity_BotTourFocusCard_attachment_cKtuIu()}
+    Attachments = ${SendActivity_BotTourFocus_attachment_cKtuIu()}
 ]
 
-# SendActivity_BotTourFocusCard_attachment_cKtuIu()
+# SendActivity_BotTourFocus_attachment_cKtuIu()
 > FocusCard
 - ```${json(CardTemplate(BotTourFocusCardHeader(),BotTourFocusCardBody(), BotTourFocusCardActions()))}```
 

--- a/generators/generator-bot-assistant-core/generators/app/templates/dialogs/BotTourDialog/language-generation/en-us/BotTourDialog.en-us.lg
+++ b/generators/generator-bot-assistant-core/generators/app/templates/dialogs/BotTourDialog/language-generation/en-us/BotTourDialog.en-us.lg
@@ -6,7 +6,7 @@
 ]
 
 # SendActivity_BotTourOverview_attachment_WGITEE()
-> ChevronCard
+> OverviewCard
 - ```${json(CardTemplate(BotTourHeader(), ExpandableListCardBody(createArray(BotTourOption(BotTourContentTextOne()),BotTourOption(BotTourContentTextTwo()),BotTourOption(BotTourContentTextThree())), 5), ''))}```
 
 # SendActivity_BotTourFocus()
@@ -15,8 +15,8 @@
 ]
 
 # SendActivity_BotTourFocus_attachment_cKtuIu()
-> FocusCard
-- ```${json(CardTemplate(BotTourFocusCardHeader(),BotTourFocusCardBody(), BotTourFocusCardActions()))}```
+> DetailsCard
+- ```${json(CardTemplate(BotTourDetailsCardHeader(),BotTourDetailsCardBody(), BotTourDetailsCardActions()))}```
 
 # BotTourTitle()
 - You can ask me...
@@ -33,7 +33,7 @@
 # BotTourContentTextThree()
 - You can also provide samples to trigger connected skills.
 
-# BotTourFocusCardText()
+# BotTourDetailsCardText()
 - You can provide a more detailed description of your skill, as well as sample utterances users can say to get started.
 
 # BotTourHeader
@@ -124,16 +124,16 @@
    ],
    "selectAction":{
       "type":"Action.Submit",
-      "title":"FocusCard",
+      "title":"DetailsCard",
       "data":{
-         "intent":"FocusCard"
+         "intent":"DetailsCard"
       }
    },
    "separator": true
 }
 ```
 
-# BotTourFocusCardHeader()
+# BotTourDetailsCardHeader()
 - ```
 {
     "type": "Container",
@@ -174,21 +174,21 @@
 }
 ```
 
-# BotTourFocusCardBody()
+# BotTourDetailsCardBody()
 -```
 {
     "type": "Container",
     "items": [
         {
             "type": "TextBlock",
-            "text": "${BotTourFocusCardText()}",
+            "text": "${BotTourDetailsCardText()}",
             "wrap": true
         }        
     ]
 }
 ```
 
-# BotTourFocusCardActions()
+# BotTourDetailsCardActions()
 - ```
 {
     "type": "ActionSet",

--- a/generators/generator-bot-assistant-core/generators/app/templates/dialogs/BotTourDialog/language-generation/en-us/BotTourDialog.en-us.lg
+++ b/generators/generator-bot-assistant-core/generators/app/templates/dialogs/BotTourDialog/language-generation/en-us/BotTourDialog.en-us.lg
@@ -2,19 +2,19 @@
 
 # SendActivity_BotTourOverview()
 [Activity
-    Attachments = ${SendActivity_BotTourOverview_attachment_AdaptiveCard()}
+    Attachments = ${SendActivity_BotTourOverview_attachment_adaptiveCard()}
 ]
 
-# SendActivity_BotTourOverview_attachment_AdaptiveCard()
+# SendActivity_BotTourOverview_attachment_adaptiveCard()
 > OverviewCard
 - ```${json(CardTemplate(BotTourHeader(), ExpandableListCardBody(createArray(BotTourOption(BotTourContentTextOne()),BotTourOption(BotTourContentTextTwo()),BotTourOption(BotTourContentTextThree())), 5), ''))}```
 
 # SendActivity_BotTourDetails()
 [Activity
-    Attachments = ${SendActivity_BotTourDetails_attachment_AdaptiveCard()}
+    Attachments = ${SendActivity_BotTourDetails_attachment_adaptiveCard()}
 ]
 
-# SendActivity_BotTourDetails_attachment_AdaptiveCard()
+# SendActivity_BotTourDetails_attachment_adaptiveCard()
 > DetailsCard
 - ```${json(CardTemplate(BotTourDetailsCardHeader(),BotTourDetailsCardBody(), BotTourDetailsCardActions()))}```
 

--- a/generators/generator-bot-assistant-core/generators/app/templates/dialogs/BotTourDialog/language-generation/en-us/BotTourDialog.en-us.lg
+++ b/generators/generator-bot-assistant-core/generators/app/templates/dialogs/BotTourDialog/language-generation/en-us/BotTourDialog.en-us.lg
@@ -1,9 +1,22 @@
 [import](common.lg)
 
-# SendActivity_YRvoei()
+# SendActivity_BotTourChevronCard()
 [Activity
-    Attachments = ${SendActivity_YRvoei_attachment_WGITEE()}
+    Attachments = ${SendActivity_BotTourChevronCard_attachment_WGITEE()}
 ]
+
+# SendActivity_BotTourChevronCard_attachment_WGITEE()
+> ChevronCard
+- ```${json(CardTemplate(BotTourHeader(), ExpandableListCardBody(createArray(BotTourOption(BotTourContentTextOne()),BotTourOption(BotTourContentTextTwo()),BotTourOption(BotTourContentTextThree())), 5), ''))}```
+
+# SendActivity_BotTourFocusCard()
+[Activity
+    Attachments = ${SendActivity_BotTourFocusCard_attachment_cKtuIu()}
+]
+
+# SendActivity_BotTourFocusCard_attachment_cKtuIu()
+> FocusCard
+- ```${json(CardTemplate(BotTourFocusCardHeader(),BotTourFocusCardBody(), BotTourFocusCardActions()))}```
 
 # BotTourTitle()
 - You can ask me...
@@ -205,15 +218,4 @@
 }
 ```
 
-# SendActivity_YRvoei_attachment_WGITEE()
-> Bot tour chevron card
-- ```${json(CardTemplate(BotTourHeader(), ExpandableListCardBody(createArray(BotTourOption(BotTourContentTextOne()),BotTourOption(BotTourContentTextTwo()),BotTourOption(BotTourContentTextThree())), 5), ''))}```
 
-# SendActivity_Z5JucQ()
-[Activity
-    Attachments = ${SendActivity_Z5JucQ_attachment_cKtuIu()}
-]
-
-# SendActivity_Z5JucQ_attachment_cKtuIu()
-> Focus card
-- ```${json(CardTemplate(BotTourFocusCardHeader(),BotTourFocusCardBody(), BotTourFocusCardActions()))}```

--- a/generators/generator-bot-assistant-core/generators/app/templates/dialogs/ChitchatDialog/ChitchatDialog.dialog
+++ b/generators/generator-bot-assistant-core/generators/app/templates/dialogs/ChitchatDialog/ChitchatDialog.dialog
@@ -37,7 +37,7 @@
               "maxTurnCount": 3,
               "alwaysPrompt": true,
               "allowInterruptions": false,
-              "prompt": "${TextInput_Prompt_C244wC()}",
+              "prompt": "${TextInput_Prompt_QnaMultiTurnResponse()}",
               "property": "turn.qnaMultiTurnResponse"
             },
             {
@@ -87,7 +87,7 @@
               "$designer": {
                 "id": "zIdYcy"
               },
-              "activity": "${SendActivity_hJgJx8()}"
+              "activity": "${SendActivity_QnaResponse()}"
             }
           ]
         }

--- a/generators/generator-bot-assistant-core/generators/app/templates/dialogs/ChitchatDialog/ChitchatDialog.dialog
+++ b/generators/generator-bot-assistant-core/generators/app/templates/dialogs/ChitchatDialog/ChitchatDialog.dialog
@@ -103,9 +103,9 @@
         {
           "$kind": "Microsoft.SendActivity",
           "$designer": {
-            "id": "gc2wn4"
+            "id": "DidntGetThat"
           },
-          "activity": "${SendActivity_gc2wn4()}"
+          "activity": "${SendActivity_DidntGetThat()}"
         }
       ]
     }

--- a/generators/generator-bot-assistant-core/generators/app/templates/dialogs/ChitchatDialog/ChitchatDialog.dialog
+++ b/generators/generator-bot-assistant-core/generators/app/templates/dialogs/ChitchatDialog/ChitchatDialog.dialog
@@ -103,7 +103,7 @@
         {
           "$kind": "Microsoft.SendActivity",
           "$designer": {
-            "id": "DidntGetThat"
+            "id": "gc2wn4"
           },
           "activity": "${SendActivity_DidntGetThat()}"
         }

--- a/generators/generator-bot-assistant-core/generators/app/templates/dialogs/ChitchatDialog/ChitchatDialog.dialog
+++ b/generators/generator-bot-assistant-core/generators/app/templates/dialogs/ChitchatDialog/ChitchatDialog.dialog
@@ -105,7 +105,7 @@
           "$designer": {
             "id": "gc2wn4"
           },
-          "activity": "${SendActivity_DidntGetThat()}"
+          "activity": "${SendActivity_DidNotUnderstand()}"
         }
       ]
     }

--- a/generators/generator-bot-assistant-core/generators/app/templates/dialogs/ChitchatDialog/language-generation/en-us/ChitchatDialog.en-us.lg
+++ b/generators/generator-bot-assistant-core/generators/app/templates/dialogs/ChitchatDialog/language-generation/en-us/ChitchatDialog.en-us.lg
@@ -1,12 +1,12 @@
 [import](common.lg)
 
-# TextInput_Prompt_C244wC()
+# TextInput_Prompt_QnaMultiTurnResponse()
 [Activity
     Text = ${expandText(@answer)}
     SuggestedActions = ${foreach(turn.recognized.answers[0].context.prompts, x, x.displayText)}
 ]
 
-# SendActivity_hJgJx8()
+# SendActivity_QnaResponse()
 - ${expandText(@answer)}
 
 # SendActivity_DidNotUnderstand()

--- a/generators/generator-bot-assistant-core/generators/app/templates/dialogs/ChitchatDialog/language-generation/en-us/ChitchatDialog.en-us.lg
+++ b/generators/generator-bot-assistant-core/generators/app/templates/dialogs/ChitchatDialog/language-generation/en-us/ChitchatDialog.en-us.lg
@@ -9,12 +9,12 @@
 # SendActivity_hJgJx8()
 - ${expandText(@answer)}
 
-# SendActivity_gc2wn4()
+# SendActivity_DidntGetThat()
 [Activity
-    Text = ${SendActivity_gc2wn4_text()}
+    Text = ${SendActivity_DidntGetThat_text()}
 ]
 
-# SendActivity_gc2wn4_text()
+# SendActivity_DidntGetThat_text()
 - I'm not sure I understand. Can you please try again?
 - Hmm, I don't understand. Can you try to ask me in a different way.
 - I didn't get that. Would you mind rephrasing and try it again.

--- a/generators/generator-bot-assistant-core/generators/app/templates/dialogs/ChitchatDialog/language-generation/en-us/ChitchatDialog.en-us.lg
+++ b/generators/generator-bot-assistant-core/generators/app/templates/dialogs/ChitchatDialog/language-generation/en-us/ChitchatDialog.en-us.lg
@@ -9,12 +9,12 @@
 # SendActivity_hJgJx8()
 - ${expandText(@answer)}
 
-# SendActivity_DidntGetThat()
+# SendActivity_DidNotUnderstand()
 [Activity
-    Text = ${SendActivity_DidntGetThat_text()}
+    Text = ${SendActivity_DidNotUnderstand_text()}
 ]
 
-# SendActivity_DidntGetThat_text()
+# SendActivity_DidNotUnderstand_text()
 - I'm not sure I understand. Can you please try again?
 - Hmm, I don't understand. Can you try to ask me in a different way.
 - I didn't get that. Would you mind rephrasing and try it again.

--- a/generators/generator-bot-assistant-core/generators/app/templates/dialogs/FeedbackDialog/FeedbackDialog.dialog
+++ b/generators/generator-bot-assistant-core/generators/app/templates/dialogs/FeedbackDialog/FeedbackDialog.dialog
@@ -25,9 +25,9 @@
         {
           "$kind": "Microsoft.SendActivity",
           "$designer": {
-            "id": "ThumbsUpDownPrompt"
+            "id": "AskAboutExperiencePrompt"
           },
-          "activity": "${SendActivity_ThumbsUpDownPrompt()}"
+          "activity": "${SendActivity_AskAboutExperiencePrompt()}"
         }
       ]
     },

--- a/generators/generator-bot-assistant-core/generators/app/templates/dialogs/FeedbackDialog/FeedbackDialog.dialog
+++ b/generators/generator-bot-assistant-core/generators/app/templates/dialogs/FeedbackDialog/FeedbackDialog.dialog
@@ -61,7 +61,7 @@
           "$designer": {
             "id": "639pkl"
           },
-          "activity": "${SendActivity_639pkl()}"
+          "activity": "${SendActivity_ThanksForFeedback()}"
         },
         {
           "$kind": "Microsoft.EndDialog",

--- a/generators/generator-bot-assistant-core/generators/app/templates/dialogs/FeedbackDialog/FeedbackDialog.dialog
+++ b/generators/generator-bot-assistant-core/generators/app/templates/dialogs/FeedbackDialog/FeedbackDialog.dialog
@@ -25,9 +25,9 @@
         {
           "$kind": "Microsoft.SendActivity",
           "$designer": {
-            "id": "GstWEQ"
+            "id": "ThumbsUpDownPrompt"
           },
-          "activity": "${SendActivity_GstWEQ()}"
+          "activity": "${SendActivity_ThumbsUpDownPrompt()}"
         }
       ]
     },
@@ -101,7 +101,7 @@
           "$designer": {
             "id": "YBCkGQ"
           },
-          "activity": "${SendActivity_YBCkGQ()}"
+          "activity": "${SendActivity_ThanksForFeedback()}"
         },
         {
           "$kind": "Microsoft.EndDialog",

--- a/generators/generator-bot-assistant-core/generators/app/templates/dialogs/FeedbackDialog/FeedbackDialog.dialog
+++ b/generators/generator-bot-assistant-core/generators/app/templates/dialogs/FeedbackDialog/FeedbackDialog.dialog
@@ -25,9 +25,9 @@
         {
           "$kind": "Microsoft.SendActivity",
           "$designer": {
-            "id": "AskAboutExperiencePrompt"
+            "id": "GstWEQ"
           },
-          "activity": "${SendActivity_AskAboutExperiencePrompt()}"
+          "activity": "${SendActivity_FeedbackExperiencePrompt()}"
         }
       ]
     },
@@ -61,7 +61,7 @@
           "$designer": {
             "id": "639pkl"
           },
-          "activity": "${SendActivity_ThanksForFeedback()}"
+          "activity": "${SendActivity_FeedbackThanks()}"
         },
         {
           "$kind": "Microsoft.EndDialog",
@@ -101,7 +101,7 @@
           "$designer": {
             "id": "YBCkGQ"
           },
-          "activity": "${SendActivity_ThanksForFeedback()}"
+          "activity": "${SendActivity_FeedbackThanks()}"
         },
         {
           "$kind": "Microsoft.EndDialog",

--- a/generators/generator-bot-assistant-core/generators/app/templates/dialogs/FeedbackDialog/language-generation/en-us/FeedbackDialog.en-us.lg
+++ b/generators/generator-bot-assistant-core/generators/app/templates/dialogs/FeedbackDialog/language-generation/en-us/FeedbackDialog.en-us.lg
@@ -3,7 +3,7 @@
 # SendActivity_FeedbackExperiencePrompt()
 [Activity
     Text = ${SendActivity_FeedbackExperiencePrompt_text()}
-    Attachments = ${SendActivity_FeedbackExperiencePrompt_attachment_N1EQ7u()}
+    Attachments = ${SendActivity_FeedbackExperiencePrompt_attachment_AdaptiveCard()}
 ]
 
 # SendActivity_FeedbackExperiencePrompt_text()
@@ -11,8 +11,8 @@
 - Did the bot meet your expectations?
 - Did you like this interaction with the bot?
 
-# SendActivity_FeedbackExperiencePrompt_attachment_N1EQ7u()
-> LikeDislike Feedback Card
+# SendActivity_FeedbackExperiencePrompt_attachment_AdaptiveCard()
+> LikeDislikeCard
 - ```${json(CardTemplate(FeedbackHeader(),FeedbackBody(),FeedbackActions()))}```
 
 # SendActivity_FeedbackThanks()

--- a/generators/generator-bot-assistant-core/generators/app/templates/dialogs/FeedbackDialog/language-generation/en-us/FeedbackDialog.en-us.lg
+++ b/generators/generator-bot-assistant-core/generators/app/templates/dialogs/FeedbackDialog/language-generation/en-us/FeedbackDialog.en-us.lg
@@ -1,19 +1,29 @@
 [import](common.lg)
 
-# SendActivity_AskAboutExperiencePrompt()
+# SendActivity_FeedbackExperiencePrompt()
 [Activity
-    Text = ${SendActivity_AskAboutExperiencePrompt_text()}
-    Attachments = ${SendActivity_AskAboutExperiencePrompt_attachment_N1EQ7u()}
+    Text = ${SendActivity_FeedbackExperiencePrompt_text()}
+    Attachments = ${SendActivity_FeedbackExperiencePrompt_attachment_N1EQ7u()}
 ]
 
-# SendActivity_AskAboutExperiencePrompt_text()
+# SendActivity_FeedbackExperiencePrompt_text()
 - Did the experience meet your expectations?
 - Did the bot meet your expectations?
 - Did you like this interaction with the bot?
 
-# SendActivity_AskAboutExperiencePrompt_attachment_N1EQ7u()
+# SendActivity_FeedbackExperiencePrompt_attachment_N1EQ7u()
 > LikeDislike Feedback Card
 - ```${json(CardTemplate(FeedbackHeader(),FeedbackBody(),FeedbackActions()))}```
+
+# SendActivity_FeedbackThanks()
+[Activity
+    Text = ${SendActivity_FeedbackThanks_text()}
+]
+
+# SendActivity_FeedbackThanks_text()
+- Thank you for this feedback.
+- Thanks for your feedback.
+- Thank you, I've captured your feedback.
 
 # FeedbackTitle()
 - Feedback
@@ -177,12 +187,4 @@
 }
 ```
 
-# SendActivity_ThanksForFeedback()
-[Activity
-    Text = ${SendActivity_ThanksForFeedback_text()}
-]
 
-# SendActivity_ThanksForFeedback_text()
-- Thank you for this feedback.
-- Thanks for your feedback.
-- Thank you, I've captured your feedback.

--- a/generators/generator-bot-assistant-core/generators/app/templates/dialogs/FeedbackDialog/language-generation/en-us/FeedbackDialog.en-us.lg
+++ b/generators/generator-bot-assistant-core/generators/app/templates/dialogs/FeedbackDialog/language-generation/en-us/FeedbackDialog.en-us.lg
@@ -3,7 +3,7 @@
 # SendActivity_FeedbackExperiencePrompt()
 [Activity
     Text = ${SendActivity_FeedbackExperiencePrompt_text()}
-    Attachments = ${SendActivity_FeedbackExperiencePrompt_attachment_AdaptiveCard()}
+    Attachments = ${SendActivity_FeedbackExperiencePrompt_attachment_adaptiveCard()}
 ]
 
 # SendActivity_FeedbackExperiencePrompt_text()
@@ -11,7 +11,7 @@
 - Did the bot meet your expectations?
 - Did you like this interaction with the bot?
 
-# SendActivity_FeedbackExperiencePrompt_attachment_AdaptiveCard()
+# SendActivity_FeedbackExperiencePrompt_attachment_adaptiveCard()
 > LikeDislikeCard
 - ```${json(CardTemplate(FeedbackHeader(),FeedbackBody(),FeedbackActions()))}```
 

--- a/generators/generator-bot-assistant-core/generators/app/templates/dialogs/FeedbackDialog/language-generation/en-us/FeedbackDialog.en-us.lg
+++ b/generators/generator-bot-assistant-core/generators/app/templates/dialogs/FeedbackDialog/language-generation/en-us/FeedbackDialog.en-us.lg
@@ -1,15 +1,19 @@
 [import](common.lg)
 
-# SendActivity_ThumbsUpDownPrompt()
+# SendActivity_AskAboutExperiencePrompt()
 [Activity
-    Text = ${SendActivity_ThumbsUpDownPrompt_text()}
-    Attachments = ${SendActivity_ThumbsUpDownPrompt_attachment_N1EQ7u()}
+    Text = ${SendActivity_AskAboutExperiencePrompt_text()}
+    Attachments = ${SendActivity_AskAboutExperiencePrompt_attachment_N1EQ7u()}
 ]
 
-# SendActivity_ThumbsUpDownPrompt_text()
+# SendActivity_AskAboutExperiencePrompt_text()
 - Did the experience meet your expectations?
 - Did the bot meet your expectations?
 - Did you like this interaction with the bot?
+
+# SendActivity_AskAboutExperiencePrompt_attachment_N1EQ7u()
+> LikeDislike Feedback Card
+- ```${json(CardTemplate(FeedbackHeader(),FeedbackBody(),FeedbackActions()))}```
 
 # FeedbackTitle()
 - Feedback
@@ -172,10 +176,6 @@
     ]
 }
 ```
-
-# SendActivity_ThumbsUpDownPrompt_attachment_N1EQ7u()
-> LikeDislike Feedback Card
-- ```${json(CardTemplate(FeedbackHeader(),FeedbackBody(),FeedbackActions()))}```
 
 # SendActivity_ThanksForFeedback()
 [Activity

--- a/generators/generator-bot-assistant-core/generators/app/templates/dialogs/FeedbackDialog/language-generation/en-us/FeedbackDialog.en-us.lg
+++ b/generators/generator-bot-assistant-core/generators/app/templates/dialogs/FeedbackDialog/language-generation/en-us/FeedbackDialog.en-us.lg
@@ -1,12 +1,12 @@
 [import](common.lg)
 
-# SendActivity_GstWEQ()
+# SendActivity_ThumbsUpDownPrompt()
 [Activity
-    Text = ${SendActivity_GstWEQ_text()}
-    Attachments = ${SendActivity_GstWEQ_attachment_N1EQ7u()}
+    Text = ${SendActivity_ThumbsUpDownPrompt_text()}
+    Attachments = ${SendActivity_ThumbsUpDownPrompt_attachment_N1EQ7u()}
 ]
 
-# SendActivity_GstWEQ_text()
+# SendActivity_ThumbsUpDownPrompt_text()
 - Did the experience meet your expectations?
 - Did the bot meet your expectations?
 - Did you like this interaction with the bot?
@@ -173,26 +173,16 @@
 }
 ```
 
-# SendActivity_GstWEQ_attachment_N1EQ7u()
+# SendActivity_ThumbsUpDownPrompt_attachment_N1EQ7u()
 > LikeDislike Feedback Card
 - ```${json(CardTemplate(FeedbackHeader(),FeedbackBody(),FeedbackActions()))}```
 
-# SendActivity_639pkl()
+# SendActivity_ThanksForFeedback()
 [Activity
-    Text = ${SendActivity_639pkl_text()}
+    Text = ${SendActivity_ThanksForFeedback_text()}
 ]
 
-# SendActivity_639pkl_text()
-- Thank you for this feedback.
-- Thanks for your feedback.
-- Thank you, I've captured your feedback.
-
-# SendActivity_YBCkGQ()
-[Activity
-    Text = ${SendActivity_YBCkGQ_text()}
-]
-
-# SendActivity_YBCkGQ_text()
+# SendActivity_ThanksForFeedback_text()
 - Thank you for this feedback.
 - Thanks for your feedback.
 - Thank you, I've captured your feedback.

--- a/generators/generator-bot-assistant-core/generators/app/templates/language-generation/en-us/botName.en-us.lg
+++ b/generators/generator-bot-assistant-core/generators/app/templates/language-generation/en-us/botName.en-us.lg
@@ -50,12 +50,12 @@
   buttons = ${BotTourEventAction()}
 ]
 
-# SendActivity_2outgQ()
+# SendActivity_ErrorOccured()
 [Activity
-    Text = ${SendActivity_2outgQ_text()}
+    Text = ${SendActivity_ErrorOccured_text()}
 ]
 
-# SendActivity_2outgQ_text()
+# SendActivity_ErrorOccured_text()
 - Oops, looks like I'm stuck. Can you try to ask me in a different way?
 - Looks like I'm all mixed up. Let's try asking again, but maybe rephrase your request?
 - Sorry, it looks like something went wrong. Can you please try again?

--- a/generators/generator-bot-assistant-core/generators/app/templates/language-generation/en-us/botName.en-us.lg
+++ b/generators/generator-bot-assistant-core/generators/app/templates/language-generation/en-us/botName.en-us.lg
@@ -10,28 +10,17 @@
 - Looks like I'm all mixed up. Let's try asking again, but maybe rephrase your request?
 - Sorry, it looks like something went wrong. Can you please try again?
 
-# SendActivity_DidntGetThat()
+# SendActivity_WelcomeReturningUser()
 [Activity
-    Text = ${SendActivity_DidntGetThat_text()}
+    Attachments = ${SendActivity_WelcomeReturningUser_attachment_9sGxgG()}
 ]
 
-# SendActivity_DidntGetThat_text()
-- I'm not sure I understand. Can you please try again?
-- Hmm, I don't understand. Can you try to ask me in a different way?
-- I didn't get that. Would you mind rephrasing and try it again?
-- Unfortunately I misunderstood, please try again.
-
-# SendActivity_yXbfKT()
+# SendActivity_WelcomeNewUser()
 [Activity
-    Attachments = ${SendActivity_yXbfKT_attachment_9sGxgG()}
+    Attachments = ${SendActivity_WelcomeNewUser_attachment_SR7bxz()}
 ]
 
-# SendActivity_XZRD8m()
-[Activity
-    Attachments = ${SendActivity_XZRD8m_attachment_SR7bxz()}
-]
-
-# SendActivity_yXbfKT_attachment_9sGxgG()
+# SendActivity_WelcomeReturningUser_attachment_9sGxgG()
 [HeroCard
   text = ${WelcomeReturningUser()}
   buttons = ${BotTourEventAction()}
@@ -44,7 +33,7 @@
     value = ${{ intent: "BotTour" }}
 ]
 
-# SendActivity_XZRD8m_attachment_SR7bxz()
+# SendActivity_WelcomeNewUser_attachment_SR7bxz()
 [HeroCard
   text = ${WelcomeNewUser()}
   buttons = ${BotTourEventAction()}

--- a/generators/generator-bot-assistant-core/generators/app/templates/language-generation/en-us/botName.en-us.lg
+++ b/generators/generator-bot-assistant-core/generators/app/templates/language-generation/en-us/botName.en-us.lg
@@ -2,10 +2,10 @@
 
 # SendActivity_GreetingNewUser()
 [Activity
-    Attachments = ${SendActivity_GreetingNewUser_attachment_SR7bxz()}
+    Attachments = ${SendActivity_GreetingNewUser_attachment_HeroCard()}
 ]
 
-# SendActivity_GreetingNewUser_attachment_SR7bxz()
+# SendActivity_GreetingNewUser_attachment_HeroCard()
 [HeroCard
   text = ${GreetingNewUser_text()}
   buttons = ${GreetingBotTourIntent_action()}
@@ -13,10 +13,10 @@
 
 # SendActivity_GreetingReturningUser()
 [Activity
-    Attachments = ${SendActivity_GreetingReturningUser_attachment_9sGxgG()}
+    Attachments = ${SendActivity_GreetingReturningUser_attachment_HeroCard()}
 ]
 
-# SendActivity_GreetingReturningUser_attachment_9sGxgG()
+# SendActivity_GreetingReturningUser_attachment_HeroCard()
 [HeroCard
   text = ${GreetingReturningUser_text()}
   buttons = ${GreetingBotTourIntent_action()}

--- a/generators/generator-bot-assistant-core/generators/app/templates/language-generation/en-us/botName.en-us.lg
+++ b/generators/generator-bot-assistant-core/generators/app/templates/language-generation/en-us/botName.en-us.lg
@@ -1,5 +1,27 @@
 [import](common.lg)
 
+# SendActivity_WelcomeNewUser()
+[Activity
+    Attachments = ${SendActivity_WelcomeNewUser_attachment_SR7bxz()}
+]
+
+# SendActivity_WelcomeNewUser_attachment_SR7bxz()
+[HeroCard
+  text = ${WelcomeNewUser()}
+  buttons = ${BotTourEventAction()}
+]
+
+# SendActivity_WelcomeReturningUser()
+[Activity
+    Attachments = ${SendActivity_WelcomeReturningUser_attachment_9sGxgG()}
+]
+
+# SendActivity_WelcomeReturningUser_attachment_9sGxgG()
+[HeroCard
+  text = ${WelcomeReturningUser()}
+  buttons = ${BotTourEventAction()}
+]
+
 # SendActivity_ErrorOccured()
 [Activity
     Text = ${SendActivity_ErrorOccured_text()}
@@ -10,22 +32,6 @@
 - Looks like I'm all mixed up. Let's try asking again, but maybe rephrase your request?
 - Sorry, it looks like something went wrong. Can you please try again?
 
-# SendActivity_WelcomeReturningUser()
-[Activity
-    Attachments = ${SendActivity_WelcomeReturningUser_attachment_9sGxgG()}
-]
-
-# SendActivity_WelcomeNewUser()
-[Activity
-    Attachments = ${SendActivity_WelcomeNewUser_attachment_SR7bxz()}
-]
-
-# SendActivity_WelcomeReturningUser_attachment_9sGxgG()
-[HeroCard
-  text = ${WelcomeReturningUser()}
-  buttons = ${BotTourEventAction()}
-]
-
 # BotTourEventAction()
 [CardAction
     title = You can ask me
@@ -33,11 +39,7 @@
     value = ${{ intent: "BotTour" }}
 ]
 
-# SendActivity_WelcomeNewUser_attachment_SR7bxz()
-[HeroCard
-  text = ${WelcomeNewUser()}
-  buttons = ${BotTourEventAction()}
-]
+
 
 # TextInput_Prompt_YQSOpf()
 [Activity

--- a/generators/generator-bot-assistant-core/generators/app/templates/language-generation/en-us/botName.en-us.lg
+++ b/generators/generator-bot-assistant-core/generators/app/templates/language-generation/en-us/botName.en-us.lg
@@ -1,25 +1,44 @@
-[import](common.lg)
+﻿[import](common.lg)
 
-# SendActivity_WelcomeNewUser()
+# SendActivity_GreetingNewUser()
 [Activity
-    Attachments = ${SendActivity_WelcomeNewUser_attachment_SR7bxz()}
+    Attachments = ${SendActivity_GreetingNewUser_attachment_SR7bxz()}
 ]
 
-# SendActivity_WelcomeNewUser_attachment_SR7bxz()
+# SendActivity_GreetingNewUser_attachment_SR7bxz()
 [HeroCard
-  text = ${WelcomeNewUser()}
-  buttons = ${BotTourEventAction()}
+  text = ${GreetingNewUser_text()}
+  buttons = ${WelcomeBotTourIntent_action()}
 ]
 
-# SendActivity_WelcomeReturningUser()
+# SendActivity_GreetingReturningUser()
 [Activity
-    Attachments = ${SendActivity_WelcomeReturningUser_attachment_9sGxgG()}
+    Attachments = ${SendActivity_GreetingReturningUser_attachment_9sGxgG()}
 ]
 
-# SendActivity_WelcomeReturningUser_attachment_9sGxgG()
+# SendActivity_GreetingReturningUser_attachment_9sGxgG()
 [HeroCard
-  text = ${WelcomeReturningUser()}
-  buttons = ${BotTourEventAction()}
+  text = ${GreetingReturningUser_text()}
+  buttons = ${WelcomeBotTourIntent_action()}
+]
+
+# GreetingNewUser_text()
+- 🖐️ Hey, there! How can I help you today?
+- 🖐️ Hi! How can I help?
+- 🖐️ Hello! What do you want to do today?
+
+# GreetingReturningUser_text()
+- 🖐️ Welcome back! How can I help you today?
+- 🖐️ Hello again! What can I help with?
+- 🖐️ Good to see you again. What do you want to do today?
+- 🖐️ Hey, there! Let's get started.
+- 🖐️ Hello again! How can I help?
+
+# WelcomeBotTourIntent_action()
+[CardAction
+    title = You can ask me
+    type = ${if(turn.activity.channelId == 'msteams', "messageBack", "postBack")}
+    value = ${{ intent: "BotTour" }}
 ]
 
 # SendActivity_ErrorOccured()
@@ -31,15 +50,6 @@
 - Oops, looks like I'm stuck. Can you try to ask me in a different way?
 - Looks like I'm all mixed up. Let's try asking again, but maybe rephrase your request?
 - Sorry, it looks like something went wrong. Can you please try again?
-
-# BotTourEventAction()
-[CardAction
-    title = You can ask me
-    type = ${if(turn.activity.channelId == 'msteams', "messageBack", "postBack")}
-    value = ${{ intent: "BotTour" }}
-]
-
-
 
 # TextInput_Prompt_YQSOpf()
 [Activity

--- a/generators/generator-bot-assistant-core/generators/app/templates/language-generation/en-us/botName.en-us.lg
+++ b/generators/generator-bot-assistant-core/generators/app/templates/language-generation/en-us/botName.en-us.lg
@@ -8,7 +8,7 @@
 # SendActivity_GreetingNewUser_attachment_SR7bxz()
 [HeroCard
   text = ${GreetingNewUser_text()}
-  buttons = ${WelcomeBotTourIntent_action()}
+  buttons = ${GreetingBotTourIntent_action()}
 ]
 
 # SendActivity_GreetingReturningUser()
@@ -19,7 +19,7 @@
 # SendActivity_GreetingReturningUser_attachment_9sGxgG()
 [HeroCard
   text = ${GreetingReturningUser_text()}
-  buttons = ${WelcomeBotTourIntent_action()}
+  buttons = ${GreetingBotTourIntent_action()}
 ]
 
 # GreetingNewUser_text()
@@ -34,7 +34,7 @@
 - 🖐️ Hey, there! Let's get started.
 - 🖐️ Hello again! How can I help?
 
-# WelcomeBotTourIntent_action()
+# GreetingBotTourIntent_action()
 [CardAction
     title = You can ask me
     type = ${if(turn.activity.channelId == 'msteams', "messageBack", "postBack")}

--- a/generators/generator-bot-assistant-core/generators/app/templates/language-generation/en-us/botName.en-us.lg
+++ b/generators/generator-bot-assistant-core/generators/app/templates/language-generation/en-us/botName.en-us.lg
@@ -1,21 +1,21 @@
 [import](common.lg)
 
-# SendActivity_mM3nez()
+# SendActivity_ErrorOccured()
 [Activity
-    Text = ${SendActivity_mM3nez_text()}
+    Text = ${SendActivity_ErrorOccured_text()}
 ]
 
-# SendActivity_mM3nez_text()
+# SendActivity_ErrorOccured_text()
 - Oops, looks like I'm stuck. Can you try to ask me in a different way?
 - Looks like I'm all mixed up. Let's try asking again, but maybe rephrase your request?
 - Sorry, it looks like something went wrong. Can you please try again?
 
-# SendActivity_CcTxh7()
+# SendActivity_DidntGetThat()
 [Activity
-    Text = ${SendActivity_CcTxh7_text()}
+    Text = ${SendActivity_DidntGetThat_text()}
 ]
 
-# SendActivity_CcTxh7_text()
+# SendActivity_DidntGetThat_text()
 - I'm not sure I understand. Can you please try again?
 - Hmm, I don't understand. Can you try to ask me in a different way?
 - I didn't get that. Would you mind rephrasing and try it again?
@@ -49,16 +49,6 @@
   text = ${WelcomeNewUser()}
   buttons = ${BotTourEventAction()}
 ]
-
-# SendActivity_ErrorOccured()
-[Activity
-    Text = ${SendActivity_ErrorOccured_text()}
-]
-
-# SendActivity_ErrorOccured_text()
-- Oops, looks like I'm stuck. Can you try to ask me in a different way?
-- Looks like I'm all mixed up. Let's try asking again, but maybe rephrase your request?
-- Sorry, it looks like something went wrong. Can you please try again?
 
 # TextInput_Prompt_YQSOpf()
 [Activity

--- a/generators/generator-bot-assistant-core/generators/app/templates/language-generation/en-us/botName.en-us.lg
+++ b/generators/generator-bot-assistant-core/generators/app/templates/language-generation/en-us/botName.en-us.lg
@@ -2,10 +2,10 @@
 
 # SendActivity_GreetingNewUser()
 [Activity
-    Attachments = ${SendActivity_GreetingNewUser_attachment_HeroCard()}
+    Attachments = ${SendActivity_GreetingNewUser_attachment_heroCard()}
 ]
 
-# SendActivity_GreetingNewUser_attachment_HeroCard()
+# SendActivity_GreetingNewUser_attachment_heroCard()
 [HeroCard
   text = ${GreetingNewUser_text()}
   buttons = ${GreetingBotTourIntent_action()}
@@ -13,10 +13,10 @@
 
 # SendActivity_GreetingReturningUser()
 [Activity
-    Attachments = ${SendActivity_GreetingReturningUser_attachment_HeroCard()}
+    Attachments = ${SendActivity_GreetingReturningUser_attachment_heroCard()}
 ]
 
-# SendActivity_GreetingReturningUser_attachment_HeroCard()
+# SendActivity_GreetingReturningUser_attachment_heroCard()
 [HeroCard
   text = ${GreetingReturningUser_text()}
   buttons = ${GreetingBotTourIntent_action()}

--- a/generators/generator-bot-assistant-core/generators/app/templates/language-generation/en-us/common.en-us.lg
+++ b/generators/generator-bot-assistant-core/generators/app/templates/language-generation/en-us/common.en-us.lg
@@ -1,14 +1,2 @@
 ﻿[Icons](icons.en-us.lg)
 [Cards](cards.en-us.lg)
-
-# WelcomeNewUser()
-- 🖐️ Hey, there! How can I help you today?
-- 🖐️ Hi! How can I help?
-- 🖐️ Hello! What do you want to do today?
-
-# WelcomeReturningUser()
-- 🖐️ Welcome back! How can I help you today?
-- 🖐️ Hello again! What can I help with?
-- 🖐️ Good to see you again. What do you want to do today?
-- 🖐️ Hey, there! Let's get started.
-- 🖐️ Hello again! How can I help?

--- a/generators/generator-bot-conversational-core/generators/app/templates/botName.dialog
+++ b/generators/generator-bot-conversational-core/generators/app/templates/botName.dialog
@@ -126,7 +126,7 @@
         {
           "$kind": "Microsoft.SendActivity",
           "$designer": {
-            "id": "DidntGetThat"
+            "id": "IQMEuO"
           },
           "activity": "${SendActivity_DidntGetThat()}"
         }

--- a/generators/generator-bot-conversational-core/generators/app/templates/botName.dialog
+++ b/generators/generator-bot-conversational-core/generators/app/templates/botName.dialog
@@ -128,7 +128,7 @@
           "$designer": {
             "id": "IQMEuO"
           },
-          "activity": "${SendActivity_DidntGetThat()}"
+          "activity": "${SendActivity_DidNotUnderstand()}"
         }
       ]
     }

--- a/generators/generator-bot-conversational-core/generators/app/templates/botName.dialog
+++ b/generators/generator-bot-conversational-core/generators/app/templates/botName.dialog
@@ -103,7 +103,7 @@
           "$designer": {
             "id": "2outgQ"
           },
-          "activity": "${SendActivity_2outgQ()}"
+          "activity": "${SendActivity_ErrorOccured()}"
         },
         {
           "$kind": "Microsoft.TraceActivity",

--- a/generators/generator-bot-conversational-core/generators/app/templates/botName.dialog
+++ b/generators/generator-bot-conversational-core/generators/app/templates/botName.dialog
@@ -126,9 +126,9 @@
         {
           "$kind": "Microsoft.SendActivity",
           "$designer": {
-            "id": "IQMEuO"
+            "id": "DidntGetThat"
           },
-          "activity": "${SendActivity_IQMEuO()}"
+          "activity": "${SendActivity_DidntGetThat()}"
         }
       ]
     }

--- a/generators/generator-bot-conversational-core/generators/app/templates/language-generation/en-us/botName.en-us.lg
+++ b/generators/generator-bot-conversational-core/generators/app/templates/language-generation/en-us/botName.en-us.lg
@@ -1,5 +1,15 @@
 [import](common.lg)
 
+# SendActivity_ErrorOccured()
+[Activity
+    Text = ${SendActivity_ErrorOccured_text()}
+]
+
+# SendActivity_ErrorOccured_text()
+- Oops, looks like I'm stuck. Can you try to ask me in a different way?
+- Looks like I'm all mixed up. Let's try asking again, but maybe rephrase your request?
+- Sorry, it looks like something went wrong. Can you please try again?
+
 # SendActivity_DidntGetThat()
 [Activity
     Text = ${SendActivity_DidntGetThat_text()}
@@ -10,13 +20,3 @@
 - I'm not sure I understand. Can you please try again?
 - Hmm, I don't understand. Can you try to ask me in a different way. 
 - I didn't get that. Would you mind rephrasing and try it again.
-
-# SendActivity_ErrorOccured()
-[Activity
-    Text = ${SendActivity_ErrorOccured_text()}
-]
-
-# SendActivity_ErrorOccured_text()
-- Oops, looks like I'm stuck. Can you try to ask me in a different way?
-- Looks like I'm all mixed up. Let's try asking again, but maybe rephrase your request?
-- Sorry, it looks like something went wrong. Can you please try again?

--- a/generators/generator-bot-conversational-core/generators/app/templates/language-generation/en-us/botName.en-us.lg
+++ b/generators/generator-bot-conversational-core/generators/app/templates/language-generation/en-us/botName.en-us.lg
@@ -11,12 +11,12 @@
 - I'm not sure I understand. Can you please try again?
 - Hmm, I don't understand. Can you try to ask me in a different way. 
 - I didn't get that. Would you mind rephrasing and try it again.
-# SendActivity_2outgQ()
+# SendActivity_ErrorOccured()
 [Activity
-    Text = ${SendActivity_2outgQ_text()}
+    Text = ${SendActivity_ErrorOccured_text()}
 ]
 
-# SendActivity_2outgQ_text()
+# SendActivity_ErrorOccured_text()
 - Oops, looks like I'm stuck. Can you try to ask me in a different way?
 - Looks like I'm all mixed up. Let's try asking again, but maybe rephrase your request?
 - Sorry, it looks like something went wrong. Can you please try again?

--- a/generators/generator-bot-conversational-core/generators/app/templates/language-generation/en-us/botName.en-us.lg
+++ b/generators/generator-bot-conversational-core/generators/app/templates/language-generation/en-us/botName.en-us.lg
@@ -1,16 +1,16 @@
 [import](common.lg)
 
-
-# SendActivity_IQMEuO()
+# SendActivity_DidntGetThat()
 [Activity
-    Text = ${SendActivity_IQMEuO_text()}
+    Text = ${SendActivity_DidntGetThat_text()}
 ]
 
-# SendActivity_IQMEuO_text()
+# SendActivity_DidntGetThat_text()
 - Sorry, I didn't get that
 - I'm not sure I understand. Can you please try again?
 - Hmm, I don't understand. Can you try to ask me in a different way. 
 - I didn't get that. Would you mind rephrasing and try it again.
+
 # SendActivity_ErrorOccured()
 [Activity
     Text = ${SendActivity_ErrorOccured_text()}

--- a/generators/generator-bot-conversational-core/generators/app/templates/language-generation/en-us/botName.en-us.lg
+++ b/generators/generator-bot-conversational-core/generators/app/templates/language-generation/en-us/botName.en-us.lg
@@ -10,12 +10,12 @@
 - Looks like I'm all mixed up. Let's try asking again, but maybe rephrase your request?
 - Sorry, it looks like something went wrong. Can you please try again?
 
-# SendActivity_DidntGetThat()
+# SendActivity_DidNotUnderstand()
 [Activity
-    Text = ${SendActivity_DidntGetThat_text()}
+    Text = ${SendActivity_DidNotUnderstand_text()}
 ]
 
-# SendActivity_DidntGetThat_text()
+# SendActivity_DidNotUnderstand_text()
 - Sorry, I didn't get that
 - I'm not sure I understand. Can you please try again?
 - Hmm, I don't understand. Can you try to ask me in a different way. 

--- a/generators/generator-bot-empty/generators/app/templates/botName.dialog
+++ b/generators/generator-bot-empty/generators/app/templates/botName.dialog
@@ -43,6 +43,21 @@
           ]
         }
       ]
+    },
+    {
+      "$kind": "Microsoft.OnUnknownIntent",
+      "$designer": {
+        "id": "mb2n1u"
+      },
+      "actions": [
+        {
+          "$kind": "Microsoft.SendActivity",
+          "$designer": {
+            "id": "kMjqz1"
+          },
+          "activity": "${SendActivity_DidntGetThat()}"
+        }
+      ]
     }
   ],
   "generator": "<%= botName %>.lg",

--- a/generators/generator-bot-empty/generators/app/templates/botName.dialog
+++ b/generators/generator-bot-empty/generators/app/templates/botName.dialog
@@ -36,7 +36,7 @@
                     "id": "859266",
                     "name": "Send a response"
                   },
-                  "activity": "${SendActivity_Welcome()}"
+                  "activity": "${SendActivity_Greeting()}"
                 }
               ]
             }

--- a/generators/generator-bot-empty/generators/app/templates/botName.dialog
+++ b/generators/generator-bot-empty/generators/app/templates/botName.dialog
@@ -55,7 +55,7 @@
           "$designer": {
             "id": "kMjqz1"
           },
-          "activity": "${SendActivity_DidntGetThat()}"
+          "activity": "${SendActivity_DidNotUnderstand()}"
         }
       ]
     }

--- a/generators/generator-bot-empty/generators/app/templates/language-generation/en-us/botName.en-us.lg
+++ b/generators/generator-bot-empty/generators/app/templates/language-generation/en-us/botName.en-us.lg
@@ -1,11 +1,11 @@
 [import](common.lg)
 
-# SendActivity_Welcome()
+# SendActivity_Greeting()
 [Activity
     Text = ${SendActivity_Welcome_text()}
 ]
 
-# SendActivity_Welcome_text()
+# SendActivity_Greeting_text()
 - Welcome to your bot.
 
 # SendActivity_DidntGetThat()

--- a/generators/generator-bot-empty/generators/app/templates/language-generation/en-us/botName.en-us.lg
+++ b/generators/generator-bot-empty/generators/app/templates/language-generation/en-us/botName.en-us.lg
@@ -2,7 +2,7 @@
 
 # SendActivity_Greeting()
 [Activity
-    Text = ${SendActivity_Welcome_text()}
+    Text = ${SendActivity_Greeting_text()}
 ]
 
 # SendActivity_Greeting_text()

--- a/generators/generator-bot-empty/generators/app/templates/language-generation/en-us/botName.en-us.lg
+++ b/generators/generator-bot-empty/generators/app/templates/language-generation/en-us/botName.en-us.lg
@@ -8,10 +8,10 @@
 # SendActivity_Greeting_text()
 - Welcome to your bot.
 
-# SendActivity_DidntGetThat()
+# SendActivity_DidNotUnderstand()
 [Activity
-    Text = ${SendActivity_DidntGetThat_text()}
+    Text = ${SendActivity_DidNotUnderstand_text()}
 ]
 
-# SendActivity_DidntGetThat_text()
+# SendActivity_DidNotUnderstand_text()
 - Sorry, I didn't get that.

--- a/generators/generator-bot-empty/generators/app/templates/language-generation/en-us/botName.en-us.lg
+++ b/generators/generator-bot-empty/generators/app/templates/language-generation/en-us/botName.en-us.lg
@@ -7,3 +7,11 @@
 
 # SendActivity_Welcome_text()
 - Welcome to your bot.
+
+# SendActivity_DidntGetThat()
+[Activity
+    Text = ${SendActivity_DidntGetThat_text()}
+]
+
+# SendActivity_DidntGetThat_text()
+- Sorry, I didn't get that.

--- a/generators/generator-bot-empty/generators/app/templates/language-generation/en-us/botName.en-us.lg
+++ b/generators/generator-bot-empty/generators/app/templates/language-generation/en-us/botName.en-us.lg
@@ -1,4 +1,9 @@
 [import](common.lg)
 
-# SendActivity_Welcome
-- ${WelcomeUser()}
+# SendActivity_Welcome()
+[Activity
+    Text = ${SendActivity_Welcome_text()}
+]
+
+# SendActivity_Welcome_text()
+- Welcome to your bot.

--- a/generators/generator-bot-empty/generators/app/templates/language-generation/en-us/common.en-us.lg
+++ b/generators/generator-bot-empty/generators/app/templates/language-generation/en-us/common.en-us.lg
@@ -1,2 +1,0 @@
-# WelcomeUser
-- Welcome to the EmptyBot sample

--- a/generators/generator-bot-enterprise-assistant/generators/app/templates/botName.dialog
+++ b/generators/generator-bot-enterprise-assistant/generators/app/templates/botName.dialog
@@ -42,18 +42,18 @@
                     {
                       "$kind": "Microsoft.SendActivity",
                       "$designer": {
-                        "id": "WelcomeReturningUser"
+                        "id": "GreetingReturningUser"
                       },
-                      "activity": "${SendActivity_WelcomeReturningUser()}"
+                      "activity": "${SendActivity_GreetingReturningUser()}"
                     }
                   ],
                   "elseActions": [
                     {
                       "$kind": "Microsoft.SendActivity",
                       "$designer": {
-                        "id": "WelcomeNewUser"
+                        "id": "GreetingNewUser"
                       },
-                      "activity": "${SendActivity_WelcomeNewUser()}"
+                      "activity": "${SendActivity_GreetingNewUser()}"
                     },
                     {
                       "$kind": "Microsoft.SetProperty",

--- a/generators/generator-bot-enterprise-assistant/generators/app/templates/botName.dialog
+++ b/generators/generator-bot-enterprise-assistant/generators/app/templates/botName.dialog
@@ -42,18 +42,18 @@
                     {
                       "$kind": "Microsoft.SendActivity",
                       "$designer": {
-                        "id": "yXbfKT"
+                        "id": "WelcomeReturningUser"
                       },
-                      "activity": "${SendActivity_yXbfKT()}"
+                      "activity": "${SendActivity_WelcomeReturningUser()}"
                     }
                   ],
                   "elseActions": [
                     {
                       "$kind": "Microsoft.SendActivity",
                       "$designer": {
-                        "id": "XZRD8m"
+                        "id": "WelcomeNewUser"
                       },
-                      "activity": "${SendActivity_XZRD8m()}"
+                      "activity": "${SendActivity_WelcomeNewUser()}"
                     },
                     {
                       "$kind": "Microsoft.SetProperty",

--- a/generators/generator-bot-enterprise-assistant/generators/app/templates/botName.dialog
+++ b/generators/generator-bot-enterprise-assistant/generators/app/templates/botName.dialog
@@ -428,7 +428,7 @@
               "$designer": {
                 "id": "SYFXJJ"
               },
-              "activity": "${SendActivity_SYFXJJ()}"
+              "activity": "${SendActivity_ErrorOccured()}"
             }
           ]
         }

--- a/generators/generator-bot-enterprise-assistant/generators/app/templates/botName.dialog
+++ b/generators/generator-bot-enterprise-assistant/generators/app/templates/botName.dialog
@@ -42,7 +42,7 @@
                     {
                       "$kind": "Microsoft.SendActivity",
                       "$designer": {
-                        "id": "GreetingReturningUser"
+                        "id": "yXbfKT"
                       },
                       "activity": "${SendActivity_GreetingReturningUser()}"
                     }
@@ -51,7 +51,7 @@
                     {
                       "$kind": "Microsoft.SendActivity",
                       "$designer": {
-                        "id": "GreetingNewUser"
+                        "id": "XZRD8m"
                       },
                       "activity": "${SendActivity_GreetingNewUser()}"
                     },

--- a/generators/generator-bot-enterprise-assistant/generators/app/templates/botName.dialog
+++ b/generators/generator-bot-enterprise-assistant/generators/app/templates/botName.dialog
@@ -131,57 +131,6 @@
       "condition": "=turn.recognized.score > 0.8"
     },
     {
-      "$kind": "Microsoft.OnIntent",
-      "$designer": {
-        "id": "9wETGs",
-        "name": "Help"
-      },
-      "intent": "Help",
-      "actions": [
-        {
-          "$kind": "Microsoft.TraceActivity",
-          "$designer": {
-            "id": "2mE4eA"
-          },
-          "name": "<%= botName %>.OnIntent_Help"
-        },
-        {
-          "$kind": "Microsoft.SendActivity",
-          "$designer": {
-            "id": "zlXdEy"
-          },
-          "activity": "${SendActivity_zlXdEy()}"
-        }
-      ],
-      "condition": "=turn.recognized.score > 0.8"
-    },
-    {
-      "$kind": "Microsoft.OnIntent",
-      "$designer": {
-        "id": "pRdAAf",
-        "name": "Feedback"
-      },
-      "intent": "Feedback",
-      "actions": [
-        {
-          "$kind": "Microsoft.TraceActivity",
-          "$designer": {
-            "id": "tXHBt0"
-          },
-          "name": "<%= botName %>.OnIntent_Feedback"
-        },
-        {
-          "$kind": "Microsoft.BeginDialog",
-          "$designer": {
-            "id": "2pSztz"
-          },
-          "activityProcessed": true,
-          "dialog": "FeedbackDialog"
-        }
-      ],
-      "condition": "=turn.recognized.score > 0.8"
-    },
-    {
       "$kind": "Microsoft.OnChooseIntent",
       "$designer": {
         "id": "YDQnEj"
@@ -313,58 +262,6 @@
       ]
     },
     {
-      "$kind": "Microsoft.OnUnknownIntent",
-      "$designer": {
-        "id": "v9Stie",
-        "name": "Unknown intent"
-      },
-      "actions": [
-        {
-          "$kind": "Microsoft.TraceActivity",
-          "$designer": {
-            "id": "nekhCR"
-          },
-          "name": "<%= botName %>.UnknownIntent"
-        },
-        {
-          "$kind": "Microsoft.IfCondition",
-          "$designer": {
-            "id": "zG90cd"
-          },
-          "condition": "turn.activity.value.skillId != null",
-          "actions": [
-            {
-              "$kind": "Microsoft.EmitEvent",
-              "$designer": {
-                "id": "ocOoKo"
-              },
-              "eventName": "ConnectToSkill",
-              "eventValue": "=turn.activity.value.skillId"
-            }
-          ],
-          "elseActions": [
-            {
-              "$kind": "Microsoft.IfCondition",
-              "$designer": {
-                "id": "VogQ3v"
-              },
-              "condition": "exists(turn.activity.text)",
-              "actions": [
-                {
-                  "$kind": "Microsoft.BeginDialog",
-                  "$designer": {
-                    "id": "P9A5BW"
-                  },
-                  "activityProcessed": false,
-                  "dialog": "ChitchatDialog"
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    },
-    {
       "$kind": "Microsoft.OnError",
       "$designer": {
         "id": "cTGK2P",
@@ -429,6 +326,109 @@
                 "id": "SYFXJJ"
               },
               "activity": "${SendActivity_ErrorOccured()}"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "$kind": "Microsoft.OnIntent",
+      "$designer": {
+        "id": "pRdAAf",
+        "name": "Feedback"
+      },
+      "intent": "Feedback",
+      "actions": [
+        {
+          "$kind": "Microsoft.TraceActivity",
+          "$designer": {
+            "id": "tXHBt0"
+          },
+          "name": "<%= botName %>.OnIntent_Feedback"
+        },
+        {
+          "$kind": "Microsoft.BeginDialog",
+          "$designer": {
+            "id": "2pSztz"
+          },
+          "activityProcessed": true,
+          "dialog": "FeedbackDialog"
+        }
+      ],
+      "condition": "=turn.recognized.score > 0.8"
+    },
+    {
+      "$kind": "Microsoft.OnIntent",
+      "$designer": {
+        "id": "9wETGs",
+        "name": "Help"
+      },
+      "intent": "Help",
+      "actions": [
+        {
+          "$kind": "Microsoft.TraceActivity",
+          "$designer": {
+            "id": "2mE4eA"
+          },
+          "name": "<%= botName %>.OnIntent_Help"
+        },
+        {
+          "$kind": "Microsoft.SendActivity",
+          "$designer": {
+            "id": "zlXdEy"
+          },
+          "activity": "${SendActivity_zlXdEy()}"
+        }
+      ],
+      "condition": "=turn.recognized.score > 0.8"
+    },
+    {
+      "$kind": "Microsoft.OnUnknownIntent",
+      "$designer": {
+        "id": "v9Stie",
+        "name": "Unknown intent"
+      },
+      "actions": [
+        {
+          "$kind": "Microsoft.TraceActivity",
+          "$designer": {
+            "id": "nekhCR"
+          },
+          "name": "<%= botName %>.UnknownIntent"
+        },
+        {
+          "$kind": "Microsoft.IfCondition",
+          "$designer": {
+            "id": "zG90cd"
+          },
+          "condition": "turn.activity.value.skillId != null",
+          "actions": [
+            {
+              "$kind": "Microsoft.EmitEvent",
+              "$designer": {
+                "id": "ocOoKo"
+              },
+              "eventName": "ConnectToSkill",
+              "eventValue": "=turn.activity.value.skillId"
+            }
+          ],
+          "elseActions": [
+            {
+              "$kind": "Microsoft.IfCondition",
+              "$designer": {
+                "id": "VogQ3v"
+              },
+              "condition": "exists(turn.activity.text)",
+              "actions": [
+                {
+                  "$kind": "Microsoft.BeginDialog",
+                  "$designer": {
+                    "id": "P9A5BW"
+                  },
+                  "activityProcessed": false,
+                  "dialog": "ChitchatDialog"
+                }
+              ]
             }
           ]
         }

--- a/generators/generator-bot-enterprise-assistant/generators/app/templates/dialogs/BotTourDialog/BotTourDialog.dialog
+++ b/generators/generator-bot-enterprise-assistant/generators/app/templates/dialogs/BotTourDialog/BotTourDialog.dialog
@@ -19,9 +19,9 @@
         {
           "$kind": "Microsoft.SendActivity",
           "$designer": {
-            "id": "YRvoei"
+            "id": "BotTourOverview"
           },
-          "activity": "${SendActivity_YRvoei()}"
+          "activity": "${SendActivity_BotTourOverview()}"
         }
       ]
     },
@@ -36,9 +36,9 @@
         {
           "$kind": "Microsoft.SendActivity",
           "$designer": {
-            "id": "yDMllq"
+            "id": "CalendarTour"
           },
-          "activity": "${SendActivity_yDMllq()}"
+          "activity": "${SendActivity_CalendarTour()}"
         }
       ]
     },
@@ -53,9 +53,9 @@
         {
           "$kind": "Microsoft.SendActivity",
           "$designer": {
-            "id": "l6vgAo"
+            "id": "PeopleTour"
           },
-          "activity": "${SendActivity_l6vgAo()}"
+          "activity": "${SendActivity_PeopleTour()}"
         }
       ]
     }

--- a/generators/generator-bot-enterprise-assistant/generators/app/templates/dialogs/BotTourDialog/BotTourDialog.dialog
+++ b/generators/generator-bot-enterprise-assistant/generators/app/templates/dialogs/BotTourDialog/BotTourDialog.dialog
@@ -38,7 +38,7 @@
           "$designer": {
             "id": "yDMllq"
           },
-          "activity": "${SendActivity_yDMllq()}"
+          "activity": "${SendActivity_CalendarTour()}"
         },
         {
           "$kind": "Microsoft.EndDialog",
@@ -61,7 +61,7 @@
           "$designer": {
             "id": "l6vgAo"
           },
-          "activity": "${SendActivity_l6vgAo()}"
+          "activity": "${SendActivity_PeopleTour()}"
         },
         {
           "$kind": "Microsoft.EndDialog",

--- a/generators/generator-bot-enterprise-assistant/generators/app/templates/dialogs/BotTourDialog/BotTourDialog.dialog
+++ b/generators/generator-bot-enterprise-assistant/generators/app/templates/dialogs/BotTourDialog/BotTourDialog.dialog
@@ -19,7 +19,7 @@
         {
           "$kind": "Microsoft.SendActivity",
           "$designer": {
-            "id": "BotTourOverview"
+            "id": "YRvoei"
           },
           "activity": "${SendActivity_BotTourOverview()}"
         }
@@ -36,7 +36,7 @@
         {
           "$kind": "Microsoft.SendActivity",
           "$designer": {
-            "id": "CalendarTour"
+            "id": "yDMllq"
           },
           "activity": "${SendActivity_CalendarTour()}"
         }
@@ -53,7 +53,7 @@
         {
           "$kind": "Microsoft.SendActivity",
           "$designer": {
-            "id": "PeopleTour"
+            "id": "l6vgAo"
           },
           "activity": "${SendActivity_PeopleTour()}"
         }

--- a/generators/generator-bot-enterprise-assistant/generators/app/templates/dialogs/BotTourDialog/language-generation/en-us/BotTourDialog.en-us.lg
+++ b/generators/generator-bot-enterprise-assistant/generators/app/templates/dialogs/BotTourDialog/language-generation/en-us/BotTourDialog.en-us.lg
@@ -6,7 +6,7 @@
 ]
 
 # SendActivity_BotTourOverview_attachment_WGITEE()
-> ChevronCard
+> OverviewCard
 - ${json(CardTemplate(BotTourHeader(), ExpandableListCardBody(BotTourOptions(), 5), ''))}
 
 

--- a/generators/generator-bot-enterprise-assistant/generators/app/templates/dialogs/BotTourDialog/language-generation/en-us/BotTourDialog.en-us.lg
+++ b/generators/generator-bot-enterprise-assistant/generators/app/templates/dialogs/BotTourDialog/language-generation/en-us/BotTourDialog.en-us.lg
@@ -1,11 +1,11 @@
 [import](common.lg)
 
-# SendActivity_BotTourChevronCard()
+# SendActivity_BotTourOverview()
 [Activity
-    Attachments = ${SendActivity_BotTourChevronCard_attachment_WGITEE()}
+    Attachments = ${SendActivity_BotTourOverview_attachment_WGITEE()}
 ]
 
-# SendActivity_BotTourChevronCard_attachment_WGITEE()
+# SendActivity_BotTourOverview_attachment_WGITEE()
 > ChevronCard
 - ${json(CardTemplate(BotTourHeader(), ExpandableListCardBody(BotTourOptions(), 5), ''))}
 

--- a/generators/generator-bot-enterprise-assistant/generators/app/templates/dialogs/BotTourDialog/language-generation/en-us/BotTourDialog.en-us.lg
+++ b/generators/generator-bot-enterprise-assistant/generators/app/templates/dialogs/BotTourDialog/language-generation/en-us/BotTourDialog.en-us.lg
@@ -2,10 +2,10 @@
 
 # SendActivity_BotTourOverview()
 [Activity
-    Attachments = ${SendActivity_BotTourOverview_attachment_WGITEE()}
+    Attachments = ${SendActivity_BotTourOverview_attachment_AdaptiveCard()}
 ]
 
-# SendActivity_BotTourOverview_attachment_WGITEE()
+# SendActivity_BotTourOverview_attachment_AdaptiveCard()
 > OverviewCard
 - ${json(CardTemplate(BotTourHeader(), ExpandableListCardBody(BotTourOptions(), 5), ''))}
 

--- a/generators/generator-bot-enterprise-assistant/generators/app/templates/dialogs/BotTourDialog/language-generation/en-us/BotTourDialog.en-us.lg
+++ b/generators/generator-bot-enterprise-assistant/generators/app/templates/dialogs/BotTourDialog/language-generation/en-us/BotTourDialog.en-us.lg
@@ -1,29 +1,29 @@
 [import](common.lg)
 
-# SendActivity_YRvoei()
+# SendActivity_BotTourChevronCard()
 [Activity
-    Attachments = ${SendActivity_YRvoei_attachment_WGITEE()}
+    Attachments = ${SendActivity_BotTourChevronCard_attachment_WGITEE()}
 ]
 
-# SendActivity_YRvoei_attachment_WGITEE()
-> Bot tour chevron card
+# SendActivity_BotTourChevronCard_attachment_WGITEE()
+> ChevronCard
 - ${json(CardTemplate(BotTourHeader(), ExpandableListCardBody(BotTourOptions(), 5), ''))}
 
 
-# SendActivity_yDMllq()
+# SendActivity_CalendarTour()
 [Activity
-    Attachments = ${SendActivity_yDMllq_attachment_nUDor4()}
+    Attachments = ${SendActivity_CalendarTour_attachment_nUDor4()}
 ]
 
-# SendActivity_yDMllq_attachment_nUDor4()
+# SendActivity_CalendarTour_attachment_nUDor4()
 - ${json(CardTemplate(CalendarTourCardHeader(), BotTourDetailsCardBody(CalendarTourCardText()), CalendarTourCardActions()))}
 
-# SendActivity_l6vgAo()
+# SendActivity_PeopleTour()
 [Activity
-    Attachments = ${SendActivity_l6vgAo_attachment_a0ogKC()}
+    Attachments = ${SendActivity_PeopleTour_attachment_a0ogKC()}
 ]
 
-# SendActivity_l6vgAo_attachment_a0ogKC()
+# SendActivity_PeopleTour_attachment_a0ogKC()
 - ${json(CardTemplate(PeopleTourCardHeader(), BotTourDetailsCardBody(PeopleTourCardText()), PeopleTourCardActions()))}
 
 # CalendarTourTitle()

--- a/generators/generator-bot-enterprise-assistant/generators/app/templates/dialogs/BotTourDialog/language-generation/en-us/BotTourDialog.en-us.lg
+++ b/generators/generator-bot-enterprise-assistant/generators/app/templates/dialogs/BotTourDialog/language-generation/en-us/BotTourDialog.en-us.lg
@@ -2,29 +2,29 @@
 
 # SendActivity_BotTourOverview()
 [Activity
-    Attachments = ${SendActivity_BotTourOverview_attachment_AdaptiveCard()}
+    Attachments = ${SendActivity_BotTourOverview_attachment_adaptiveCard()}
 ]
 
-# SendActivity_BotTourOverview_attachment_AdaptiveCard()
+# SendActivity_BotTourOverview_attachment_adaptiveCard()
 > OverviewCard
 - ${json(CardTemplate(BotTourHeader(), ExpandableListCardBody(BotTourOptions(), 5), ''))}
 
 
 # SendActivity_CalendarTour()
 [Activity
-    Attachments = ${SendActivity_CalendarTour_attachment_AdaptiveCard()}
+    Attachments = ${SendActivity_CalendarTour_attachment_adaptiveCard()}
 ]
 
-# SendActivity_CalendarTour_attachment_AdaptiveCard()
+# SendActivity_CalendarTour_attachment_adaptiveCard()
 > CalendarDetailsCard
 - ${json(CardTemplate(CalendarTourCardHeader(), BotTourDetailsCardBody(CalendarTourCardText()), CalendarTourCardActions()))}
 
 # SendActivity_PeopleTour()
 [Activity
-    Attachments = ${SendActivity_PeopleTour_attachment_AdaptiveCard()}
+    Attachments = ${SendActivity_PeopleTour_attachment_adaptiveCard()}
 ]
 
-# SendActivity_PeopleTour_attachment_AdaptiveCard()
+# SendActivity_PeopleTour_attachment_adaptiveCard()
 > PeopleDetailsCard
 - ${json(CardTemplate(PeopleTourCardHeader(), BotTourDetailsCardBody(PeopleTourCardText()), PeopleTourCardActions()))}
 

--- a/generators/generator-bot-enterprise-assistant/generators/app/templates/dialogs/BotTourDialog/language-generation/en-us/BotTourDialog.en-us.lg
+++ b/generators/generator-bot-enterprise-assistant/generators/app/templates/dialogs/BotTourDialog/language-generation/en-us/BotTourDialog.en-us.lg
@@ -12,18 +12,20 @@
 
 # SendActivity_CalendarTour()
 [Activity
-    Attachments = ${SendActivity_CalendarTour_attachment_nUDor4()}
+    Attachments = ${SendActivity_CalendarTour_attachment_AdaptiveCard()}
 ]
 
-# SendActivity_CalendarTour_attachment_nUDor4()
+# SendActivity_CalendarTour_attachment_AdaptiveCard()
+> CalendarDetailsCard
 - ${json(CardTemplate(CalendarTourCardHeader(), BotTourDetailsCardBody(CalendarTourCardText()), CalendarTourCardActions()))}
 
 # SendActivity_PeopleTour()
 [Activity
-    Attachments = ${SendActivity_PeopleTour_attachment_a0ogKC()}
+    Attachments = ${SendActivity_PeopleTour_attachment_AdaptiveCard()}
 ]
 
-# SendActivity_PeopleTour_attachment_a0ogKC()
+# SendActivity_PeopleTour_attachment_AdaptiveCard()
+> PeopleDetailsCard
 - ${json(CardTemplate(PeopleTourCardHeader(), BotTourDetailsCardBody(PeopleTourCardText()), PeopleTourCardActions()))}
 
 # CalendarTourTitle()

--- a/generators/generator-bot-enterprise-assistant/generators/app/templates/dialogs/ChitchatDialog/ChitchatDialog.dialog
+++ b/generators/generator-bot-enterprise-assistant/generators/app/templates/dialogs/ChitchatDialog/ChitchatDialog.dialog
@@ -112,7 +112,7 @@
           "$designer": {
             "id": "gc2wn4"
           },
-          "activity": "${SendActivity_DidntGetThat()}"
+          "activity": "${SendActivity_DidNotUnderstand()}"
         }
       ]
     }

--- a/generators/generator-bot-enterprise-assistant/generators/app/templates/dialogs/ChitchatDialog/ChitchatDialog.dialog
+++ b/generators/generator-bot-enterprise-assistant/generators/app/templates/dialogs/ChitchatDialog/ChitchatDialog.dialog
@@ -110,7 +110,7 @@
         {
           "$kind": "Microsoft.SendActivity",
           "$designer": {
-            "id": "DidntGetThat"
+            "id": "gc2wn4"
           },
           "activity": "${SendActivity_DidntGetThat()}"
         }

--- a/generators/generator-bot-enterprise-assistant/generators/app/templates/dialogs/ChitchatDialog/ChitchatDialog.dialog
+++ b/generators/generator-bot-enterprise-assistant/generators/app/templates/dialogs/ChitchatDialog/ChitchatDialog.dialog
@@ -44,7 +44,7 @@
               "maxTurnCount": 3,
               "alwaysPrompt": true,
               "allowInterruptions": false,
-              "prompt": "${TextInput_Prompt_C244wC()}",
+              "prompt": "${TextInput_Prompt_QnaMultiTurnResponse()}",
               "property": "turn.qnaMultiTurnResponse"
             },
             {
@@ -94,7 +94,7 @@
               "$designer": {
                 "id": "zIdYcy"
               },
-              "activity": "${SendActivity_hJgJx8()}"
+              "activity": "${SendActivity_QnaResponse()}"
             }
           ]
         }

--- a/generators/generator-bot-enterprise-assistant/generators/app/templates/dialogs/ChitchatDialog/ChitchatDialog.dialog
+++ b/generators/generator-bot-enterprise-assistant/generators/app/templates/dialogs/ChitchatDialog/ChitchatDialog.dialog
@@ -110,9 +110,9 @@
         {
           "$kind": "Microsoft.SendActivity",
           "$designer": {
-            "id": "gc2wn4"
+            "id": "DidntGetThat"
           },
-          "activity": "${SendActivity_gc2wn4()}"
+          "activity": "${SendActivity_DidntGetThat()}"
         }
       ]
     }

--- a/generators/generator-bot-enterprise-assistant/generators/app/templates/dialogs/ChitchatDialog/language-generation/en-us/ChitchatDialog.en-us.lg
+++ b/generators/generator-bot-enterprise-assistant/generators/app/templates/dialogs/ChitchatDialog/language-generation/en-us/ChitchatDialog.en-us.lg
@@ -1,12 +1,12 @@
 [import](common.lg)
 
-# TextInput_Prompt_C244wC()
+# TextInput_Prompt_QnaMultiTurnResponse()
 [Activity
     Text = ${expandText(@answer)}
     SuggestedActions = ${foreach(turn.recognized.answers[0].context.prompts, x, x.displayText)}
 ]
 
-# SendActivity_hJgJx8()
+# SendActivity_QnaResponse()
 - ${expandText(@answer)}
 
 # SendActivity_DidNotUnderstand()

--- a/generators/generator-bot-enterprise-assistant/generators/app/templates/dialogs/ChitchatDialog/language-generation/en-us/ChitchatDialog.en-us.lg
+++ b/generators/generator-bot-enterprise-assistant/generators/app/templates/dialogs/ChitchatDialog/language-generation/en-us/ChitchatDialog.en-us.lg
@@ -11,7 +11,7 @@
 
 # SendActivity_DidntGetThat()
 [Activity
-    Text = ${SendActivity_gc2wn4_text()}
+    Text = ${SendActivity_DidntGetThat_text()}
 ]
 
 # SendActivity_DidntGetThat_text()

--- a/generators/generator-bot-enterprise-assistant/generators/app/templates/dialogs/ChitchatDialog/language-generation/en-us/ChitchatDialog.en-us.lg
+++ b/generators/generator-bot-enterprise-assistant/generators/app/templates/dialogs/ChitchatDialog/language-generation/en-us/ChitchatDialog.en-us.lg
@@ -9,12 +9,12 @@
 # SendActivity_hJgJx8()
 - ${expandText(@answer)}
 
-# SendActivity_gc2wn4()
+# SendActivity_DidntGetThat()
 [Activity
     Text = ${SendActivity_gc2wn4_text()}
 ]
 
-# SendActivity_gc2wn4_text()
+# SendActivity_DidntGetThat_text()
 - I'm not sure I understand. Can you please try again?
 - Hmm, I don't understand. Can you try to ask me in a different way.
 - I didn't get that. Would you mind rephrasing and try it again.

--- a/generators/generator-bot-enterprise-assistant/generators/app/templates/dialogs/ChitchatDialog/language-generation/en-us/ChitchatDialog.en-us.lg
+++ b/generators/generator-bot-enterprise-assistant/generators/app/templates/dialogs/ChitchatDialog/language-generation/en-us/ChitchatDialog.en-us.lg
@@ -9,12 +9,12 @@
 # SendActivity_hJgJx8()
 - ${expandText(@answer)}
 
-# SendActivity_DidntGetThat()
+# SendActivity_DidNotUnderstand()
 [Activity
-    Text = ${SendActivity_DidntGetThat_text()}
+    Text = ${SendActivity_DidNotUnderstand_text()}
 ]
 
-# SendActivity_DidntGetThat_text()
+# SendActivity_DidNotUnderstand_text()
 - I'm not sure I understand. Can you please try again?
 - Hmm, I don't understand. Can you try to ask me in a different way.
 - I didn't get that. Would you mind rephrasing and try it again.

--- a/generators/generator-bot-enterprise-assistant/generators/app/templates/dialogs/FeedbackDialog/FeedbackDialog.dialog
+++ b/generators/generator-bot-enterprise-assistant/generators/app/templates/dialogs/FeedbackDialog/FeedbackDialog.dialog
@@ -25,9 +25,9 @@
         {
           "$kind": "Microsoft.SendActivity",
           "$designer": {
-            "id": "ThumbsUpDownPrompt"
+            "id": "AskAboutExperiencePrompt"
           },
-          "activity": "${SendActivity_ThumbsUpDownPrompt()}"
+          "activity": "${SendActivity_AskAboutExperiencePrompt()}"
         }
       ]
     },

--- a/generators/generator-bot-enterprise-assistant/generators/app/templates/dialogs/FeedbackDialog/FeedbackDialog.dialog
+++ b/generators/generator-bot-enterprise-assistant/generators/app/templates/dialogs/FeedbackDialog/FeedbackDialog.dialog
@@ -25,7 +25,7 @@
         {
           "$kind": "Microsoft.SendActivity",
           "$designer": {
-            "id": "AskAboutExperiencePrompt"
+            "id": "GstWEQ"
           },
           "activity": "${SendActivity_AskAboutExperiencePrompt()}"
         }
@@ -99,7 +99,7 @@
         {
           "$kind": "Microsoft.SendActivity",
           "$designer": {
-            "id": "639pkl"
+            "id": "YBCkGQ"
           },
           "activity": "${SendActivity_ThanksForFeedback()}"
         },

--- a/generators/generator-bot-enterprise-assistant/generators/app/templates/dialogs/FeedbackDialog/FeedbackDialog.dialog
+++ b/generators/generator-bot-enterprise-assistant/generators/app/templates/dialogs/FeedbackDialog/FeedbackDialog.dialog
@@ -25,9 +25,9 @@
         {
           "$kind": "Microsoft.SendActivity",
           "$designer": {
-            "id": "GstWEQ"
+            "id": "ThumbsUpDownPrompt"
           },
-          "activity": "${SendActivity_GstWEQ()}"
+          "activity": "${SendActivity_ThumbsUpDownPrompt()}"
         }
       ]
     },
@@ -61,7 +61,7 @@
           "$designer": {
             "id": "639pkl"
           },
-          "activity": "${SendActivity_639pkl()}"
+          "activity": "${SendActivity_ThanksForFeedback()}"
         },
         {
           "$kind": "Microsoft.EndDialog",
@@ -99,9 +99,9 @@
         {
           "$kind": "Microsoft.SendActivity",
           "$designer": {
-            "id": "YBCkGQ"
+            "id": "639pkl"
           },
-          "activity": "${SendActivity_YBCkGQ()}"
+          "activity": "${SendActivity_ThanksForFeedback()}"
         },
         {
           "$kind": "Microsoft.EndDialog",

--- a/generators/generator-bot-enterprise-assistant/generators/app/templates/dialogs/FeedbackDialog/FeedbackDialog.dialog
+++ b/generators/generator-bot-enterprise-assistant/generators/app/templates/dialogs/FeedbackDialog/FeedbackDialog.dialog
@@ -27,7 +27,7 @@
           "$designer": {
             "id": "GstWEQ"
           },
-          "activity": "${SendActivity_AskAboutExperiencePrompt()}"
+          "activity": "${SendActivity_FeedbackExperiencePrompt()}"
         }
       ]
     },
@@ -61,7 +61,7 @@
           "$designer": {
             "id": "639pkl"
           },
-          "activity": "${SendActivity_ThanksForFeedback()}"
+          "activity": "${SendActivity_FeedbackThanks()}"
         },
         {
           "$kind": "Microsoft.EndDialog",
@@ -101,7 +101,7 @@
           "$designer": {
             "id": "YBCkGQ"
           },
-          "activity": "${SendActivity_ThanksForFeedback()}"
+          "activity": "${SendActivity_FeedbackThanks()}"
         },
         {
           "$kind": "Microsoft.EndDialog",

--- a/generators/generator-bot-enterprise-assistant/generators/app/templates/dialogs/FeedbackDialog/language-generation/en-us/FeedbackDialog.en-us.lg
+++ b/generators/generator-bot-enterprise-assistant/generators/app/templates/dialogs/FeedbackDialog/language-generation/en-us/FeedbackDialog.en-us.lg
@@ -1,15 +1,19 @@
 [import](common.lg)
 
-# SendActivity_ThumbsUpDownPrompt()
+# SendActivity_AskAboutExperiencePrompt()
 [Activity
-    Text = ${SendActivity_ThumbsUpDownPrompt_text()}
-    Attachments = ${SendActivity_ThumbsUpDownPrompt_attachment_N1EQ7u()}
+    Text = ${SendActivity_AskAboutExperiencePrompt_text()}
+    Attachments = ${SendActivity_AskAboutExperiencePrompt_attachment_N1EQ7u()}
 ]
 
-# SendActivity_ThumbsUpDownPrompt_text()
+# SendActivity_AskAboutExperiencePrompt_text()
 - Did the experience meet your expectations?
 - Did the bot meet your expectations?
 - Did you like this interaction with the bot?
+
+# SendActivity_AskAboutExperiencePrompt_attachment_N1EQ7u()
+> LikeDislike Feedback Card
+- ```${json(CardTemplate(FeedbackHeader(),FeedbackBody(),FeedbackActions()))}```
 
 # FeedbackTitle()
 - Feedback
@@ -173,10 +177,6 @@
     ]
 }
 ```
-
-# SendActivity_ThumbsUpDownPrompt_attachment_N1EQ7u()
-> LikeDislike Feedback Card
-- ```${json(CardTemplate(FeedbackHeader(),FeedbackBody(),FeedbackActions()))}```
 
 # SendActivity_ThanksForFeedback()
 [Activity

--- a/generators/generator-bot-enterprise-assistant/generators/app/templates/dialogs/FeedbackDialog/language-generation/en-us/FeedbackDialog.en-us.lg
+++ b/generators/generator-bot-enterprise-assistant/generators/app/templates/dialogs/FeedbackDialog/language-generation/en-us/FeedbackDialog.en-us.lg
@@ -3,7 +3,7 @@
 # SendActivity_FeedbackExperiencePrompt()
 [Activity
     Text = ${SendActivity_FeedbackExperiencePrompt_text()}
-    Attachments = ${SendActivity_FeedbackExperiencePrompt_attachment_N1EQ7u()}
+    Attachments = ${SendActivity_FeedbackExperiencePrompt_attachment_AdaptiveCard()}
 ]
 
 # SendActivity_FeedbackExperiencePrompt_text()
@@ -11,8 +11,8 @@
 - Did the bot meet your expectations?
 - Did you like this interaction with the bot?
 
-# SendActivity_FeedbackExperiencePrompt_attachment_N1EQ7u()
-> LikeDislike Feedback Card
+# SendActivity_FeedbackExperiencePrompt_attachment_AdaptiveCard()
+> LikeDislikeCard
 - ```${json(CardTemplate(FeedbackHeader(),FeedbackBody(),FeedbackActions()))}```
 
 # SendActivity_FeedbackThanks()

--- a/generators/generator-bot-enterprise-assistant/generators/app/templates/dialogs/FeedbackDialog/language-generation/en-us/FeedbackDialog.en-us.lg
+++ b/generators/generator-bot-enterprise-assistant/generators/app/templates/dialogs/FeedbackDialog/language-generation/en-us/FeedbackDialog.en-us.lg
@@ -1,12 +1,12 @@
 [import](common.lg)
 
-# SendActivity_GstWEQ()
+# SendActivity_ThumbsUpDownPrompt()
 [Activity
-    Text = ${SendActivity_GstWEQ_text()}
-    Attachments = ${SendActivity_GstWEQ_attachment_N1EQ7u()}
+    Text = ${SendActivity_ThumbsUpDownPrompt_text()}
+    Attachments = ${SendActivity_ThumbsUpDownPrompt_attachment_N1EQ7u()}
 ]
 
-# SendActivity_GstWEQ_text()
+# SendActivity_ThumbsUpDownPrompt_text()
 - Did the experience meet your expectations?
 - Did the bot meet your expectations?
 - Did you like this interaction with the bot?
@@ -174,26 +174,16 @@
 }
 ```
 
-# SendActivity_GstWEQ_attachment_N1EQ7u()
+# SendActivity_ThumbsUpDownPrompt_attachment_N1EQ7u()
 > LikeDislike Feedback Card
 - ```${json(CardTemplate(FeedbackHeader(),FeedbackBody(),FeedbackActions()))}```
 
-# SendActivity_639pkl()
+# SendActivity_ThanksForFeedback()
 [Activity
-    Text = ${SendActivity_639pkl_text()}
+    Text = ${SendActivity_ThanksForFeedback_text()}
 ]
 
-# SendActivity_639pkl_text()
-- Thank you for this feedback.
-- Thanks for your feedback.
-- Thank you, I've captured your feedback.
-
-# SendActivity_YBCkGQ()
-[Activity
-    Text = ${SendActivity_YBCkGQ_text()}
-]
-
-# SendActivity_YBCkGQ_text()
+# SendActivity_ThanksForFeedback_text()
 - Thank you for this feedback.
 - Thanks for your feedback.
 - Thank you, I've captured your feedback.

--- a/generators/generator-bot-enterprise-assistant/generators/app/templates/dialogs/FeedbackDialog/language-generation/en-us/FeedbackDialog.en-us.lg
+++ b/generators/generator-bot-enterprise-assistant/generators/app/templates/dialogs/FeedbackDialog/language-generation/en-us/FeedbackDialog.en-us.lg
@@ -3,7 +3,7 @@
 # SendActivity_FeedbackExperiencePrompt()
 [Activity
     Text = ${SendActivity_FeedbackExperiencePrompt_text()}
-    Attachments = ${SendActivity_FeedbackExperiencePrompt_attachment_AdaptiveCard()}
+    Attachments = ${SendActivity_FeedbackExperiencePrompt_attachment_adaptiveCard()}
 ]
 
 # SendActivity_FeedbackExperiencePrompt_text()
@@ -11,7 +11,7 @@
 - Did the bot meet your expectations?
 - Did you like this interaction with the bot?
 
-# SendActivity_FeedbackExperiencePrompt_attachment_AdaptiveCard()
+# SendActivity_FeedbackExperiencePrompt_attachment_adaptiveCard()
 > LikeDislikeCard
 - ```${json(CardTemplate(FeedbackHeader(),FeedbackBody(),FeedbackActions()))}```
 

--- a/generators/generator-bot-enterprise-assistant/generators/app/templates/dialogs/FeedbackDialog/language-generation/en-us/FeedbackDialog.en-us.lg
+++ b/generators/generator-bot-enterprise-assistant/generators/app/templates/dialogs/FeedbackDialog/language-generation/en-us/FeedbackDialog.en-us.lg
@@ -1,19 +1,29 @@
 [import](common.lg)
 
-# SendActivity_AskAboutExperiencePrompt()
+# SendActivity_FeedbackExperiencePrompt()
 [Activity
-    Text = ${SendActivity_AskAboutExperiencePrompt_text()}
-    Attachments = ${SendActivity_AskAboutExperiencePrompt_attachment_N1EQ7u()}
+    Text = ${SendActivity_FeedbackExperiencePrompt_text()}
+    Attachments = ${SendActivity_FeedbackExperiencePrompt_attachment_N1EQ7u()}
 ]
 
-# SendActivity_AskAboutExperiencePrompt_text()
+# SendActivity_FeedbackExperiencePrompt_text()
 - Did the experience meet your expectations?
 - Did the bot meet your expectations?
 - Did you like this interaction with the bot?
 
-# SendActivity_AskAboutExperiencePrompt_attachment_N1EQ7u()
+# SendActivity_FeedbackExperiencePrompt_attachment_N1EQ7u()
 > LikeDislike Feedback Card
 - ```${json(CardTemplate(FeedbackHeader(),FeedbackBody(),FeedbackActions()))}```
+
+# SendActivity_FeedbackThanks()
+[Activity
+    Text = ${SendActivity_FeedbackThanks_text()}
+]
+
+# SendActivity_FeedbackThanks_text()
+- Thank you for this feedback.
+- Thanks for your feedback.
+- Thank you, I've captured your feedback.
 
 # FeedbackTitle()
 - Feedback
@@ -161,8 +171,7 @@
             ]
         }
 ```
-
-# FeedbackActions()
+# FeedbackActions
 - ```
 {
     "type": "ActionSet",
@@ -178,12 +187,4 @@
 }
 ```
 
-# SendActivity_ThanksForFeedback()
-[Activity
-    Text = ${SendActivity_ThanksForFeedback_text()}
-]
 
-# SendActivity_ThanksForFeedback_text()
-- Thank you for this feedback.
-- Thanks for your feedback.
-- Thank you, I've captured your feedback.

--- a/generators/generator-bot-enterprise-assistant/generators/app/templates/language-generation/en-us/botName.en-us.lg
+++ b/generators/generator-bot-enterprise-assistant/generators/app/templates/language-generation/en-us/botName.en-us.lg
@@ -1,28 +1,40 @@
-[import](common.lg)
+﻿[import](common.lg)
 
-# SendActivity_WelcomeNewUser()
+# SendActivity_GreetingNewUser()
 [Activity
-    Attachments = ${SendActivity_WelcomeNewUser_attachment_SR7bxz()}
+    Attachments = ${SendActivity_GreetingNewUser_attachment_SR7bxz()}
 ]
 
-# SendActivity_WelcomeNewUser_attachment_SR7bxz()
+# SendActivity_GreetingNewUser_attachment_SR7bxz()
 [HeroCard
-  text = ${WelcomeNewUser()}
-  buttons = ${BotTourEventAction()}
+  text = ${GreetingNewUser_text()}
+  buttons = ${WelcomeBotTourIntent_action()}
 ]
 
-# SendActivity_WelcomeReturningUser()
+# SendActivity_GreetingReturningUser()
 [Activity
-    Attachments = ${SendActivity_WelcomeReturningUser_attachment_9sGxgG()}
+    Attachments = ${SendActivity_GreetingReturningUser_attachment_9sGxgG()}
 ]
 
-# SendActivity_WelcomeReturningUser_attachment_9sGxgG()
+# SendActivity_GreetingReturningUser_attachment_9sGxgG()
 [HeroCard
-  text = ${WelcomeReturningUser()}
-  buttons = ${BotTourEventAction()}
+  text = ${GreetingReturningUser_text()}
+  buttons = ${WelcomeBotTourIntent_action()}
 ]
 
-# BotTourEventAction()
+# GreetingNewUser_text()
+- 🖐️ Hey, there! How can I help you today?
+- 🖐️ Hi! How can I help?
+- 🖐️ Hello! What do you want to do today?
+
+# GreetingReturningUser_text()
+- 🖐️ Welcome back! How can I help you today?
+- 🖐️ Hello again! What can I help with?
+- 🖐️ Good to see you again. What do you want to do today?
+- 🖐️ Hey, there! Let's get started.
+- 🖐️ Hello again! How can I help?
+
+# WelcomeBotTourIntent_action()
 [CardAction
     title = You can ask me
     type = ${if(turn.activity.channelId == 'msteams', "messageBack", "postBack")}
@@ -31,7 +43,7 @@
 
 # SendActivity_ErrorOccured()
 [Activity
-    Text = ${SendActivity_SYFXJJ_text()}
+    Text = ${SendActivity_ErrorOccured_text()}
 ]
 
 # SendActivity_ErrorOccured_text()

--- a/generators/generator-bot-enterprise-assistant/generators/app/templates/language-generation/en-us/botName.en-us.lg
+++ b/generators/generator-bot-enterprise-assistant/generators/app/templates/language-generation/en-us/botName.en-us.lg
@@ -1,24 +1,24 @@
 [import](common.lg)
 
-# SendActivity_WelcomeReturningUser()
-[Activity
-    Attachments = ${SendActivity_WelcomeReturningUser_attachment_9sGxgG()}
-]
-
 # SendActivity_WelcomeNewUser()
 [Activity
     Attachments = ${SendActivity_WelcomeNewUser_attachment_SR7bxz()}
 ]
 
-# SendActivity_WelcomeReturningUser_attachment_9sGxgG()
-[HeroCard
-  text = ${WelcomeReturningUser()}
-  buttons = ${BotTourEventAction()}
-]
-
 # SendActivity_WelcomeNewUser_attachment_SR7bxz()
 [HeroCard
   text = ${WelcomeNewUser()}
+  buttons = ${BotTourEventAction()}
+]
+
+# SendActivity_WelcomeReturningUser()
+[Activity
+    Attachments = ${SendActivity_WelcomeReturningUser_attachment_9sGxgG()}
+]
+
+# SendActivity_WelcomeReturningUser_attachment_9sGxgG()
+[HeroCard
+  text = ${WelcomeReturningUser()}
   buttons = ${BotTourEventAction()}
 ]
 
@@ -29,12 +29,12 @@
     value = ${{ intent: "BotTour" }}
 ]
 
-# SendActivity_SYFXJJ()
+# SendActivity_ErrorOccured()
 [Activity
     Text = ${SendActivity_SYFXJJ_text()}
 ]
 
-# SendActivity_SYFXJJ_text()
+# SendActivity_ErrorOccured_text()
 - Oops, looks like I'm stuck. Can you try to ask me in a different way?
 - Looks like I'm all mixed up. Let's try asking again, but maybe rephrase your request?
 - Sorry, it looks like something went wrong. Can you please try again?

--- a/generators/generator-bot-enterprise-assistant/generators/app/templates/language-generation/en-us/botName.en-us.lg
+++ b/generators/generator-bot-enterprise-assistant/generators/app/templates/language-generation/en-us/botName.en-us.lg
@@ -2,10 +2,10 @@
 
 # SendActivity_GreetingNewUser()
 [Activity
-    Attachments = ${SendActivity_GreetingNewUser_attachment_SR7bxz()}
+    Attachments = ${SendActivity_GreetingNewUser_attachment_HeroCard()}
 ]
 
-# SendActivity_GreetingNewUser_attachment_SR7bxz()
+# SendActivity_GreetingNewUser_attachment_HeroCard()
 [HeroCard
   text = ${GreetingNewUser_text()}
   buttons = ${GreetingBotTourIntent_action()}
@@ -13,10 +13,10 @@
 
 # SendActivity_GreetingReturningUser()
 [Activity
-    Attachments = ${SendActivity_GreetingReturningUser_attachment_9sGxgG()}
+    Attachments = ${SendActivity_GreetingReturningUser_attachment_HeroCard()}
 ]
 
-# SendActivity_GreetingReturningUser_attachment_9sGxgG()
+# SendActivity_GreetingReturningUser_attachment_HeroCard()
 [HeroCard
   text = ${GreetingReturningUser_text()}
   buttons = ${GreetingBotTourIntent_action()}

--- a/generators/generator-bot-enterprise-assistant/generators/app/templates/language-generation/en-us/botName.en-us.lg
+++ b/generators/generator-bot-enterprise-assistant/generators/app/templates/language-generation/en-us/botName.en-us.lg
@@ -8,7 +8,7 @@
 # SendActivity_GreetingNewUser_attachment_SR7bxz()
 [HeroCard
   text = ${GreetingNewUser_text()}
-  buttons = ${WelcomeBotTourIntent_action()}
+  buttons = ${GreetingBotTourIntent_action()}
 ]
 
 # SendActivity_GreetingReturningUser()
@@ -19,7 +19,7 @@
 # SendActivity_GreetingReturningUser_attachment_9sGxgG()
 [HeroCard
   text = ${GreetingReturningUser_text()}
-  buttons = ${WelcomeBotTourIntent_action()}
+  buttons = ${GreetingBotTourIntent_action()}
 ]
 
 # GreetingNewUser_text()
@@ -34,7 +34,7 @@
 - 🖐️ Hey, there! Let's get started.
 - 🖐️ Hello again! How can I help?
 
-# WelcomeBotTourIntent_action()
+# GreetingBotTourIntent_action()
 [CardAction
     title = You can ask me
     type = ${if(turn.activity.channelId == 'msteams', "messageBack", "postBack")}

--- a/generators/generator-bot-enterprise-assistant/generators/app/templates/language-generation/en-us/botName.en-us.lg
+++ b/generators/generator-bot-enterprise-assistant/generators/app/templates/language-generation/en-us/botName.en-us.lg
@@ -2,10 +2,10 @@
 
 # SendActivity_GreetingNewUser()
 [Activity
-    Attachments = ${SendActivity_GreetingNewUser_attachment_HeroCard()}
+    Attachments = ${SendActivity_GreetingNewUser_attachment_heroCard()}
 ]
 
-# SendActivity_GreetingNewUser_attachment_HeroCard()
+# SendActivity_GreetingNewUser_attachment_heroCard()
 [HeroCard
   text = ${GreetingNewUser_text()}
   buttons = ${GreetingBotTourIntent_action()}
@@ -13,10 +13,10 @@
 
 # SendActivity_GreetingReturningUser()
 [Activity
-    Attachments = ${SendActivity_GreetingReturningUser_attachment_HeroCard()}
+    Attachments = ${SendActivity_GreetingReturningUser_attachment_heroCard()}
 ]
 
-# SendActivity_GreetingReturningUser_attachment_HeroCard()
+# SendActivity_GreetingReturningUser_attachment_heroCard()
 [HeroCard
   text = ${GreetingReturningUser_text()}
   buttons = ${GreetingBotTourIntent_action()}

--- a/generators/generator-bot-enterprise-assistant/generators/app/templates/language-generation/en-us/botName.en-us.lg
+++ b/generators/generator-bot-enterprise-assistant/generators/app/templates/language-generation/en-us/botName.en-us.lg
@@ -1,22 +1,22 @@
 [import](common.lg)
 
-# SendActivity_yXbfKT()
+# SendActivity_WelcomeReturningUser()
 [Activity
-    Attachments = ${SendActivity_yXbfKT_attachment_9sGxgG()}
+    Attachments = ${SendActivity_WelcomeReturningUser_attachment_9sGxgG()}
 ]
 
-# SendActivity_XZRD8m()
+# SendActivity_WelcomeNewUser()
 [Activity
-    Attachments = ${SendActivity_XZRD8m_attachment_SR7bxz()}
+    Attachments = ${SendActivity_WelcomeNewUser_attachment_SR7bxz()}
 ]
 
-# SendActivity_yXbfKT_attachment_9sGxgG()
+# SendActivity_WelcomeReturningUser_attachment_9sGxgG()
 [HeroCard
   text = ${WelcomeReturningUser()}
   buttons = ${BotTourEventAction()}
 ]
 
-# SendActivity_XZRD8m_attachment_SR7bxz()
+# SendActivity_WelcomeNewUser_attachment_SR7bxz()
 [HeroCard
   text = ${WelcomeNewUser()}
   buttons = ${BotTourEventAction()}

--- a/generators/generator-bot-enterprise-assistant/generators/app/templates/language-generation/en-us/common.en-us.lg
+++ b/generators/generator-bot-enterprise-assistant/generators/app/templates/language-generation/en-us/common.en-us.lg
@@ -1,14 +1,2 @@
 [Icons](icons.en-us.lg)
 [Cards](cards.en-us.lg)
-
-# WelcomeNewUser
-- 🖐️ Hey, there! How can I help you today?
-- 🖐️ Hi! How can I help?
-- 🖐️ Hello! What do you want to do today?
-
-# WelcomeReturningUser
-- 🖐️ Welcome back! How can I help you today?
-- 🖐️ Hello again! What can I help with?
-- 🖐️ Good to see you again. What do you want to do today?
-- 🖐️ Hey, there! Let's get started.
-- 🖐️ Hello again! How can I help?

--- a/packages/HelpAndCancel/exported/CancelDialog/CancelDialog.dialog
+++ b/packages/HelpAndCancel/exported/CancelDialog/CancelDialog.dialog
@@ -26,7 +26,7 @@
           "maxTurnCount": 3,
           "alwaysPrompt": false,
           "allowInterruptions": false,
-          "prompt": "${ConfirmInput_Prompt_DTdbkd()}",
+          "prompt": "${ConfirmInput_Prompt_AreYouSure()}",
           "unrecognizedPrompt": "",
           "invalidPrompt": "",
           "choiceOptions": {
@@ -49,7 +49,7 @@
               "$designer": {
                 "id": "zbC0VV"
               },
-              "activity": "${SendActivity_zbC0VV()}"
+              "activity": "${SendActivity_CancelConfirmation()}"
             },
             {
               "$kind": "Microsoft.CancelAllDialogs",
@@ -65,7 +65,7 @@
               "$designer": {
                 "id": "5kB8oO"
               },
-              "activity": "${SendActivity_5kB8oO()}"
+              "activity": "${SendActivity_ContinueConfirmation()}"
             }
           ]
         }

--- a/packages/HelpAndCancel/exported/CancelDialog/language-generation/en-us/CancelDialog.en-us.lg
+++ b/packages/HelpAndCancel/exported/CancelDialog/language-generation/en-us/CancelDialog.en-us.lg
@@ -1,33 +1,33 @@
 [import](common.lg)
 
-# ConfirmInput_Prompt_DTdbkd()
+# ConfirmInput_Prompt_AreYouSure()
 [Activity
-    Text = ${ConfirmInput_Prompt_DTdbkd_text()}
+    Text = ${ConfirmInput_Prompt_AreYouSure_text()}
 ]
 
-# ConfirmInput_Prompt_DTdbkd_text()
+# ConfirmInput_Prompt_AreYouSure_text()
 - Are you sure you want to cancel?
 - Do you want to cancel?
 - I will cancel this for you, but are you sure?
 
-# SendActivity_zbC0VV()
+# SendActivity_CancelConfirmation()
 [Activity
-    Text = ${SendActivity_zbC0VV_text()}
+    Text = ${SendActivity_CancelConfirmation_text()}
 ]
 
-# SendActivity_zbC0VV_text()
+# SendActivity_CancelConfirmation_text()
 - OK, no problem.
 - Sure. I'll cancel.
 - OK, I will stop.
 - Got it, I'll stop here.
 - No problem, I will stop.
 
-# SendActivity_5kB8oO()
+# SendActivity_ContinueConfirmation()
 [Activity
-    Text = ${SendActivity_5kB8oO_text()}
+    Text = ${SendActivity_ContinueConfirmation_text()}
 ]
 
-# SendActivity_5kB8oO_text()
+# SendActivity_ContinueConfirmation_text()
 - OK, let's continue.
 - Alright, let's move on.
 - Let's continue then.

--- a/packages/HelpAndCancel/exported/HelpDialog/HelpDialog.dialog
+++ b/packages/HelpAndCancel/exported/HelpDialog/HelpDialog.dialog
@@ -21,7 +21,7 @@
           "$designer": {
             "id": "5JQ9rf"
           },
-          "activity": "${SendActivity_5JQ9rf()}"
+          "activity": "${SendActivity_HelpOverview()}"
         }
       ]
     }

--- a/packages/HelpAndCancel/exported/HelpDialog/language-generation/en-us/HelpDialog.en-us.lg
+++ b/packages/HelpAndCancel/exported/HelpDialog/language-generation/en-us/HelpDialog.en-us.lg
@@ -1,11 +1,11 @@
 [import](common.lg)
 
-# SendActivity_5JQ9rf()
+# SendActivity_HelpOverview()
 [Activity
-    Text = ${SendActivity_5JQ9rf_text()}
+    Text = ${SendActivity_HelpOverview_text()}
 ]
 
-# SendActivity_5JQ9rf_text()
+# SendActivity_HelpOverview_text()
 - I'm here to help with simple asks. I'm just a basic bot for now. 
 - I'm a simple bot, I can help you with minimal requests. 
 - For now, I can only help you with simple questions.

--- a/packages/Welcome/exported/WelcomeDialog/WelcomeDialog.dialog
+++ b/packages/Welcome/exported/WelcomeDialog/WelcomeDialog.dialog
@@ -30,7 +30,7 @@
               "$designer": {
                 "id": "PsAJ3p"
               },
-              "activity": "${SendActivity_PsAJ3p()}"
+              "activity": "${SendActivity_WelcomeReturningUser()}"
             }
           ],
           "elseActions": [
@@ -39,7 +39,7 @@
               "$designer": {
                 "id": "f3uG2y"
               },
-              "activity": "${SendActivity_f3uG2y()}"
+              "activity": "${SendActivity_WelcomeNewUser()}"
             },
             {
               "$kind": "Microsoft.SetProperty",

--- a/packages/Welcome/exported/WelcomeDialog/language-generation/en-us/WelcomeDialog.en-us.lg
+++ b/packages/Welcome/exported/WelcomeDialog/language-generation/en-us/WelcomeDialog.en-us.lg
@@ -1,23 +1,23 @@
 ﻿[import](common.lg)
 
-# SendActivity_PsAJ3p()
+# SendActivity_WelcomeReturningUser()
 [Activity
-    Text = ${SendActivity_PsAJ3p_text()}
+    Text = ${SendActivity_WelcomeReturningUser_text()}
 ]
 
-# SendActivity_PsAJ3p_text()
+# SendActivity_WelcomeReturningUser_text()
 - 🖐️ Welcome back! How can I help you today?
 - 🖐️ Hello again! What can I help with?
 - 🖐️ Good to see you again. What do you want to do today?
 - 🖐️ Hey, there! Let's get started.
 - 🖐️ Hello again! How can I help?
 
-# SendActivity_f3uG2y()
+# SendActivity_WelcomeNewUser()
 [Activity
-    Text = ${SendActivity_f3uG2y_text()}
+    Text = ${SendActivity_WelcomeNewUser_text()}
 ]
 
-# SendActivity_f3uG2y_text()
+# SendActivity_WelcomeNewUser_text()
 - 🖐️ Hey, there! How can I help you today?
 - 🖐️ Hi! How can I help?
 - 🖐️ Hello! What do you want to do today?


### PR DESCRIPTION
<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
### Purpose
*What is the context of this pull request? Why is it being done?*
Close #895 
Close #938 

This pull request refactors the LG templates to adhere to Composer's schema (so that they may render as expected in the UI) while having a friendly name for users inspecting through the Bot Responses tab. With the intention of aligning to Composer standards, the template format I've opted for is:
```
SendActivity_{description}_{property}_{id}
```

- Description gives context to what the bot's response is
- Property is the activity property (text, speak, attachments), this is what Composer looks for
- Id is the final id should properties need to identify uniquely, like attachments

![image](https://user-images.githubusercontent.com/43043272/115774402-6287f100-a366-11eb-9618-489a9bf15866.png)
![image](https://user-images.githubusercontent.com/43043272/115774369-58fe8900-a366-11eb-9874-341081b42c44.png)


### Changes
*Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.)*

#### Empty bot
- Rename Greeting activity and update content
- Add Unknown intent handling

#### Core Bot with Language
- Renamed ErrorOccured activity
- Renamed Unknown intent activity

#### Core Assistant Bot
- Renamed Greeting activities
- Renamed ErrorOccured activity
- Renamed and reordered BotTour activities
- Renamed ChitChat activities (QnA responses, Unknown)
- Renamed Feedback dialog activities

#### Enterprise Assistant Bot
- Reorder root bot triggers to same as Assistant Core + PbX additions
- Renamed Greeting activities
- Renamed ErrorOccured activity
- Renamed BotTour activities
- Renamed ChitChat activities (QnA responses, Unknown)
- Renamed Feedback dialog activities

#### HelpAndCancel
- Renamed Help activity
- Renamed Cancel activities

#### Welcome
- Rename Welcome activities
### Tests
*Is this covered by existing tests or new ones? If no, why not?*
Manually validated

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*
- Will have another PR related to #954 for both Core and Enterprise Assistant Bots
- Need to publish these changes for HelpAndCancel/Welcome, then update the reference in related templates
- Tracking #937 for what we can/should do regarding the `$designer` objects added by Composer


