### PR TITLE
Add better examples for Graph package schemas

### DIFF
--- a/packages/Graph/Schemas/Microsoft.Graph.Calendar.AcceptEvent.schema
+++ b/packages/Graph/Schemas/Microsoft.Graph.Calendar.AcceptEvent.schema
@@ -12,20 +12,25 @@
     "id": {
       "type": "string",
       "title": "Id",
-      "description": "Optional id for the dialog"
+      "description": "Optional id for the dialog",
+      "examples": [
+        "AcceptEventDialog"
+      ]
     },
     "resultProperty": {
       "$ref": "schema:#/definitions/stringExpression",
       "title": "Result property",
       "description": "Named state location to store result.",
-      "examples": []
+      "examples": [
+        "turn.result" 
+      ]
     },
     "token": {
       "$ref": "schema:#/definitions/valueExpression",
       "title": "Token",
       "description": "Microsoft Graph API authentication token.",
       "examples": [
-        "turn.token.token"
+        "=turn.token.token"
       ]
     },
     "eventId": {
@@ -33,7 +38,7 @@
       "title": "Event ID",
       "description": "The ID of the event to accept.",
       "examples": [
-        "dialog.event.id"
+        "=dialog.event.id"
       ]
     }
   }

--- a/packages/Graph/Schemas/Microsoft.Graph.Calendar.CreateEvent.schema
+++ b/packages/Graph/Schemas/Microsoft.Graph.Calendar.CreateEvent.schema
@@ -12,33 +12,42 @@
     "id": {
       "type": "string",
       "title": "Id",
-      "description": "Optional id for the dialog"
+      "description": "Optional id for the dialog",
+      "examples": [
+        "CreateEventDialog"
+      ]
     },
     "resultProperty": {
       "$ref": "schema:#/definitions/stringExpression",
       "title": "Result property",
       "description": "Named state location to store result.",
-      "examples": []
+      "examples": [
+        "turn.Result"
+      ]
     },
     "token": {
       "$ref": "schema:#/definitions/valueExpression",
       "title": "Token",
       "description": "Microsoft Graph API authentication token.",
       "examples": [
-        "turn.token.token"
+        "=turn.token.token"
       ]
     },
     "eventToCreateProperty": {
       "$ref": "schema:#/definitions/valueExpression",
       "title": "New event",
       "description": "Event object to create.",
-      "examples": []
+      "examples": [
+        "=turn.event"
+      ]
     },
     "timeZoneProperty": {
       "$ref": "schema:#/definitions/valueExpression",
       "title": "Time Zone",
       "description": "Target time zone to create the event in.",
-      "examples": []
+      "examples": [
+        "=turn.timezone"
+      ]
     }
   }
 }

--- a/packages/Graph/Schemas/Microsoft.Graph.Calendar.DeclineEvent.schema
+++ b/packages/Graph/Schemas/Microsoft.Graph.Calendar.DeclineEvent.schema
@@ -12,20 +12,25 @@
     "id": {
       "type": "string",
       "title": "Id",
-      "description": "Optional id for the dialog"
+      "description": "Optional id for the dialog",
+      "examples": [
+        "DeclineEventDialog"
+      ]
     },
     "resultProperty": {
       "$ref": "schema:#/definitions/stringExpression",
       "title": "Result property",
       "description": "Named state location to store result.",
-      "examples": []
+      "examples": [
+        "turn.result"
+      ]
     },
     "token": {
       "$ref": "schema:#/definitions/valueExpression",
       "title": "Token",
       "description": "Microsoft Graph API authentication token.",
       "examples": [
-        "turn.token.token"
+        "=turn.token.token"
       ]
     },
     "eventId": {
@@ -33,7 +38,7 @@
       "title": "Event ID",
       "description": "The ID of the event to decline.",
       "examples": [
-        "dialog.event.id"
+        "=dialog.event.id"
       ]
     }
   }

