### PR TITLE
Emit trace when the bot does not have oAuthConnectionName configured

### DIFF
--- a/skills/declarative/Calendar/Calendar/dialogs/AuthenticationDialog/AuthenticationDialog.dialog
+++ b/skills/declarative/Calendar/Calendar/dialogs/AuthenticationDialog/AuthenticationDialog.dialog
@@ -28,7 +28,7 @@
           "$designer": {
             "id": "teXtvE"
           },
-          "condition": "=settings.oauthConnectionName == null || not(exists(settings.oauthConnectionName))",
+          "condition": "=settings.oauthConnectionName == null || not(exists(settings.oauthConnectionName)) || empty(settings.oAuthConnectionName)",
           "actions": [
             {
               "$kind": "Microsoft.TraceActivity",

--- a/skills/declarative/Calendar/Calendar/dialogs/AuthenticationDialog/AuthenticationDialog.dialog
+++ b/skills/declarative/Calendar/Calendar/dialogs/AuthenticationDialog/AuthenticationDialog.dialog
@@ -24,6 +24,23 @@
           "value": "=null"
         },
         {
+          "$kind": "Microsoft.IfCondition",
+          "$designer": {
+            "id": "teXtvE"
+          },
+          "condition": "=settings.oauthConnectionName == null || not(exists(settings.oauthConnectionName))",
+          "actions": [
+            {
+              "$kind": "Microsoft.TraceActivity",
+              "$designer": {
+                "id": "Svi926"
+              },
+              "name": "AuthenticationDialog.BeginDialog.Error",
+              "label": "OAuthConnectionNotConfigured"
+            }
+          ]
+        },
+        {
           "$kind": "Microsoft.OAuthInput",
           "$designer": {
             "id": "m7gWCJ"

--- a/skills/declarative/whoSkill/whoSkill/dialogs/AuthenticationDialog/AuthenticationDialog.dialog
+++ b/skills/declarative/whoSkill/whoSkill/dialogs/AuthenticationDialog/AuthenticationDialog.dialog
@@ -28,7 +28,7 @@
           "$designer": {
             "id": "jf8cXp"
           },
-          "condition": "=settings.oauthConnectionName == null || not(exists(settings.oauthConnectionName))",
+          "condition": "=settings.oauthConnectionName == null || not(exists(settings.oauthConnectionName)) || empty(settings.oAuthConnectionName)",
           "actions": [
             {
               "$kind": "Microsoft.TraceActivity",

--- a/skills/declarative/whoSkill/whoSkill/dialogs/AuthenticationDialog/AuthenticationDialog.dialog
+++ b/skills/declarative/whoSkill/whoSkill/dialogs/AuthenticationDialog/AuthenticationDialog.dialog
@@ -24,6 +24,23 @@
           "name": "PeopleSkill.AuthenticationDialog.BeginDialog"
         },
         {
+          "$kind": "Microsoft.IfCondition",
+          "$designer": {
+            "id": "jf8cXp"
+          },
+          "condition": "=settings.oauthConnectionName == null || not(exists(settings.oauthConnectionName))",
+          "actions": [
+            {
+              "$kind": "Microsoft.TraceActivity",
+              "$designer": {
+                "id": "q8Tnab"
+              },
+              "name": "PeopleSkill.AuthenticationDialog.BeginDialog.Error",
+              "label": "OAuthConnectionNotConfigured"
+            }
+          ]
+        },
+        {
           "$kind": "Microsoft.OAuthInput",
           "$designer": {
             "id": "IQuSlw"


### PR DESCRIPTION
<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
### Purpose
Emit a trace entry when the required oAuthConnectionName is not present in the setting or is empty string.

![image](https://user-images.githubusercontent.com/9922190/115773870-afb79300-a365-11eb-97a5-c22caf04fd97.png)

### Changes
- Updated the authentication dialog in People and Calendar skill to reflect the check

### Tests
Manually test.

### Feature Plan
Integrate with template

### Checklist

#### General
- [x] I have commented my code, particularly in hard-to-understand areas	
- [x] I have added or updated the appropriate tests	
- [x] I have updated related documentation
