### PR TITLE
chore: fix typo in pr-labeler action

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,4 +1,4 @@
-name: PR Labeler"
+name: PR Labeler
 
 on:
   pull_request:


### PR DESCRIPTION
Remove extraneous `"` in PR labeler action

#minor