--- a/packages/Graph/Schemas/Microsoft.Graph.Calendar.DeleteEvent.schema
+++ b/packages/Graph/Schemas/Microsoft.Graph.Calendar.DeleteEvent.schema
@@ -12,20 +12,25 @@
     "id": {
       "type": "string",
       "title": "Id",
-      "description": "Optional id for the dialog"
+      "description": "Optional id for the dialog",
+      "examples": [
+        "DeleteEventDialog"
+      ]
     },
     "resultProperty": {
       "$ref": "schema:#/definitions/stringExpression",
       "title": "Result property",
       "description": "Named state location to store result.",
-      "examples": []
+      "examples": [
+        "turn.result"
+      ]
     },
     "token": {
       "$ref": "schema:#/definitions/valueExpression",
       "title": "Token",
       "description": "Microsoft Graph API authentication token.",
       "examples": [
-        "turn.token.token"
+        "=turn.token.token"
       ]
     },
     "eventId": {
@@ -33,7 +38,7 @@
       "title": "Event ID",
       "description": "The ID of the event to delete.",
       "examples": [
-        "dialog.event.id"
+        "=dialog.event.id"
       ]
     }
   }

--- a/packages/Graph/Schemas/Microsoft.Graph.Calendar.FindMeetingTimes.schema
+++ b/packages/Graph/Schemas/Microsoft.Graph.Calendar.FindMeetingTimes.schema
@@ -13,39 +13,50 @@
     "id": {
       "type": "string",
       "title": "Id",
-      "description": "Optional id for the dialog"
+      "description": "Optional id for the dialog",
+      "examples": [
+        "FindMeetingTimesDialog"
+      ]
     },
     "resultProperty": {
       "$ref": "schema:#/definitions/stringExpression",
       "title": "Result property",
       "description": "Named state location to store result.",
-      "examples": []
+      "examples": [
+        "turn.result"
+      ]
     },
     "token": {
       "$ref": "schema:#/definitions/valueExpression",
       "title": "Token",
       "description": "Microsoft Graph API authentication token.",
       "examples": [
-        "turn.token.token"
+        "=turn.token.token"
       ]
     },
     "attendeesProperty": {
       "$ref": "schema:#/definitions/valueExpression",
       "title": "Attendees",
       "description": "Event attendees",
-      "examples": []
+      "examples": [
+        "=turn.meeting.attendees"
+      ]
     },
     "durationProperty": {
       "$ref": "schema:#/definitions/valueExpression",
       "title": "Duration",
       "description": "Duration of meeting",
-      "examples": []
+      "examples": [
+        "=turn.meeting.duration"
+      ]
     },
     "timeZoneProperty": {
       "$ref": "schema:#/definitions/valueExpression",
       "title": "Time zone",
       "description": "Time zone for the meeting",
-      "examples": []
+      "examples": [
+        "=turn.meeting.timezone"
+      ]
     }
   }
 }

--- a/packages/Graph/Schemas/Microsoft.Graph.Calendar.GetContacts.schema
+++ b/packages/Graph/Schemas/Microsoft.Graph.Calendar.GetContacts.schema
@@ -12,27 +12,34 @@
     "id": {
       "type": "string",
       "title": "Id",
-      "description": "Optional id for the dialog"
+      "description": "Optional id for the dialog",
+      "examples": [
+        "GetContactsDialog"
+      ]
     },
     "resultProperty": {
       "$ref": "schema:#/definitions/stringExpression",
       "title": "Result property",
       "description": "Named state location to store result.",
-      "examples": []
+      "examples": [
+        "turn.result"
+      ]
     },
     "token": {
       "$ref": "schema:#/definitions/valueExpression",
       "title": "Token",
       "description": "Microsoft Graph API authentication token.",
       "examples": [
-        "turn.token.token"
+        "=turn.token.token"
       ]
     },
     "nameProperty": {
       "$ref": "schema:#/definitions/valueExpression",
       "title": "Name",
       "description": "Name to lookup",
-      "examples": []
+      "examples": [
+        "=turn.nametolookup"
+      ]
     }
   }
 }

--- a/packages/Graph/Schemas/Microsoft.Graph.Calendar.GetEventById.schema
+++ b/packages/Graph/Schemas/Microsoft.Graph.Calendar.GetEventById.schema
@@ -13,20 +13,25 @@
     "id": {
       "type": "string",
       "title": "Id",
-      "description": "Optional id for the dialog"
+      "description": "Optional id for the dialog",
+      "examples": [
+        "GetEventByIdDialog"
+      ]
     },
     "resultProperty": {
       "$ref": "schema:#/definitions/stringExpression",
       "title": "Result property",
       "description": "Named state location to store result.",
-      "examples": []
+      "examples": [
+        "turn.result"
+      ]
     },
     "token": {
       "$ref": "schema:#/definitions/valueExpression",
       "title": "Token",
       "description": "Microsoft Graph API authentication token.",
       "examples": [
-        "turn.token.token"
+        "=turn.token.token"
       ]
     },
     "eventIdProperty": {
@@ -34,7 +39,7 @@
       "title": "Event ID",
       "description": "The ID of the event to lookup.",
       "examples": [
-        "dialog.event.id"
+        "=dialog.event.id"
       ]
     },
     "timeZoneProperty": {
@@ -42,7 +47,7 @@
       "title": "Time zone",
       "description": "Target time zone to display the event in",
       "examples": [
-        "user.timeZone"
+        "=user.timezone"
       ]
     }
   }

