### PR TITLE
New pipelines for calendar and people

### DIFF
--- a/build/yaml/pipelines/calendar.yml
+++ b/build/yaml/pipelines/calendar.yml
@@ -1,0 +1,19 @@
+name: $(Build.BuildId)
+trigger: none  # ci trigger is set in ADO
+pr: none # pr trigger is set in ADO
+
+pool: 
+  vmImage: $[ coalesce( variables['VMImage'], 'windows-2019' ) ] # or 'windows-latest' or 'vs2017-win2016'
+  
+extends:
+  template: ../templates/component-template.yml
+
+variables:
+  BuildConfiguration: Release
+  BuildPlatform: anycpu
+  ComponentType: codeExtension
+  DeploymentRing: preview
+  # DeploymentRingOverride: # set in ADO
+  # PublishPackageArtifacts: # set in ADO
+  # ReleaseCandidateNumber: # set in ADO
+  WorkingDirectory: skills/declarative/calendar/calendar

--- a/build/yaml/pipelines/people.yml
+++ b/build/yaml/pipelines/people.yml
@@ -1,0 +1,19 @@
+name: $(Build.BuildId)
+trigger: none  # ci trigger is set in ADO
+pr: none # pr trigger is set in ADO
+
+pool: 
+  vmImage: $[ coalesce( variables['VMImage'], 'windows-2019' ) ] # or 'windows-latest' or 'vs2017-win2016'
+  
+extends:
+  template: ../templates/component-template.yml
+
+variables:
+  BuildConfiguration: Release
+  BuildPlatform: anycpu
+  ComponentType: codeExtension
+  DeploymentRing: preview
+  # DeploymentRingOverride: # set in ADO
+  # PublishPackageArtifacts: # set in ADO
+  # ReleaseCandidateNumber: # set in ADO
+  WorkingDirectory: skills/declarative/whoSkill/whoSkill


### PR DESCRIPTION
<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
### Purpose
Add CICD pipelines for calendar people skill that was originally GH actions but now has to move to ADO.

### Changes
New pipeline definitions to build the bot csproj and then run tests

### Tests
*Is this covered by existing tests or new ones? If no, why not?*

### Feature Plan
*Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues.*

### Checklist

#### General
- [x] I have commented my code, particularly in hard-to-understand areas	
- [x] I have added or updated the appropriate tests	
- [x] I have updated related documentation
