### PR TITLE
maintenance: Enable auto-assign pull request author to assignee

### DIFF
--- a/.github/auto_assign.yml
+++ b/.github/auto_assign.yml
@@ -2,14 +2,12 @@
 addReviewers: false
 
 # Set to true to add assignees to pull requests
-addAssignees: false
+# Set to author to set pr creator as assignee
+addAssignees: author
 
 # A list of reviewers to be added to pull requests (GitHub user name)
 reviewers:
-  - lauren-mills
-  - bobokids
-  - kaymkm
-  - xhr0804
+  - microsoft/bot-framework-components-team
   
 # A number of reviewers added to the pull request
 # Set 0 to add all the reviewers (default: 0)


### PR DESCRIPTION
<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
### Purpose
*What is the context of this pull request? Why is it being done?*
We have the [auto-assign](https://github.com/kentaro-m/auto-assign/) bot installed but not enabled on this repository and would benefit from automating more of our process. 

#### How it works
- When the pull request is opened, automatically add reviewers/assignees to the pull request.
- If the number of reviewers is specified, randomly add reviewers/assignees to the pull request.
- If reviewers/assignees are separated into groups in the config file, randomly select the number of reviewers from each group.
- If the title of the pull request contains a specific keyword, do not add reviewers/assignees to the pull request.

### Changes
Close #979, which enables the auto-assign bot to add a PR author as the designated assignee. This also cleans up the reviewers list to the [microsot/bot-framework-components-team](https://github.com/orgs/microsoft/teams/bot-framework-components-team) but does not automatically assign anyone. 
