### PR TITLE
fix: replace Basic Assistant bot tour multichoice logic with intents

### DIFF
--- a/generators/generator-bot-core-assistant/generators/app/templates/dialogs/BotTourDialog/BotTourDialog.dialog
+++ b/generators/generator-bot-core-assistant/generators/app/templates/dialogs/BotTourDialog/BotTourDialog.dialog
@@ -34,79 +34,62 @@
       "intent": "DetailsCard",
       "actions": [
         {
-          "$kind": "Microsoft.ChoiceInput",
+          "$kind": "Microsoft.SendActivity",
           "$designer": {
-            "id": "8kK1VI"
+            "id": "ZMzFeP"
           },
-          "defaultLocale": "en-us",
-          "disabled": false,
-          "maxTurnCount": 3,
-          "alwaysPrompt": false,
-          "allowInterruptions": true,
-          "unrecognizedPrompt": "",
-          "invalidPrompt": "",
-          "prompt": "${ChoiceInput_Prompt_BotTourDetails()}",
-          "choiceOptions": {
-            "includeNumbers": true,
-            "inlineOrMore": ", or ",
-            "inlineOr": " or ",
-            "inlineSeparator": ", "
-          },
-          "choices": [
-            "A",
-            "B",
-            "C"
-          ],
-          "style": "none",
-          "recognizerOptions": {
-            "recognizeOrdinals": true
-          },
-          "property": "user.botTourDetailsChoice"
-        },
+          "activity": "${SendActivity_BotTourDetails()}"
+        }
+      ]
+    },
+    {
+      "$kind": "Microsoft.OnIntent",
+      "$designer": {
+        "id": "vdn2Dw",
+        "name": "ActionA"
+      },
+      "intent": "ActionA",
+      "actions": [
         {
-          "$kind": "Microsoft.SwitchCondition",
+          "$kind": "Microsoft.SendActivity",
           "$designer": {
-            "id": "Vjasiy"
+            "id": "oeL3EC"
           },
-          "condition": "user.botTourDetailsChoice",
-          "cases": [
-            {
-              "value": "A",
-              "actions": [
-                {
-                  "$kind": "Microsoft.SendActivity",
-                  "$designer": {
-                    "id": "ic0cAT"
-                  },
-                  "activity": "${SendActivity_SuggestedActionAContent()}"
-                }
-              ]
-            },
-            {
-              "value": "B",
-              "actions": [
-                {
-                  "$kind": "Microsoft.SendActivity",
-                  "$designer": {
-                    "id": "lCESbU"
-                  },
-                  "activity": "${SendActivity_SuggestedActionBContent()}"
-                }
-              ]
-            },
-            {
-              "value": "C",
-              "actions": [
-                {
-                  "$kind": "Microsoft.SendActivity",
-                  "$designer": {
-                    "id": "3ixDCm"
-                  },
-                  "activity": "${SendActivity_SuggestedActionCContent()}"
-                }
-              ]
-            }
-          ]
+          "activity": "${SendActivity_SuggestedActionAContent()}"
+        }
+      ]
+    },
+    {
+      "$kind": "Microsoft.OnIntent",
+      "$designer": {
+        "id": "ruLbcx",
+        "name": "ActionB"
+      },
+      "intent": "ActionB",
+      "actions": [
+        {
+          "$kind": "Microsoft.SendActivity",
+          "$designer": {
+            "id": "PSsrvD"
+          },
+          "activity": "${SendActivity_SuggestedActionBContent()}"
+        }
+      ]
+    },
+    {
+      "$kind": "Microsoft.OnIntent",
+      "$designer": {
+        "id": "Fris5p",
+        "name": "ActionC"
+      },
+      "intent": "ActionC",
+      "actions": [
+        {
+          "$kind": "Microsoft.SendActivity",
+          "$designer": {
+            "id": "N0UxWx"
+          },
+          "activity": "${SendActivity_SuggestedActionCContent()}"
         }
       ]
     },

--- a/generators/generator-bot-core-assistant/generators/app/templates/dialogs/BotTourDialog/language-generation/en-us/BotTourDialog.en-us.lg
+++ b/generators/generator-bot-core-assistant/generators/app/templates/dialogs/BotTourDialog/language-generation/en-us/BotTourDialog.en-us.lg
@@ -9,29 +9,23 @@
 > OverviewCard
 - ${json(CardTemplate(BotTourHeader(), ExpandableListCardBody(createArray(BotTourOption(BotTourContentTextOne()),BotTourOption(BotTourContentTextTwo()),BotTourOption(BotTourContentTextThree())), 5), ''))}
 
-# ChoiceInput_Prompt_BotTourDetails()
+# SendActivity_BotTourDetails()
 [Activity
-    Attachments = ${ChoiceInput_Prompt_BotTourDetails_attachment_adaptiveCard()}
+    Attachments = ${SendActivity_BotTourDetails_attachment_adaptiveCard()}
 ]
 
-# ChoiceInput_Prompt_BotTourDetails_attachment_adaptiveCard()
+# SendActivity_BotTourDetails_attachment_adaptiveCard()
 > DetailsCard
 - ${json(CardTemplate(BotTourDetailsCardHeader(),BotTourDetailsCardBody(), BotTourDetailsCardActions()))}
 
-# SendActivity_SuggestedActionAContent()
-[Activity
-    Text = You can link content for suggested action A here.
-]
+# SendActivity_SuggestedActionAContent
+- You can replace content for suggested action A here.
 