--- a/packages/Graph/Schemas/Microsoft.Graph.Calendar.GetEvents.schema
+++ b/packages/Graph/Schemas/Microsoft.Graph.Calendar.GetEvents.schema
@@ -14,65 +14,88 @@
     "id": {
       "type": "string",
       "title": "Id",
-      "description": "Optional id for the dialog"
+      "description": "Optional id for the dialog",
+      "examples": [
+        "GetEventsDialog"
+      ]
     },
     "resultProperty": {
       "$ref": "schema:#/definitions/stringExpression",
       "title": "Result property",
       "description": "Named state location to store result.",
-      "examples": []
+      "examples": [
+        "turn.result"
+      ]
     },
     "token": {
       "$ref": "schema:#/definitions/valueExpression",
       "title": "Token",
       "description": "Microsoft Graph API authentication token.",
       "examples": [
-        "turn.token.token"
+        "=turn.token.token"
       ]
     },
     "startProperty": {
       "$ref": "schema:#/definitions/valueExpression",
       "title": "Start",
       "description": "Start datetime of event search range.",
-      "examples": []
+      "examples": [
+        "=turn.searchbegindatetime"
+      ]
     },
     "endProperty": {
       "$ref": "schema:#/definitions/valueExpression",
       "title": "End",
       "description": "End datetime of event search range.",
-      "examples": []
+      "examples": [
+        "=turn.searchenddatetime"
+      ]
     },
     "dateTimeTypeProperty": {
       "$ref": "schema:#/definitions/valueExpression",
       "title": "DateTimeType",
       "description": "DateTime type, e.g. date, datetime, datetimerange.",
       "examples": [
-        "dialog.dateTime.type"
+        "=dialog.dateTime.type",
+        "date",
+        "datetime",
+        "datetimerange"
       ]
     },
     "timeZoneProperty": {
       "$ref": "schema:#/definitions/valueExpression",
       "title": "TimeZone",
       "description": "Target time zone to display events in.",
-      "examples": []
+      "examples": [
+        "=user.timezone"
+      ]
     },
     "userEmailProperty": {
       "$ref": "schema:#/definitions/valueExpression",
       "title": "User Email",
       "description": "Current user's email address (to exclude from attendees list).",
-      "examples": []
+      "examples": [
+        "=user.email"
+      ]
     },
     "futureEventsOnlyProperty": {
       "$ref": "schema:#/definitions/booleanExpression",
       "title": "Future Events Only",
       "description": "If true, only return matching events in the future.",
-      "examples": []
+      "examples": [
+        "=turn.futuresonly",
+        "true",
+        "false"
+      ]
     },
     "maxResultsProperty": {
       "$ref": "schema:#/definitions/integerExpression",
       "title": "Max Results",
       "description": "Max number of results to return.",
-      "examples": []
+      "examples": [
+        "=turn.maxresults",
+        "10"
+      ]
     }
   }
 }

--- a/packages/Graph/Schemas/Microsoft.Graph.Calendar.GetWorkingHours.schema
+++ b/packages/Graph/Schemas/Microsoft.Graph.Calendar.GetWorkingHours.schema
@@ -12,27 +12,34 @@
     "id": {
       "type": "string",
       "title": "Id",
-      "description": "Optional id for the dialog"
+      "description": "Optional id for the dialog",
+      "examples": [
+        "GetWorkingHoursDialog"
+      ]
     },
     "resultProperty": {
       "$ref": "schema:#/definitions/stringExpression",
       "title": "Result property",
       "description": "Named state location to store result.",
-      "examples": []
+      "examples": [
+        "turn.result"
+      ]
     },
     "token": {
       "$ref": "schema:#/definitions/valueExpression",
       "title": "Token",
       "description": "Microsoft Graph API authentication token.",
       "examples": [
-        "turn.token.token"
+        "=turn.token.token"
       ]
     },
     "addressProperty": {
       "$ref": "schema:#/definitions/valueExpression",
       "title": "Email Address",
       "description": "Microsoft Graph SMTP address of user, distribution list, or resource to get availability information for.",
-      "examples": []
+      "examples": [
+        "=user.email"
+      ]
     }
   }
 }

