### PR TITLE
[EA] Added allowed callers error message

### DIFF
--- a/generators/generator-bot-enterprise-assistant/generators/app/templates/botName.dialog
+++ b/generators/generator-bot-enterprise-assistant/generators/app/templates/botName.dialog
@@ -335,7 +335,7 @@
                   "$designer": {
                     "id": "QVRnBT"
                   },
-                  "condition": "=exists(settings.skill) && not(exists(settings.runtimeSettings.skills.allowedCallers))",
+                  "condition": "=exists(settings.skill) && (not(exists(settings.runtimeSettings.skills.allowedCallers)) || count(where(settings.runtimeSettings.skills.allowedCallers, x, x != "")) == 0)",
                   "actions": [
                     {
                       "$kind": "Microsoft.SendActivity",

--- a/generators/generator-bot-enterprise-assistant/generators/app/templates/botName.dialog
+++ b/generators/generator-bot-enterprise-assistant/generators/app/templates/botName.dialog
@@ -331,6 +331,22 @@
               "value": "emulator",
               "actions": [
                 {
+                  "$kind": "Microsoft.IfCondition",
+                  "$designer": {
+                    "id": "QVRnBT"
+                  },
+                  "condition": "=exists(settings.skill) && not(exists(settings.runtimeSettings.skills.allowedCallers))",
+                  "actions": [
+                    {
+                      "$kind": "Microsoft.SendActivity",
+                      "$designer": {
+                        "id": "UopnaT"
+                      },
+                      "activity": "${SendActivity_UopnaT()}"
+                    }
+                  ]
+                },
+                {
                   "$kind": "Microsoft.TraceActivity",
                   "$designer": {
                     "id": "EqWeYD"

--- a/generators/generator-bot-enterprise-assistant/generators/app/templates/dialogs/BotTourDialog/language-generation/en-us/BotTourDialog.en-us.lg
+++ b/generators/generator-bot-enterprise-assistant/generators/app/templates/dialogs/BotTourDialog/language-generation/en-us/BotTourDialog.en-us.lg
@@ -70,9 +70,9 @@
 {
     "type": "ActionSet",
     "actions": [
-        ${BuildSubmitAction("Who is a peer of...", "People")},
-        ${BuildSubmitAction("Who is the manager of...", "People")},
-        ${BuildSubmitAction("Who reports to...", "People")}
+        ${BuildSubmitAction("Who are Joni's peers?", "People")},
+        ${BuildSubmitAction("Who is Allan's manager?", "People")},
+        ${BuildSubmitAction("Who reports to Nestor?", "People")}
     ]
 }
 ```

--- a/generators/generator-bot-enterprise-assistant/generators/app/templates/language-generation/en-us/botName.en-us.lg
+++ b/generators/generator-bot-enterprise-assistant/generators/app/templates/language-generation/en-us/botName.en-us.lg
@@ -173,3 +173,8 @@ Try saying:
 * "When do I have breaks today?" or "What is scheduled for tomorrow?"
 * "Who is the manager of" or "Who reports to", and much more!
 ```
+
+# SendActivity_UopnaT()
+[Activity
+    Text = **ERROR**: Your root bot does not have allowed callers configured. Open **Project Settings > Skills Configuration** to specifiy allowed callers.
+]


### PR DESCRIPTION
If the root bot does not have allowedCallers configured and throws an error, the bot will send a message to explain.

This will only be shown in the emulator channel.

Fixes: #973