-# SendActivity_SuggestedActionBContent()
-[Activity
-    Text = You can link content for suggested action B here.
-]
+# SendActivity_SuggestedActionBContent
+- You can replace content for suggested action B here.
 
-# SendActivity_SuggestedActionCContent()
-[Activity
-    Text = You can link content for suggested action C here.
-]
+# SendActivity_SuggestedActionCContent
+- You can replace content for suggested action C here.
 
 # BotTourTitle()
 - You can ask me...
@@ -212,17 +206,23 @@
         {
             "type": "Action.Submit",
             "title": "\"Suggested action A\"",
-            "data": "A"
+                  "data":{
+         "intent":"ActionA"
+      }
         },
         {
             "type": "Action.Submit",
             "title": "\"Suggested action B\"",
-            "data": "B"
+                  "data":{
+         "intent":"ActionB"
+      }
         },
         {
             "type": "Action.Submit",
             "title": "\"Suggested action C\"",
-            "data": "C"
+                  "data":{
+         "intent":"ActionC"
+      }
         }
     ]
 }

--- a/generators/generator-bot-core-assistant/generators/app/templates/dialogs/BotTourDialog/language-generation/en-us/BotTourDialog.en-us.lg
+++ b/generators/generator-bot-core-assistant/generators/app/templates/dialogs/BotTourDialog/language-generation/en-us/BotTourDialog.en-us.lg
@@ -212,23 +212,23 @@
         {
             "type": "Action.Submit",
             "title": "\"Suggested action A\"",
-                  "data":{
-         "intent":"ActionA"
-      }
+            "data":{
+               "intent":"ActionA"
+            }
         },
         {
             "type": "Action.Submit",
             "title": "\"Suggested action B\"",
-                  "data":{
-         "intent":"ActionB"
-      }
+            "data":{
+               "intent":"ActionB"
+            }
         },
         {
             "type": "Action.Submit",
             "title": "\"Suggested action C\"",
-                  "data":{
-         "intent":"ActionC"
-      }
+            "data":{
+               "intent":"ActionC"
+            }
         }
     ]
 }

--- a/generators/generator-bot-core-assistant/generators/app/templates/dialogs/BotTourDialog/language-generation/en-us/BotTourDialog.en-us.lg
+++ b/generators/generator-bot-core-assistant/generators/app/templates/dialogs/BotTourDialog/language-generation/en-us/BotTourDialog.en-us.lg
@@ -18,14 +18,20 @@
 > DetailsCard
 - ${json(CardTemplate(BotTourDetailsCardHeader(),BotTourDetailsCardBody(), BotTourDetailsCardActions()))}
 
-# SendActivity_SuggestedActionAContent
-- You can replace content for suggested action A here.
+# SendActivity_SuggestedActionAContent()
+[Activity
+    Text = You can link content for suggested action A here.
+]
 
-# SendActivity_SuggestedActionBContent
-- You can replace content for suggested action B here.
+# SendActivity_SuggestedActionBContent()
+[Activity
+    Text = You can link content for suggested action B here.
+]
 
-# SendActivity_SuggestedActionCContent
-- You can replace content for suggested action C here.
+# SendActivity_SuggestedActionCContent()
+[Activity
+    Text = You can link content for suggested action C here.
+]
 
 # BotTourTitle()
 - You can ask me...

--- a/generators/generator-bot-core-assistant/generators/app/templates/dialogs/BotTourDialog/language-generation/en-us/BotTourDialog.en-us.lg
+++ b/generators/generator-bot-core-assistant/generators/app/templates/dialogs/BotTourDialog/language-generation/en-us/BotTourDialog.en-us.lg
@@ -213,21 +213,21 @@
             "type": "Action.Submit",
             "title": "\"Suggested action A\"",
             "data":{
-               "intent":"ActionA"
+               "intent": "ActionA"
             }
         },
         {
             "type": "Action.Submit",
             "title": "\"Suggested action B\"",
             "data":{
-               "intent":"ActionB"
+               "intent": "ActionB"
             }
         },
         {
             "type": "Action.Submit",
             "title": "\"Suggested action C\"",
             "data":{
-               "intent":"ActionC"
+               "intent": "ActionC"
             }
         }
     ]


### PR DESCRIPTION
<!--- This repository only accepts pull requests related to open issues, please link the open issue in description below. See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. 
For example - Close #123: Description goes here. -->
### Purpose
Close #1032 

### Changes
#1023 introduced additional edge cases where interruptions didn't work as expected, this addresses that by reverting to the better understood intent routing logic used before.

DetailsCard sends an activity with a card attachment.
![image](https://user-images.githubusercontent.com/43043272/116444480-9dc46d00-a809-11eb-8dc5-01ed264116ff.png)

Each suggested action maps to its own intent and response that can be customized by the user.
![image](https://user-images.githubusercontent.com/43043272/116444504-a452e480-a809-11eb-8317-aa82717ed4cc.png)

#### Expected flow
![image](https://user-images.githubusercontent.com/43043272/116444348-7cfc1780-a809-11eb-9b94-670d3793525e.png)

#### Interruptions
![image](https://user-images.githubusercontent.com/43043272/116444405-8ab19d00-a809-11eb-8b5f-fbec526c2573.png)
![image](https://user-images.githubusercontent.com/43043272/116444461-97ce8c00-a809-11eb-916a-1024eb565377.png)