--- a/packages/Graph/Schemas/Microsoft.Graph.Calendar.Helpers.FilterEvents.schema
+++ b/packages/Graph/Schemas/Microsoft.Graph.Calendar.Helpers.FilterEvents.schema
@@ -11,43 +11,61 @@
     "id": {
       "type": "string",
       "title": "Id",
-      "description": "Optional id for the dialog"
+      "description": "Optional id for the dialog",
+      "examples": [
+        "FilterEventsDialog"
+      ]
     },
     "resultProperty": {
       "$ref": "schema:#/definitions/stringExpression",
       "title": "Result property",
       "description": "Named state location to store result.",
-      "examples": []
+      "examples": [
+        "turn.result"
+      ]
     },
     "eventsProperty": {
       "$ref": "schema:#/definitions/valueExpression",
       "title": "Events",
       "description": "Events to filter",
-      "examples": []
+      "examples": [
+        "=turn.eventsfilter"
+      ]
     },
     "titleProperty": {
       "$ref": "schema:#/definitions/valueExpression",
       "title": "Title",
       "description": "Title to filter by",
-      "examples": []
+      "examples": [
+        "=turn.titlefilter"
+      ]
     },
     "locationProperty": {
       "$ref": "schema:#/definitions/valueExpression",
       "title": "Location",
       "description": "Location to filter by",
-      "examples": []
+      "examples": [
+        "=turn.locationfilter"
+      ]
     },
     "attendeesProperty": {
       "$ref": "schema:#/definitions/valueExpression",
       "title": "Attendees",
       "description": "Attendees to filter by",
-      "examples": []
+      "examples": [
+        "=turn.attendeesfilter"
+      ]
     },
     "ordinalProperty": {
       "$ref": "schema:#/definitions/valueExpression",
       "title": "Ordinal",
       "description": "Ordinal (e.g. next, first, last) to filter by",
-      "examples": []
+      "examples": [
+        "=turn.ordinalfilter",
+        "first",
+        "next",
+        "last"
+      ]
     }
   }
 }

--- a/packages/Graph/Schemas/Microsoft.Graph.Calendar.Helpers.FindAvailableTimes.schema
+++ b/packages/Graph/Schemas/Microsoft.Graph.Calendar.Helpers.FindAvailableTimes.schema
@@ -14,37 +14,50 @@
     "id": {
       "type": "string",
       "title": "Id",
-      "description": "Optional id for the dialog"
+      "description": "Optional id for the dialog",
+      "examples": [
+        "FindAvailableTimesDialog"
+      ]
     },
     "resultProperty": {
       "$ref": "schema:#/definitions/stringExpression",
       "title": "Result property",
       "description": "Named state location to store result.",
-      "examples": []
+      "examples": [
+        "turn.result"
+      ]
     },
     "eventsProperty": {
       "$ref": "schema:#/definitions/valueExpression",
       "title": "Events",
       "description": "List of events for date.",
-      "examples": []
+      "examples": [
+        "=turn.events"
+      ]
     },
     "workingHourStartProperty": {
       "$ref": "schema:#/definitions/valueExpression",
       "title": "Working Hours Start",
       "description": "Current user's configured work day start time.",
-      "examples": []
+      "examples": [
+        "=user.workingHoursStart"
+      ]
     },
     "workingHourEndProperty": {
       "$ref": "schema:#/definitions/valueExpression",
       "title": "Working Hours End",
       "description": "Current user's configured work day end time.",
-      "examples": []
+      "examples": [
+        "=user.workingHoursEnd"
+      ]
     },
     "startProperty": {
       "$ref": "schema:#/definitions/valueExpression",
       "title": "Date",
       "description": "Date for finding available times",
-      "examples": []
+      "examples": [
+        "=turn.searchDate"
+      ]
     }
   }
 }

