### PR TITLE
Teams triggers don't need to repeat the word "Teams" in all of the trigger names

### DIFF
--- a/packages/Teams/Schemas/TriggerConditions/Teams.OnCardAction.schema
+++ b/packages/Teams/Schemas/TriggerConditions/Teams.OnCardAction.schema
@@ -1,7 +1,7 @@
 {
     "$schema": "https://schemas.botframework.com/schemas/component/v1.0/component.schema",
     "$role": [ "implements(Microsoft.ITrigger)", "extends(Microsoft.OnCondition)" ],
-    "title": "On Teams card action",
+    "title": "On card action",
     "description": "Actions triggered when a Teams InvokeActivity is received with no activity.name.",
     "type": "object",
     "required": [

--- a/packages/Teams/Schemas/TriggerConditions/Teams.OnCardAction.uischema
+++ b/packages/Teams/Schemas/TriggerConditions/Teams.OnCardAction.uischema
@@ -12,6 +12,7 @@
         "subtitle": "Invoke activity with no activity.name"
     },
     "trigger": {
-      "submenu": "Microsoft Teams"
+      "submenu": "Microsoft Teams",
+      "label": "On card action"
     }
 }

--- a/packages/Teams/Schemas/TriggerConditions/Teams.OnChannelCreated.schema
+++ b/packages/Teams/Schemas/TriggerConditions/Teams.OnChannelCreated.schema
@@ -1,7 +1,7 @@
 {
     "$schema": "https://schemas.botframework.com/schemas/component/v1.0/component.schema",
     "$role": [ "implements(Microsoft.ITrigger)", "extends(Microsoft.OnCondition)" ],
-    "title": "On Teams channel created",
+    "title": "On channel created",
     "description": "Actions triggered when a Teams ConversationUpdateActivity with channelData.eventType == 'channelCreated'.",
     "type": "object",
     "required": [

--- a/packages/Teams/Schemas/TriggerConditions/Teams.OnChannelCreated.uischema
+++ b/packages/Teams/Schemas/TriggerConditions/Teams.OnChannelCreated.uischema
@@ -1,6 +1,7 @@
 {
     "$schema": "https://schemas.botframework.com/schemas/ui/v1.0/ui.schema",
     "trigger": {
-      "submenu": "Microsoft Teams"
+      "submenu": "Microsoft Teams",
+      "label": "On channel created"
     }
 }

--- a/packages/Teams/Schemas/TriggerConditions/Teams.OnChannelDeleted.schema
+++ b/packages/Teams/Schemas/TriggerConditions/Teams.OnChannelDeleted.schema
@@ -1,7 +1,7 @@
 {
     "$schema": "https://schemas.botframework.com/schemas/component/v1.0/component.schema",
     "$role": [ "implements(Microsoft.ITrigger)", "extends(Microsoft.OnCondition)" ],
-    "title": "On Teams channel deleted",
+    "title": "On channel deleted",
     "description": "Actions triggered when a Teams ConversationUpdateActivity with channelData.eventType == 'channelDeleted'.",
     "type": "object",
     "required": [

--- a/packages/Teams/Schemas/TriggerConditions/Teams.OnChannelDeleted.uischema
+++ b/packages/Teams/Schemas/TriggerConditions/Teams.OnChannelDeleted.uischema
@@ -1,6 +1,7 @@
 {
     "$schema": "https://schemas.botframework.com/schemas/ui/v1.0/ui.schema",
     "trigger": {
-      "submenu": "Microsoft Teams"
+      "submenu": "Microsoft Teams",
+      "label": "On channel deleted"
     }
 }

--- a/packages/Teams/Schemas/TriggerConditions/Teams.OnChannelRenamed.schema
+++ b/packages/Teams/Schemas/TriggerConditions/Teams.OnChannelRenamed.schema
@@ -1,7 +1,7 @@
 {
     "$schema": "https://schemas.botframework.com/schemas/component/v1.0/component.schema",
     "$role": [ "implements(Microsoft.ITrigger)", "extends(Microsoft.OnCondition)" ],
-    "title": "On Teams channel renamed",
+    "title": "On channel renamed",
     "description": "Actions triggered when a Teams ConversationUpdateActivity with channelData.eventType == 'channelRenamed'.",
     "type": "object",
     "required": [

--- a/packages/Teams/Schemas/TriggerConditions/Teams.OnChannelRenamed.uischema
+++ b/packages/Teams/Schemas/TriggerConditions/Teams.OnChannelRenamed.uischema
@@ -1,6 +1,7 @@
 {
     "$schema": "https://schemas.botframework.com/schemas/ui/v1.0/ui.schema",
     "trigger": {
-      "submenu": "Microsoft Teams"
+      "submenu": "Microsoft Teams",
+      "label": "On channel renamed"
     }
 }

--- a/packages/Teams/Schemas/TriggerConditions/Teams.OnChannelRestored.schema
+++ b/packages/Teams/Schemas/TriggerConditions/Teams.OnChannelRestored.schema
@@ -1,7 +1,7 @@
 {
     "$schema": "https://schemas.botframework.com/schemas/component/v1.0/component.schema",
     "$role": [ "implements(Microsoft.ITrigger)", "extends(Microsoft.OnCondition)" ],
-    "title": "On Teams channel restored",
+    "title": "On channel restored",
     "description": "Actions triggered when a Teams ConversationUpdateActivity with channelData.eventType == 'channelRestored'.",
     "type": "object",
     "required": [

--- a/packages/Teams/Schemas/TriggerConditions/Teams.OnChannelRestored.uischema
+++ b/packages/Teams/Schemas/TriggerConditions/Teams.OnChannelRestored.uischema
@@ -1,6 +1,7 @@
 {
     "$schema": "https://schemas.botframework.com/schemas/ui/v1.0/ui.schema",
     "trigger": {
-      "submenu": "Microsoft Teams"
+      "submenu": "Microsoft Teams",
+      "label": "On channel restored"
     }
 }

--- a/packages/Teams/Schemas/TriggerConditions/Teams.OnFileConsent.schema
+++ b/packages/Teams/Schemas/TriggerConditions/Teams.OnFileConsent.schema
@@ -1,7 +1,7 @@
 {
     "$schema": "https://schemas.botframework.com/schemas/component/v1.0/component.schema",
     "$role": [ "implements(Microsoft.ITrigger)", "extends(Microsoft.OnCondition)" ],
-    "title": "On Teams file consent",
+    "title": "On file consent",
     "description": "Actions triggered when a Teams InvokeActivity is received with activity.name == 'fileConsent/invoke'.",
     "type": "object",
     "required": [

--- a/packages/Teams/Schemas/TriggerConditions/Teams.OnFileConsent.uischema
+++ b/packages/Teams/Schemas/TriggerConditions/Teams.OnFileConsent.uischema
@@ -1,6 +1,7 @@
 {
     "$schema": "https://schemas.botframework.com/schemas/ui/v1.0/ui.schema",
     "trigger": {
-      "submenu": "Microsoft Teams"
+      "submenu": "Microsoft Teams",
+      "label": "On file consent"
     }
 }

--- a/packages/Teams/Schemas/TriggerConditions/Teams.OnO365ConnectorCardAction.schema
+++ b/packages/Teams/Schemas/TriggerConditions/Teams.OnO365ConnectorCardAction.schema
@@ -1,7 +1,7 @@
 {
     "$schema": "https://schemas.botframework.com/schemas/component/v1.0/component.schema",
     "$role": [ "implements(Microsoft.ITrigger)", "extends(Microsoft.OnCondition)" ],
-    "title": "On Teams O365 connector card action",
+    "title": "On O365 connector card action",
     "description": "Actions triggered when a Teams InvokeActivity is received for 'actionableMessage/executeAction'.",
     "type": "object",
     "required": [

--- a/packages/Teams/Schemas/TriggerConditions/Teams.OnO365ConnectorCardAction.uischema
+++ b/packages/Teams/Schemas/TriggerConditions/Teams.OnO365ConnectorCardAction.uischema
@@ -12,6 +12,7 @@
         "subtitle": "Invoke activity.name='actionableMessage/executeAction'"
     },
     "trigger": {
-      "submenu": "Microsoft Teams"
+      "submenu": "Microsoft Teams",
+      "label": "On O365 connector card action"
     }
 }

--- a/packages/Teams/Schemas/TriggerConditions/Teams.OnTabFetch.schema
+++ b/packages/Teams/Schemas/TriggerConditions/Teams.OnTabFetch.schema
@@ -1,7 +1,7 @@
 {
     "$schema": "https://schemas.botframework.com/schemas/component/v1.0/component.schema",
     "$role": [ "implements(Microsoft.ITrigger)", "extends(Microsoft.OnCondition)" ],
-    "title": "On Teams Tab Fetch",
+    "title": "On Tab Fetch",
     "description": "Actions triggered when a Teams InvokeActivity is received with activity.name='tab/fetch'.",
     "type": "object",
     "required": [

--- a/packages/Teams/Schemas/TriggerConditions/Teams.OnTabFetch.uischema
+++ b/packages/Teams/Schemas/TriggerConditions/Teams.OnTabFetch.uischema
@@ -12,6 +12,7 @@
         "subtitle": "Invoke activity.name='tab/fetch'"
     },
     "trigger": {
-      "submenu": "Microsoft Teams"
+      "submenu": "Microsoft Teams",
+      "label": "On Tab Fetch"
     }
 }

--- a/packages/Teams/Schemas/TriggerConditions/Teams.OnTabSubmit.schema
+++ b/packages/Teams/Schemas/TriggerConditions/Teams.OnTabSubmit.schema
@@ -1,7 +1,7 @@
 {
     "$schema": "https://schemas.botframework.com/schemas/component/v1.0/component.schema",
     "$role": [ "implements(Microsoft.ITrigger)", "extends(Microsoft.OnCondition)" ],
-    "title": "On Teams Tab Submit",
+    "title": "On Tab Submit",
     "description": "Actions triggered when a Teams InvokeActivity is received with activity.name='tab/submit'.",
     "type": "object",
     "required": [

--- a/packages/Teams/Schemas/TriggerConditions/Teams.OnTabSubmit.uischema
+++ b/packages/Teams/Schemas/TriggerConditions/Teams.OnTabSubmit.uischema
@@ -1,6 +1,7 @@
 {
     "$schema": "https://schemas.botframework.com/schemas/ui/v1.0/ui.schema",
     "trigger": {
-      "submenu": "Microsoft Teams"
+      "submenu": "Microsoft Teams",
+      "label": "On Tab Submit"
     }
 }

--- a/packages/Teams/Schemas/TriggerConditions/Teams.OnTaskModuleFetch.schema
+++ b/packages/Teams/Schemas/TriggerConditions/Teams.OnTaskModuleFetch.schema
@@ -1,7 +1,7 @@
 {
     "$schema": "https://schemas.botframework.com/schemas/component/v1.0/component.schema",
     "$role": [ "implements(Microsoft.ITrigger)", "extends(Microsoft.OnCondition)" ],
-    "title": "On Teams task module fetch",
+    "title": "On task module fetch",
     "description": "Actions triggered when a Teams Invoke Activity is received with activity.name='task/fetch'.",
     "type": "object",
     "required": [

--- a/packages/Teams/Schemas/TriggerConditions/Teams.OnTaskModuleFetch.uischema
+++ b/packages/Teams/Schemas/TriggerConditions/Teams.OnTaskModuleFetch.uischema
@@ -12,6 +12,7 @@
         "subtitle": "Invoke activity.name='task/fetch'"
     },
     "trigger": {
-      "submenu": "Microsoft Teams"
+      "submenu": "Microsoft Teams",
+      "label": "On task module fetch"
     }
 }

--- a/packages/Teams/Schemas/TriggerConditions/Teams.OnTaskModuleSubmit.schema
+++ b/packages/Teams/Schemas/TriggerConditions/Teams.OnTaskModuleSubmit.schema
@@ -1,7 +1,7 @@
 {
     "$schema": "https://schemas.botframework.com/schemas/component/v1.0/component.schema",
     "$role": [ "implements(Microsoft.ITrigger)", "extends(Microsoft.OnCondition)" ],
-    "title": "On Teams task module submit",
+    "title": "On task module submit",
     "description": "Actions triggered when a Teams InvokeActivity is received with activity.name='task/submit'.",
     "type": "object",
     "required": [

--- a/packages/Teams/Schemas/TriggerConditions/Teams.OnTaskModuleSubmit.uischema
+++ b/packages/Teams/Schemas/TriggerConditions/Teams.OnTaskModuleSubmit.uischema
@@ -12,6 +12,7 @@
         "subtitle": "Invoke activity.name='task/submit'"
     },
     "trigger": {
-      "submenu": "Microsoft Teams"
+      "submenu": "Microsoft Teams",
+      "label": "On task module submit"
     }
 }

--- a/packages/Teams/Schemas/TriggerConditions/Teams.OnTeamArchived.schema
+++ b/packages/Teams/Schemas/TriggerConditions/Teams.OnTeamArchived.schema
@@ -1,7 +1,7 @@
 {
     "$schema": "https://schemas.botframework.com/schemas/component/v1.0/component.schema",
     "$role": [ "implements(Microsoft.ITrigger)", "extends(Microsoft.OnCondition)" ],
-    "title": "On Teams team archived",
+    "title": "On team archived",
     "description": "Actions triggered when a Teams ConversationUpdate with channelData.eventType == 'teamArchived'.",
     "type": "object",
     "required": [

--- a/packages/Teams/Schemas/TriggerConditions/Teams.OnTeamArchived.uischema
+++ b/packages/Teams/Schemas/TriggerConditions/Teams.OnTeamArchived.uischema
@@ -1,6 +1,7 @@
 {
     "$schema": "https://schemas.botframework.com/schemas/ui/v1.0/ui.schema",
     "trigger": {
-      "submenu": "Microsoft Teams"
+      "submenu": "Microsoft Teams",
+      "label": "On team archived"
     }
 }

--- a/packages/Teams/Schemas/TriggerConditions/Teams.OnTeamDeleted.schema
+++ b/packages/Teams/Schemas/TriggerConditions/Teams.OnTeamDeleted.schema
@@ -1,7 +1,7 @@
 {
     "$schema": "https://schemas.botframework.com/schemas/component/v1.0/component.schema",
     "$role": [ "implements(Microsoft.ITrigger)", "extends(Microsoft.OnCondition)" ],
-    "title": "On Teams team deleted",
+    "title": "On team deleted",
     "description": "Actions triggered when a Teams ConversationUpdate with channelData.eventType == 'teamDeleted'.",
     "type": "object",
     "required": [

--- a/packages/Teams/Schemas/TriggerConditions/Teams.OnTeamDeleted.uischema
+++ b/packages/Teams/Schemas/TriggerConditions/Teams.OnTeamDeleted.uischema
@@ -1,6 +1,7 @@
 {
     "$schema": "https://schemas.botframework.com/schemas/ui/v1.0/ui.schema",
     "trigger": {
-      "submenu": "Microsoft Teams"
+      "submenu": "Microsoft Teams",
+      "label": "On team deleted"
     }
 }

--- a/packages/Teams/Schemas/TriggerConditions/Teams.OnTeamHardDeleted.schema
+++ b/packages/Teams/Schemas/TriggerConditions/Teams.OnTeamHardDeleted.schema
@@ -1,7 +1,7 @@
 {
     "$schema": "https://schemas.botframework.com/schemas/component/v1.0/component.schema",
     "$role": [ "implements(Microsoft.ITrigger)", "extends(Microsoft.OnCondition)" ],
-    "title": "On Teams team hard deleted",
+    "title": "On team hard deleted",
     "description": "Actions triggered when a Teams ConversationUpdate with channelData.eventType == 'teamHardDeleted'.",
     "type": "object",
     "required": [

--- a/packages/Teams/Schemas/TriggerConditions/Teams.OnTeamRenamed.schema
+++ b/packages/Teams/Schemas/TriggerConditions/Teams.OnTeamRenamed.schema
@@ -1,7 +1,7 @@
 {
     "$schema": "https://schemas.botframework.com/schemas/component/v1.0/component.schema",
     "$role": [ "implements(Microsoft.ITrigger)", "extends(Microsoft.OnCondition)" ],
-    "title": "On Teams team renamed",
+    "title": "On team renamed",
     "description": "Actions triggered when a Teams ConversationUpdate with channelData.eventType == 'teamRenamed'.",
     "type": "object",
     "required": [

--- a/packages/Teams/Schemas/TriggerConditions/Teams.OnTeamRenamed.uischema
+++ b/packages/Teams/Schemas/TriggerConditions/Teams.OnTeamRenamed.uischema
@@ -1,6 +1,7 @@
 {
     "$schema": "https://schemas.botframework.com/schemas/ui/v1.0/ui.schema",
     "trigger": {
-      "submenu": "Microsoft Teams"
+      "submenu": "Microsoft Teams",
+      "label": "On team renamed"
     }
 }

--- a/packages/Teams/Schemas/TriggerConditions/Teams.OnTeamRestored.schema
+++ b/packages/Teams/Schemas/TriggerConditions/Teams.OnTeamRestored.schema
@@ -1,7 +1,7 @@
 {
     "$schema": "https://schemas.botframework.com/schemas/component/v1.0/component.schema",
     "$role": [ "implements(Microsoft.ITrigger)", "extends(Microsoft.OnCondition)" ],
-    "title": "On Teams team restored",
+    "title": "On team restored",
     "description": "Actions triggered when a Teams ConversationUpdate with channelData.eventType == 'teamRestored'.",
     "type": "object",
     "required": [

--- a/packages/Teams/Schemas/TriggerConditions/Teams.OnTeamRestored.uischema
+++ b/packages/Teams/Schemas/TriggerConditions/Teams.OnTeamRestored.uischema
@@ -1,6 +1,7 @@
 {
     "$schema": "https://schemas.botframework.com/schemas/ui/v1.0/ui.schema",
     "trigger": {
-      "submenu": "Microsoft Teams"
+      "submenu": "Microsoft Teams",
+      "label": "On team restored"
     }
 }

--- a/packages/Teams/Schemas/TriggerConditions/Teams.OnTeamUnarchived.schema
+++ b/packages/Teams/Schemas/TriggerConditions/Teams.OnTeamUnarchived.schema
@@ -1,7 +1,7 @@
 {
     "$schema": "https://schemas.botframework.com/schemas/component/v1.0/component.schema",
     "$role": [ "implements(Microsoft.ITrigger)", "extends(Microsoft.OnCondition)" ],
-    "title": "On Teams team unarchived",
+    "title": "On team unarchived",
     "description": "Actions triggered when a Teams ConversationUpdate with channelData.eventType == 'teamUnarchived'.",
     "type": "object",
     "required": [

--- a/packages/Teams/Schemas/TriggerConditions/Teams.OnTeamUnarchived.uischema
+++ b/packages/Teams/Schemas/TriggerConditions/Teams.OnTeamUnarchived.uischema
@@ -1,6 +1,7 @@
 {
     "$schema": "https://schemas.botframework.com/schemas/ui/v1.0/ui.schema",
     "trigger": {
-      "submenu": "Microsoft Teams"
+      "submenu": "Microsoft Teams",
+      "label": "On team unarchived"
     }
 }


### PR DESCRIPTION
Fixes #924 