### PR TITLE
fix: Core/Enterprise Assistant replace ChooseIntent implementation

### DIFF
--- a/generators/generator-bot-assistant-core/generators/app/templates/botName.dialog
+++ b/generators/generator-bot-assistant-core/generators/app/templates/botName.dialog
@@ -127,105 +127,88 @@
     {
       "$kind": "Microsoft.OnChooseIntent",
       "$designer": {
-        "id": "YDQnEj"
+        "id": "YuA75w"
       },
       "actions": [
         {
           "$kind": "Microsoft.SetProperties",
           "$designer": {
-            "id": "LMu0fC"
+            "id": "VutAjG"
           },
           "assignments": [
             {
-              "value": "=turn.recognized.candidates[0]",
-              "property": "dialog.luisResult"
+              "property": "turn.minThreshold",
+              "value": 0.5
             },
             {
-              "property": "dialog.qnaResult",
-              "value": "=turn.recognized.candidates[1]"
+              "property": "turn.maxChoices",
+              "value": 3
+            },
+            {
+              "property": "conversation.lastAmbiguousUtterance",
+              "value": "=turn.activity.text"
+            },
+            {
+              "property": "dialog.candidates",
+              "value": "=take(sortByDescending(where(flatten(select(turn.recognized.candidates, x, if (x.intent==\"ChooseIntent\", x.result.candidates, x))), c, not(startsWith(c.intent, \"DeferToRecognizer_QnA\")) && c.score > turn.minThreshold), 'score'), turn.maxChoices)"
             }
           ]
         },
         {
-          "$kind": "Microsoft.IfCondition",
+          "$kind": "Microsoft.SwitchCondition",
           "$designer": {
-            "id": "1flIQn"
+            "id": "uCZ5AG"
           },
-          "condition": "dialog.luisResult.score >= 0.9 && dialog.qnaResult.score <= 0.5",
-          "actions": [
+          "condition": "=count(dialog.candidates)",
+          "cases": [
             {
-              "$kind": "Microsoft.EmitEvent",
-              "$designer": {
-                "id": "86jqYT"
-              },
-              "eventName": "recognizedIntent",
-              "eventValue": "=dialog.luisResult.result"
+              "value": "0",
+              "actions": [
+                {
+                  "$kind": "Microsoft.EmitEvent",
+                  "$designer": {
+                    "id": "s7XJNJ"
+                  },
+                  "eventName": "unknownIntent"
+                },
+                {
+                  "$kind": "Microsoft.EndDialog",
+                  "$designer": {
+                    "id": "xORMrt"
+                  }
+                }
+              ]
             },
             {
-              "$kind": "Microsoft.BreakLoop",
-              "$designer": {
-                "id": "YOHNju"
-              }
+              "value": "1",
+              "actions": [
+                {
+                  "$kind": "Microsoft.EmitEvent",
+                  "$designer": {
+                    "id": "1dcLLx"
+                  },
+                  "eventName": "recognizedIntent",
+                  "eventValue": "=first(dialog.candidates).result"
+                },
+                {
+                  "$kind": "Microsoft.EndDialog",
+                  "$designer": {
+                    "id": "h5Aagx"
+                  }
+                }
+              ]
             }
           ]
-        },
-        {
-          "$kind": "Microsoft.IfCondition",
-          "$designer": {
-            "id": "1n7wbU"
-          },
-          "condition": "dialog.luisResult.score <= 0.5 && dialog.qnaResult.score >= 0.9",
-          "actions": [
-            {
-              "$kind": "Microsoft.EmitEvent",
-              "$designer": {
-                "id": "NAyC56"
-              },
-              "eventName": "recognizedIntent",
-              "eventValue": "=dialog.qnaResult.result"
-            },
-            {
-              "$kind": "Microsoft.BreakLoop",
-              "$designer": {
-                "id": "3fxdQ1"
-              }
-            }
-          ]
-        },
-        {
-          "$kind": "Microsoft.IfCondition",
-          "$designer": {
-            "id": "cRerUu"
-          },
-          "condition": "dialog.qnaResult.score <= 0.05",
-          "actions": [
-            {
-              "$kind": "Microsoft.EmitEvent",
-              "$designer": {
-                "id": "rVjgzi"
-              },
-              "eventName": "recognizedIntent",
-              "eventValue": "=dialog.luisResult.result"
-            },
-            {
-              "$kind": "Microsoft.BreakLoop",
-              "$designer": {
-                "id": "iP9W7S"
-              }
-            }
-          ],
-          "top": 3,
-          "cardNoMatchResponse": "Thanks for the feedback.",
-          "cardNoMatchText": "None of the above."
         },
         {
           "$kind": "Microsoft.TextInput",
           "$designer": {
-            "id": "YQSOpf"
+            "id": "I11eFC"
           },
           "maxTurnCount": 3,
           "alwaysPrompt": true,
           "allowInterruptions": false,
+          "prompt": "${SendActivity_ChooseIntentPrompt()}",
           "property": "turn.intentChoice",
           "value": "=@userChosenIntent",
           "top": 3,
@@ -236,32 +219,31 @@
           "noAnswer": "Sorry, I did not find an answer.",
           "hostname": "=settings.qna.hostname",
           "endpointKey": "=settings.qna.endpointkey",
-          "knowledgeBaseId": "=settings.qna.knowledgebaseid",
-          "prompt": "${TextInput_Prompt_YQSOpf()}"
+          "knowledgeBaseId": "=settings.qna.knowledgebaseid"
         },
         {
           "$kind": "Microsoft.IfCondition",
           "$designer": {
-            "id": "Xh7TIa"
+            "id": "tjutdL"
           },
           "condition": "turn.intentChoice != 'none'",
           "actions": [
             {
               "$kind": "Microsoft.EmitEvent",
               "$designer": {
-                "id": "HUqDv8"
+                "id": "IazF4M"
               },
               "eventName": "recognizedIntent",
-              "eventValue": "=dialog[turn.intentChoice].result"
+              "eventValue": "=dialog.candidates[int(turn.intentChoice)].result"
             }
           ],
           "elseActions": [
             {
               "$kind": "Microsoft.SendActivity",
               "$designer": {
-                "id": "ufxNYo"
+                "id": "48DXRF"
               },
-              "activity": "${SendActivity_ufxNYo()}"
+              "activity": "${SendActivity_ChooseNoIntent()}"
             }
           ],
           "top": 3,

--- a/generators/generator-bot-assistant-core/generators/app/templates/language-generation/en-us/botName.en-us.lg
+++ b/generators/generator-bot-assistant-core/generators/app/templates/language-generation/en-us/botName.en-us.lg
@@ -60,19 +60,13 @@
 - Looks like I'm all mixed up. Let's try asking again, but maybe rephrase your request?
 - Sorry, it looks like something went wrong. Can you please try again?
 
-# TextInput_Prompt_YQSOpf()
+# SendActivity_ChooseIntentPrompt()
 [Activity
-    Attachments = ${json(ChooseIntentCard())}
+    Attachments = ${json(SendActivity_ChooseIntentPrompt_attachment_card(dialog.candidates))}
 ]
 
-# SendActivity_ufxNYo()
-[Activity
-    Text = Sure, no worries.
-]
-
-# ChooseIntentCard()
--```
-{
+# SendActivity_ChooseIntentPrompt_attachment_card(candidates)
+-```{
       "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
       "version": "1.0",
       "type": "AdaptiveCard",
@@ -80,12 +74,12 @@
       "body": [
           {
               "type": "TextBlock",
-              "text": "${whichOneDidYouMean()}",
+              "text": "${SendActivity_ChooseIntentPrompt_attachment_whichOneDidYouMean()}",
               "weight": "Bolder"
           },
           {
               "type": "TextBlock",
-              "text": "${pickOne()}",
+              "text": "${SendActivity_ChooseIntentPrompt_attachment_pickOne()}",
               "separator": "true"
           },
           {
@@ -93,14 +87,7 @@
               "placeholder": "Placeholder text",
               "id": "userChosenIntent",
               "choices": [
-                           {
-                               "title": "${getIntentReadBack()}",
-                               "value": "luisResult"
-                           },
-                           {
-                               "title": "${getAnswerReadBack()}",
-                               "value": "qnaResult"
-                           },
+                           ${SendActivity_ChooseIntentPrompt_attachment_generateChoices()},
                            {
                                "title": "None of the above",
                                "value": "none"
@@ -125,20 +112,31 @@
 }
 ```
 
-# whichOneDidYouMean()
+# SendActivity_ChooseIntentPrompt_attachment_whichOneDidYouMean()
 - I'm not sure which one you mean.
 - Hmmm, I find that to be ambiguous.
 
-# pickOne()
+# SendActivity_ChooseIntentPrompt_attachment_pickOne()
 - Can you pick one ?
 - Can you help clarify by choosing one ?
 
-# getAnswerReadBack()
+# SendActivity_ChooseIntentPrompt_attachment_getAnswerReadBack()
 - See an answer from the Knowledge Base
 
-# getIntentReadBack()
-- SWITCH : ${toLower(dialog.luisResult.intent)}
+# SendActivity_ChooseIntentPrompt_attachment_getIntentReadBack(intent)
+- SWITCH : ${intent}
+- CASE: ${'QnAMatch'}
+    - ${SendActivity_ChooseIntentPrompt_attachment_getAnswerReadBack()}
 - CASE : ${'GetUserProfile'}
   - Start filling in your profile(GetUserProfile intent)
 - DEFAULT :
-  - ${dialog.luisResult.intent}
+  - ${intent}
+
+# SendActivity_ChooseIntentPrompt_attachment_generateChoices(candidates)
+- ${join(foreach(indicesAndValues(candidates), c, SendActivity_ChooseIntentPrompt_attachment_choice(c.value.intent, c.index)), ',')}
+
+# SendActivity_ChooseIntentPrompt_attachment_choice(title, value)
+- { "title": "${SendActivity_ChooseIntentPrompt_attachment_getIntentReadBack(title)}", "value": "${value}" }
+
+# SendActivity_ChooseNoIntent()
+- Sure, no worries.

--- a/generators/generator-bot-enterprise-assistant/generators/app/templates/botName.dialog
+++ b/generators/generator-bot-enterprise-assistant/generators/app/templates/botName.dialog
@@ -203,131 +203,134 @@
     {
       "$kind": "Microsoft.OnChooseIntent",
       "$designer": {
-        "id": "YDQnEj"
+        "id": "YuA75w"
       },
       "actions": [
         {
           "$kind": "Microsoft.SetProperties",
           "$designer": {
-            "id": "LMu0fC"
+            "id": "VutAjG"
           },
           "assignments": [
             {
-              "value": "=turn.recognized.candidates[0]",
-              "property": "dialog.luisResult"
+              "property": "turn.minThreshold",
+              "value": 0.5
             },
             {
-              "property": "dialog.qnaResult",
-              "value": "=turn.recognized.candidates[1]"
+              "property": "turn.maxChoices",
+              "value": 3
+            },
+            {
+              "property": "conversation.lastAmbiguousUtterance",
+              "value": "=turn.activity.text"
+            },
+            {
+              "property": "dialog.candidates",
+              "value": "=take(sortByDescending(where(flatten(select(turn.recognized.candidates, x, if (x.intent==\"ChooseIntent\", x.result.candidates, x))), c, not(startsWith(c.intent, \"DeferToRecognizer_QnA\")) && c.score > turn.minThreshold), 'score'), turn.maxChoices)"
             }
           ]
         },
         {
-          "$kind": "Microsoft.IfCondition",
+          "$kind": "Microsoft.SwitchCondition",
           "$designer": {
-            "id": "1flIQn"
+            "id": "uCZ5AG"
           },
-          "condition": "dialog.luisResult.score >= 0.9 && dialog.qnaResult.score <= 0.5",
-          "actions": [
+          "condition": "=count(dialog.candidates)",
+          "cases": [
             {
-              "$kind": "Microsoft.EmitEvent",
-              "$designer": {
-                "id": "86jqYT"
-              },
-              "eventName": "recognizedIntent",
-              "eventValue": "=dialog.luisResult.result"
+              "value": "0",
+              "actions": [
+                {
+                  "$kind": "Microsoft.EmitEvent",
+                  "$designer": {
+                    "id": "s7XJNJ"
+                  },
+                  "eventName": "unknownIntent"
+                },
+                {
+                  "$kind": "Microsoft.EndDialog",
+                  "$designer": {
+                    "id": "xORMrt"
+                  }
+                }
+              ]
             },
             {
-              "$kind": "Microsoft.BreakLoop",
-              "$designer": {
-                "id": "YOHNju"
-              }
-            }
-          ]
-        },
-        {
-          "$kind": "Microsoft.IfCondition",
-          "$designer": {
-            "id": "1n7wbU"
-          },
-          "condition": "dialog.luisResult.score <= 0.5 && dialog.qnaResult.score >= 0.9",
-          "actions": [
-            {
-              "$kind": "Microsoft.EmitEvent",
-              "$designer": {
-                "id": "NAyC56"
-              },
-              "eventName": "recognizedIntent",
-              "eventValue": "=dialog.qnaResult.result"
-            },
-            {
-              "$kind": "Microsoft.BreakLoop",
-              "$designer": {
-                "id": "3fxdQ1"
-              }
-            }
-          ]
-        },
-        {
-          "$kind": "Microsoft.IfCondition",
-          "$designer": {
-            "id": "cRerUu"
-          },
-          "condition": "dialog.qnaResult.score <= 0.05",
-          "actions": [
-            {
-              "$kind": "Microsoft.EmitEvent",
-              "$designer": {
-                "id": "rVjgzi"
-              },
-              "eventName": "recognizedIntent",
-              "eventValue": "=dialog.luisResult.result"
-            },
-            {
-              "$kind": "Microsoft.BreakLoop",
-              "$designer": {
-                "id": "iP9W7S"
-              }
+              "value": "1",
+              "actions": [
+                {
+                  "$kind": "Microsoft.EmitEvent",
+                  "$designer": {
+                    "id": "1dcLLx"
+                  },
+                  "eventName": "recognizedIntent",
+                  "eventValue": "=first(dialog.candidates).result"
+                },
+                {
+                  "$kind": "Microsoft.EndDialog",
+                  "$designer": {
+                    "id": "h5Aagx"
+                  }
+                }
+              ]
             }
           ]
         },
         {
           "$kind": "Microsoft.TextInput",
           "$designer": {
-            "id": "YQSOpf"
+            "id": "I11eFC"
           },
           "maxTurnCount": 3,
           "alwaysPrompt": true,
           "allowInterruptions": false,
+          "prompt": "${SendActivity_ChooseIntentPrompt()}",
           "property": "turn.intentChoice",
           "value": "=@userChosenIntent",
-          "prompt": "${TextInput_Prompt_YQSOpf()}"
+          "top": 3,
+          "cardNoMatchResponse": "Thanks for the feedback.",
+          "cardNoMatchText": "None of the above.",
+          "activeLearningCardTitle": "Did you mean:",
+          "threshold": 0.3,
+          "noAnswer": "Sorry, I did not find an answer.",
+          "hostname": "=settings.qna.hostname",
+          "endpointKey": "=settings.qna.endpointkey",
+          "knowledgeBaseId": "=settings.qna.knowledgebaseid"
         },
         {
           "$kind": "Microsoft.IfCondition",
           "$designer": {
-            "id": "Xh7TIa"
+            "id": "tjutdL"
           },
           "condition": "turn.intentChoice != 'none'",
           "actions": [
             {
               "$kind": "Microsoft.EmitEvent",
               "$designer": {
-                "id": "HUqDv8"
+                "id": "IazF4M"
               },
               "eventName": "recognizedIntent",
-              "eventValue": "=dialog[turn.intentChoice].result"
+              "eventValue": "=dialog.candidates[int(turn.intentChoice)].result"
             }
           ],
           "elseActions": [
             {
               "$kind": "Microsoft.SendActivity",
               "$designer": {
-                "id": "ufxNYo"
+                "id": "48DXRF"
               },
-              "activity": "${SendActivity_ufxNYo()}"
+              "activity": "${SendActivity_ChooseNoIntent()}"
             }
-          ]
+          ],
+          "top": 3,
+          "cardNoMatchResponse": "Thanks for the feedback.",
+          "cardNoMatchText": "None of the above.",
+          "activeLearningCardTitle": "Did you mean:",
+          "threshold": 0.3,
+          "noAnswer": "Sorry, I did not find an answer.",
+          "hostname": "=settings.qna.hostname",
+          "endpointKey": "=settings.qna.endpointkey",
+          "knowledgeBaseId": "=settings.qna.knowledgebaseid"
         }
       ]
     },

--- a/generators/generator-bot-enterprise-assistant/generators/app/templates/language-generation/en-us/botName.en-us.lg
+++ b/generators/generator-bot-enterprise-assistant/generators/app/templates/language-generation/en-us/botName.en-us.lg
@@ -43,19 +43,14 @@
 [Activity
     Text = ${turn.dialogEvent.value}
 ]
-# TextInput_Prompt_YQSOpf()
+
+# SendActivity_ChooseIntentPrompt()
 [Activity
-    Attachments = ${json(ChooseIntentCard())}
+    Attachments = ${json(SendActivity_ChooseIntentPrompt_attachment_card(dialog.candidates))}
 ]
 
-# SendActivity_ufxNYo()
-[Activity
-    Text = Sure, no worries.
-]
-
-# ChooseIntentCard()
--```
-{
+# SendActivity_ChooseIntentPrompt_attachment_card(candidates)
+-```{
       "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
       "version": "1.0",
       "type": "AdaptiveCard",
@@ -63,12 +58,12 @@
       "body": [
           {
               "type": "TextBlock",
-              "text": "${whichOneDidYouMean()}",
+              "text": "${SendActivity_ChooseIntentPrompt_attachment_whichOneDidYouMean()}",
               "weight": "Bolder"
           },
           {
               "type": "TextBlock",
-              "text": "${pickOne()}",
+              "text": "${SendActivity_ChooseIntentPrompt_attachment_pickOne()}",
               "separator": "true"
           },
           {
@@ -76,18 +71,11 @@
               "placeholder": "Placeholder text",
               "id": "userChosenIntent",
               "choices": [
-                {
-                    "title": "${getIntentReadBack()}",
-                    "value": "luisResult"
-                },
-                {
-                    "title": "${getAnswerReadBack()}",
-                    "value": "qnaResult"
-                },
-                {
-                    "title": "None of the above",
-                    "value": "none"
-                }
+                           ${SendActivity_ChooseIntentPrompt_attachment_generateChoices()},
+                           {
+                               "title": "None of the above",
+                               "value": "none"
+                           }
              ],
              "style": "expanded",
              "value": "luis"
@@ -99,32 +87,43 @@
                      "type": "Action.Submit",
                      "title": "Submit",
                      "data": {
-                       "intent": "chooseIntentCardResponse"
-                    }
+                   "intent": "chooseIntentCardResponse"
                 }
-            ]
-        }
+         }
+       ]
+     }
     ]
 }
 ```
 
-# whichOneDidYouMean()
+# SendActivity_ChooseIntentPrompt_attachment_whichOneDidYouMean()
 - I'm not sure which one you mean.
 - Hmmm, I find that to be ambiguous.
 
-# pickOne()
+# SendActivity_ChooseIntentPrompt_attachment_pickOne()
 - Can you pick one ?
 - Can you help clarify by choosing one ?
 
-# getAnswerReadBack()
+# SendActivity_ChooseIntentPrompt_attachment_getAnswerReadBack()
 - See an answer from the Knowledge Base
 
-# getIntentReadBack()
-- SWITCH : ${toLower(dialog.luisResult.intent)}
+# SendActivity_ChooseIntentPrompt_attachment_getIntentReadBack(intent)
+- SWITCH : ${intent}
+- CASE: ${'QnAMatch'}
+    - ${SendActivity_ChooseIntentPrompt_attachment_getAnswerReadBack()}
 - CASE : ${'GetUserProfile'}
   - Start filling in your profile(GetUserProfile intent)
 - DEFAULT :
-  - ${dialog.luisResult.intent}
+  - ${intent}
+
+# SendActivity_ChooseIntentPrompt_attachment_generateChoices(candidates)
+- ${join(foreach(indicesAndValues(candidates), c, SendActivity_ChooseIntentPrompt_attachment_choice(c.value.intent, c.index)), ',')}
+
+# SendActivity_ChooseIntentPrompt_attachment_choice(title, value)
+- { "title": "${SendActivity_ChooseIntentPrompt_attachment_getIntentReadBack(title)}", "value": "${value}" }
+
+# SendActivity_ChooseNoIntent()
+- Sure, no worries.
 
 # SendActivity_bGYBta()
 [Activity


### PR DESCRIPTION
<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
### Purpose
*What is the context of this pull request? Why is it being done?*
Close #954 which updates the disambiguation feature for the Core and Enterprise Assistant templates. The LG templates are renamed in the same manner as #955. See microsoft/botframework-composer#7004 for additional context.