--- a/packages/Graph/Schemas/Microsoft.Graph.Calendar.Helpers.GroupEventsByDate.schema
+++ b/packages/Graph/Schemas/Microsoft.Graph.Calendar.Helpers.GroupEventsByDate.schema
@@ -14,32 +14,41 @@
     "id": {
       "type": "string",
       "title": "Id",
-      "description": "Optional id for the dialog"
+      "description": "Optional id for the dialog",
+      "examples": [
+        "GroupEventsByDateDialog"
+      ]
     },
     "resultProperty": {
       "$ref": "schema:#/definitions/stringExpression",
       "title": "Result property",
       "description": "Named state location to store result.",
-      "examples": []
+      "examples": [
+        "turn.result"
+      ]
     },
     "startProperty": {
       "$ref": "schema:#/definitions/valueExpression",
       "title": "Start",
       "description": "DateTime range start.",
-      "examples": []
+      "examples": [
+        "=turn.groupdatetimestart"
+      ]
     },
     "endProperty": {
       "$ref": "schema:#/definitions/valueExpression",
       "title": "End",
       "description": "DateTime range end.",
-      "examples": []
+      "examples": [
+        "=turn.groupdatetimeend"
+      ]
     },
     "eventsProperty": {
       "$ref": "schema:#/definitions/valueExpression",
       "title": "Events",
       "description": "List of events to sort.",
       "examples": [
-        "dialog.events"
+        "=turn.events"
       ]
     }
   }

--- a/packages/Graph/Schemas/Microsoft.Graph.Calendar.Helpers.RecognizeDateTime.schema
+++ b/packages/Graph/Schemas/Microsoft.Graph.Calendar.Helpers.RecognizeDateTime.schema
@@ -12,25 +12,34 @@
     "id": {
       "type": "string",
       "title": "Id",
-      "description": "Optional id for the dialog"
+      "description": "Optional id for the dialog",
+      "examples": [
+        "RecognizeDateTimeDialog"
+      ]
     },
     "resultProperty": {
       "$ref": "schema:#/definitions/stringExpression",
       "title": "Result Property",
       "description": "Named state location to store result.",
-      "examples": []
+      "examples": [
+        "turn.result"
+      ]
     },
     "queryProperty": {
       "$ref": "schema:#/definitions/valueExpression",
       "title": "Query",
       "description": "Query string to run recognition against.",
-      "examples": []
+      "examples": [
+        "=turn.datetimequery"
+      ]
     },
     "timeZoneProperty": {
       "$ref": "schema:#/definitions/valueExpression",
       "title": "Time zone",
       "description": "Time zone for resolutions.",
-      "examples": []
+      "examples": [
+        "=turn.timezone"
+      ]
     }
   }
 }

--- a/packages/Graph/Schemas/Microsoft.Graph.Calendar.TentativelyAcceptEvent.schema
+++ b/packages/Graph/Schemas/Microsoft.Graph.Calendar.TentativelyAcceptEvent.schema
@@ -12,20 +12,25 @@
     "id": {
       "type": "string",
       "title": "Id",
-      "description": "Optional id for the dialog"
+      "description": "Optional id for the dialog",
+      "examples": [
+        "TentativelyAcceptEventDialog"
+      ]
     },
     "resultProperty": {
       "$ref": "schema:#/definitions/stringExpression",
       "title": "Result property",
       "description": "Named state location to store result.",
-      "examples": []
+      "examples": [
+        "turn.result"
+      ]
     },
     "token": {
       "$ref": "schema:#/definitions/valueExpression",
       "title": "Token",
       "description": "Microsoft Graph API authentication token.",
       "examples": [
-        "turn.token.token"
+        "=turn.token.token"
       ]
     },
     "eventId": {
@@ -33,7 +38,7 @@
       "title": "Event ID",
       "description": "The ID of the event to tentatively accept.",
       "examples": [
-        "dialog.event.id"
+        "=turn.event.id"
       ]
     }
   }

--- a/packages/Graph/Schemas/Microsoft.Graph.Calendar.UpdateEvent.schema
+++ b/packages/Graph/Schemas/Microsoft.Graph.Calendar.UpdateEvent.schema
@@ -12,27 +12,34 @@
     "id": {
       "type": "string",
       "title": "Id",
-      "description": "Optional id for the dialog"
+      "description": "Optional id for the dialog",
+      "examples": [
+        "UpdateEventDialog"
+      ]
     },
     "resultProperty": {
       "$ref": "schema:#/definitions/stringExpression",
       "title": "Result property",
       "description": "Named state location to store result.",
-      "examples": []
+      "examples": [
+        "turn.result"
+      ]
     },
     "token": {
       "$ref": "schema:#/definitions/valueExpression",
       "title": "Token",
       "description": "Microsoft Graph API authentication token.",
       "examples": [
-        "turn.token.token"
+        "=turn.token.token"
       ]
     },
     "eventToUpdateProperty": {
       "$ref": "schema:#/definitions/valueExpression",
       "title": "Updated event",
       "description": "Updated event object",
-      "examples": []
+      "examples": [
+        "=turn.eventsToUpdate"
+      ]
     }
   }
 }

