### PR TITLE
[Calendar] Reduce properties returned from graph API for contacts and people

### DIFF
--- a/packages/Graph/Actions/Contacts/GetContacts.cs
+++ b/packages/Graph/Actions/Contacts/GetContacts.cs
@@ -55,7 +55,7 @@ namespace Microsoft.Bot.Component.Graph.Actions
             optionList.Add(new QueryOption("$search", $"\"{name}\""));
 
             // Get the current user's profile.
-            IUserContactsCollectionPage contacts = await client.Me.Contacts.Request(optionList).GetAsync(cancellationToken);
+            IUserContactsCollectionPage contacts = await client.Me.Contacts.Request(optionList).Select("displayName,emailAddresses,imAddresses").GetAsync(cancellationToken);
 
             var contactsResult = new List<CalendarSkillContactModel>();
             if (contacts?.Count > 0)
@@ -81,7 +81,7 @@ namespace Microsoft.Bot.Component.Graph.Actions
                 }
             }
 
-            IUserPeopleCollectionPage people = await client.Me.People.Request(optionList).GetAsync(cancellationToken);
+            IUserPeopleCollectionPage people = await client.Me.People.Request(optionList).Select("displayName,emailAddresses").GetAsync(cancellationToken);
 
             if (people?.Count > 0)
             {

--- a/skills/declarative/Calendar/Calendar/dialogs/AuthenticationDialog/AuthenticationDialog.dialog
+++ b/skills/declarative/Calendar/Calendar/dialogs/AuthenticationDialog/AuthenticationDialog.dialog
@@ -41,14 +41,14 @@
           "$designer": {
             "id": "zXbLp8"
           },
-          "condition": "=not(exists(user.profile))",
+          "condition": "=not(exists(turn.user.profile))",
           "actions": [
             {
               "$kind": "Microsoft.Graph.User.GetProfile",
               "$designer": {
                 "id": "mR0Tzk"
               },
-              "resultProperty": "user.profile",
+              "resultProperty": "turn.user.profile",
               "token": "=turn.token.token"
             }
           ]
@@ -66,7 +66,7 @@
                 "id": "4d4VCn"
               },
               "token": "=turn.token.token",
-              "addressProperty": "=user.profile.userPrincipalName",
+              "addressProperty": "=turn.user.profile.userPrincipalName",
               "resultProperty": "user.workingHours"
             }
           ]

--- a/skills/declarative/Calendar/Calendar/dialogs/GetContactsDialog/GetContactsDialog.dialog
+++ b/skills/declarative/Calendar/Calendar/dialogs/GetContactsDialog/GetContactsDialog.dialog
@@ -288,6 +288,14 @@
           "value": "=null"
         },
         {
+          "$kind": "Microsoft.SetProperty",
+          "$designer": {
+            "id": "ECk0NA"
+          },
+          "property": "$nameProperty",
+          "value": "=turn.dialogEvent.value"
+        },
+        {
           "$kind": "Microsoft.BeginDialog",
           "$designer": {
             "id": "1IGw8o"
@@ -300,7 +308,7 @@
           "$designer": {
             "id": "Ha1csy"
           },
-          "nameProperty": "=turn.dialogEvent.value",
+          "nameProperty": "=$nameProperty",
           "resultProperty": "$searchResults",
           "token": "=turn.token.token"
         },

--- a/skills/declarative/Calendar/Calendar/dialogs/GetEventsDialog/GetEventsDialog.dialog
+++ b/skills/declarative/Calendar/Calendar/dialogs/GetEventsDialog/GetEventsDialog.dialog
@@ -352,7 +352,7 @@
           "dateTimeTypeProperty": "=coalesce($parameters.dateTimeType, \"date\")",
           "startProperty": "=$parameters.start",
           "futureEventsOnlyProperty": "=coalesce($futureOnly, true)",
-          "userEmailProperty": "=user.profile.mail",
+          "userEmailProperty": "=turn.user.profile.mail",
           "maxResultsProperty": "=25"
         },
         {

--- a/skills/declarative/Calendar/Calendar/language-generation/en-us/common.en-us.lg
+++ b/skills/declarative/Calendar/Calendar/language-generation/en-us/common.en-us.lg
@@ -4,8 +4,8 @@
 [Actions](actions.en-us.lg)
 
 # WelcomeUser()
-- IF: ${user.profile.displayName != null}
-    - Hi ${user.profile.displayName} 🖐, ${IntroMessage()}
+- IF: ${turn.user.profile.displayName != null}
+    - Hi ${turn.user.profile.displayName} 🖐, ${IntroMessage()}
 - ELSE: 
     - Hi there 🖐, ${IntroMessage()}
 


### PR DESCRIPTION
- Adds a select clause to the getContacts and getPeople apis used in Calendar
- Moves user.profile (basic Graph profile) to turn state