--- a/packages/Graph/Schemas/Microsoft.Graph.Photo.GetPhoto.schema
+++ b/packages/Graph/Schemas/Microsoft.Graph.Photo.GetPhoto.schema
@@ -12,20 +12,25 @@
     "id": {
       "type": "string",
       "title": "Id",
-      "description": "Optional id for the dialog"
+      "description": "Optional id for the dialog",
+      "examples": [
+        "GetProfilePhotoDialog"
+      ]
     },
     "resultProperty": {
       "$ref": "schema:#/definitions/stringExpression",
       "title": "Result property",
       "description": "Named state location to store result.",
-      "examples": []
+      "examples": [
+        "turn.result"
+      ]
     },
     "token": {
       "$ref": "schema:#/definitions/valueExpression",
       "title": "Token",
       "description": "Microsoft Graph API authentication token.",
       "examples": [
-        "turn.token.token"
+        "=turn.token.token"
       ]
     },
     "userId": {
@@ -33,7 +38,7 @@
       "title": "User ID",
       "description": "The ID of the user to retrieve the photo for",
       "examples": [
-        "dialog.userId"
+        "=turn.userId"
       ]
     }
   }

--- a/packages/Graph/Schemas/Microsoft.Graph.User.GetDirectReports.schema
+++ b/packages/Graph/Schemas/Microsoft.Graph.User.GetDirectReports.schema
@@ -12,20 +12,25 @@
     "id": {
       "type": "string",
       "title": "Id",
-      "description": "Optional id for the dialog"
+      "description": "Optional id for the dialog",
+      "examples": [
+        "GetDirectReportsDialog"
+      ]
     },
     "resultProperty": {
       "$ref": "schema:#/definitions/stringExpression",
       "title": "Result property",
       "description": "Named state location to store result.",
-      "examples": []
+      "examples": [
+        "turn.result"
+      ]
     },
     "token": {
       "$ref": "schema:#/definitions/valueExpression",
       "title": "Token",
       "description": "Microsoft Graph API authentication token.",
       "examples": [
-        "turn.token.token"
+        "=turn.token.token"
       ]
     },
     "maxCount": {
@@ -33,7 +38,7 @@
       "title": "Max Results",
       "description": "Max number of results to return",
       "examples": [
-        "dialog.worksWithMe.maxResults"
+        "=turn.maxResults"
       ]
     },
     "propertiesToSelect": {
@@ -46,7 +51,14 @@
       "items": {
         "type": "string",
         "title": "Property",
-        "description": "Property name from the User object to select in Graph API."
+        "description": "Property name from the User object to select in Graph API.",
+        "examples": [
+          "id",
+          "displayName",
+          "mail",
+          "offliceLocation",
+          "jobTitle"
+        ]
       }
     },
     "userId": {
@@ -54,7 +66,7 @@
       "title": "User ID",
       "description": "The ID of the user to retrieve direct reports of",
       "examples": [
-        "dialog.user.id"
+        "=turn.user.id"
       ]
     }
   }

--- a/packages/Graph/Schemas/Microsoft.Graph.User.GetManager.schema
+++ b/packages/Graph/Schemas/Microsoft.Graph.User.GetManager.schema
@@ -12,20 +12,25 @@
     "id": {
       "type": "string",
       "title": "Id",
-      "description": "Optional id for the dialog"
+      "description": "Optional id for the dialog",
+      "examples": [
+        "GetManagerDialog"
+      ]
     },
     "resultProperty": {
       "$ref": "schema:#/definitions/stringExpression",
       "title": "Result property",
       "description": "Named state location to store result.",
-      "examples": []
+      "examples": [
+        "turn.result"
+      ]
     },
     "token": {
       "$ref": "schema:#/definitions/valueExpression",
       "title": "Token",
       "description": "Microsoft Graph API authentication token.",
       "examples": [
-        "turn.token.token"
+        "=turn.token.token"
       ]
     },
     "propertiesToSelect": {
@@ -38,7 +43,14 @@
       "items": {
         "type": "string",
         "title": "Property",
-        "description": "Property name from the User object to select in Graph API."
+        "description": "Property name from the User object to select in Graph API.",
+        "examples": [
+          "id",
+          "displayName",
+          "mail",
+          "offliceLocation",
+          "jobTitle"
+        ]
       }
     },
     "userId": {
@@ -46,7 +58,7 @@
       "title": "User ID",
       "description": "The ID of the user to get the manager of",
       "examples": [
-        "dialog.user.id"
+        "=turn.user.id"
       ]
     }
   }

--- a/packages/Graph/Schemas/Microsoft.Graph.User.GetPeers.schema
+++ b/packages/Graph/Schemas/Microsoft.Graph.User.GetPeers.schema
@@ -12,20 +12,25 @@
     "id": {
       "type": "string",
       "title": "Id",
-      "description": "Optional id for the dialog"
+      "description": "Optional id for the dialog",
+      "examples": [
+        "GetPeersDialog"
+      ]
     },
     "resultProperty": {
       "$ref": "schema:#/definitions/stringExpression",
       "title": "Result property",
       "description": "Named state location to store result.",
-      "examples": []
+      "examples": [
+        "turn.result"
+      ]
     },
     "token": {
       "$ref": "schema:#/definitions/valueExpression",
       "title": "Token",
       "description": "Microsoft Graph API authentication token.",
       "examples": [
-        "turn.token.token"
+        "=turn.token.token"
       ]
     },
     "maxCount": {
@@ -33,7 +38,7 @@
       "title": "Max Results",
       "description": "Max number of results to return",
       "examples": [
-        "dialog.peers.maxResults"
+        "=turn.maxResults"
       ]
     },
     "propertiesToSelect": {
@@ -46,7 +51,14 @@
       "items": {
         "type": "string",
         "title": "Property",
-        "description": "Property name from the User object to select in Graph API."
+        "description": "Property name from the User object to select in Graph API.",
+        "examples": [
+          "id",
+          "displayName",
+          "mail",
+          "offliceLocation",
+          "jobTitle"
+        ]
       }
     },
     "userId": {
@@ -54,7 +66,7 @@
       "title": "User ID",
       "description": "The ID of the user to get the peers of",
       "examples": [
-        "dialog.user.id"
+        "=turn.user.id"
       ]
     }
   }

--- a/packages/Graph/Schemas/Microsoft.Graph.User.GetProfile.schema
+++ b/packages/Graph/Schemas/Microsoft.Graph.User.GetProfile.schema
@@ -11,20 +11,25 @@
     "id": {
       "type": "string",
       "title": "Id",
-      "description": "Optional id for the dialog"
+      "description": "Optional id for the dialog",
+      "examples": [
+        "GetProfileDialog"
+      ]
     },
     "resultProperty": {
       "$ref": "schema:#/definitions/stringExpression",
       "title": "Result property",
       "description": "Named state location to store result.",
-      "examples": []
+      "examples": [
+        "turn.result"
+      ]
     },
     "token": {
       "$ref": "schema:#/definitions/valueExpression",
       "title": "Token",
       "description": "Microsoft Graph API authentication token.",
       "examples": [
-        "turn.token.token"
+        "=turn.token.token"
       ]
     }
   }

--- a/packages/Graph/Schemas/Microsoft.Graph.User.GetUserProfile.schema
+++ b/packages/Graph/Schemas/Microsoft.Graph.User.GetUserProfile.schema
@@ -12,20 +12,25 @@
     "id": {
       "type": "string",
       "title": "Id",
-      "description": "Optional id for the dialog"
+      "description": "Optional id for the dialog",
+      "examples": [
+        "GetUserProfileDialog"
+      ]
     },
     "resultProperty": {
       "$ref": "schema:#/definitions/stringExpression",
       "title": "Result property",
       "description": "Named state location to store result.",
-      "examples": []
+      "examples": [
+        "turn.result"
+      ]
     },
     "token": {
       "$ref": "schema:#/definitions/valueExpression",
       "title": "Token",
       "description": "Microsoft Graph API authentication token.",
       "examples": [
-        "turn.token.token"
+        "=turn.token.token"
       ]
     },
     "propertiesToSelect": {
@@ -38,7 +43,14 @@
       "items": {
         "type": "string",
         "title": "Property",
-        "description": "Property name from the User object to select in Graph API."
+        "description": "Property name from the User object to select in Graph API.",
+        "examples": [
+          "id",
+          "displayName",
+          "mail",
+          "offliceLocation",
+          "jobTitle"
+        ]
       }
     },
     "userId": {
@@ -46,7 +58,7 @@
       "title": "User ID",
       "description": "The ID of the user to get the profile of",
       "examples": [
-        "dialog.user.id"
+        "=turn.user.id"
       ]
     }
   }

--- a/packages/Graph/Schemas/Microsoft.Graph.User.GetUsers.schema
+++ b/packages/Graph/Schemas/Microsoft.Graph.User.GetUsers.schema
@@ -12,20 +12,25 @@
     "id": {
       "type": "string",
       "title": "Id",
-      "description": "Optional id for the dialog"
+      "description": "Optional id for the dialog",
+      "examples": [
+        "GetUsersDialog"
+      ]
     },
     "resultProperty": {
       "$ref": "schema:#/definitions/stringExpression",
       "title": "Result property",
       "description": "Named state location to store result.",
-      "examples": []
+      "examples": [
+        "turn.result"
+      ]
     },
     "token": {
       "$ref": "schema:#/definitions/valueExpression",
       "title": "Token",
       "description": "Microsoft Graph API authentication token.",
       "examples": [
-        "turn.token.token"
+        "=turn.token.token"
       ]
     },
     "maxCount": {
@@ -33,7 +38,7 @@
       "title": "Max Results",
       "description": "Max number of results to return",
       "examples": [
-        "dialog.worksWithMe.maxResults"
+        "=turn.maxResults"
       ]
     },
     "propertiesToSelect": {
@@ -46,15 +51,22 @@
       "items": {
         "type": "string",
         "title": "Property",
-        "description": "Property name from the User object to select in Graph API."
-        }
+        "description": "Property name from the User object to select in Graph API.",
+        "examples": [
+          "id",
+          "displayName",
+          "mail",
+          "offliceLocation",
+          "jobTitle"
+        ]
+      }
       },
       "nameToSearchFor": {
         "$ref": "schema:#/definitions/stringExpression",
         "title": "Search Name",
         "description": "Name of the user",
         "examples": [
-          "dialog.user.name"
+          "=turn.nametosearch"
         ]
       }
     }

--- a/packages/Graph/Schemas/Microsoft.Graph.User.GetWorksWith.schema
+++ b/packages/Graph/Schemas/Microsoft.Graph.User.GetWorksWith.schema
@@ -12,20 +12,25 @@
     "id": {
       "type": "string",
       "title": "Id",
-      "description": "Optional id for the dialog"
+      "description": "Optional id for the dialog",
+      "examples": [
+        "GetWorksWithDialog"
+      ]
     },
     "resultProperty": {
       "$ref": "schema:#/definitions/stringExpression",
       "title": "Result property",
       "description": "Named state location to store result.",
-      "examples": []
+      "examples": [
+        "turn.result"
+      ]
     },
     "token": {
       "$ref": "schema:#/definitions/valueExpression",
       "title": "Token",
       "description": "Microsoft Graph API authentication token.",
       "examples": [
-        "turn.token.token"
+        "=turn.token.token"
       ]
     },
     "maxCount": {
@@ -33,7 +38,7 @@
       "title": "Max Results",
       "description": "Max number of results to return",
       "examples": [
-        "dialog.worksWithMe.maxResults"
+        "=turn.maxResults"
       ]
     },
     "userId": {
@@ -41,7 +46,7 @@
       "title": "User ID",
       "description": "The ID of the user to get the collaborators of",
       "examples": [
-        "dialog.user.id"
+        "=turn.user.id"
       ]
     }
   }


### PR DESCRIPTION
<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
### Purpose
A lot of the example in the Graph package schemas are rather meaningless. Potentially leading to confusion in people who consumes these templates.

### Changes
Update the examples in the schema to include better ones:
- The examples are now more realistic, instead of "Hello ${user.name}" it would not say things like "turn.result" something that makes sense to the specific scenario
- If the property is an _input_ driven from something in the memory scope, then they would include "=" at the start to denote to give people better idea that is an adaptive expression to resolve a value from the memory scope.

### Tests
Tested by updating schema in the Composer than ensuring the samples are showing up.

### Feature Plan
Update the Graph package with the improved schema examples

### Checklist

#### General
- [x] I have commented my code, particularly in hard-to-understand areas	
- [x] I have added or updated the appropriate tests	
- [x] I have updated related documentation
