### PR TITLE
fix: Removing redundant componentType check in npm-versioning-steps.yml.

### DIFF
--- a/build/yaml/templates/npm-versioning-steps.yml
+++ b/build/yaml/templates/npm-versioning-steps.yml
@@ -29,29 +29,27 @@ steps:
       $vs = "-" + $dateStamp + "." + $commitHash;
     }
 
-    # If declarative assets or generator, get and set version from package.json
-    if ($componentType.ToLowerInvariant() -eq "declarativeAsset" -Or $componentType.ToLowerInvariant() -eq "generator" ) {
-      if (Test-Path -Path package.json) {
-        # Get existing version from package.json
-        $packageJson = Get-Content package.json;
-        $packageJsonData = $packageJson | ConvertFrom-Json;
-        $packageVersion = $packageJsonData.version
-        "Version Prefix = $packageVersion";
+    # Get and set version from package.json
+    if (Test-Path -Path package.json) {
+      # Get existing version from package.json
+      $packageJson = Get-Content package.json;
+      $packageJsonData = $packageJson | ConvertFrom-Json;
+      $packageVersion = $packageJsonData.version
+      "Version Prefix = $packageVersion";
 
-        # Configure version suffix based on deployment ring
-        if ($deploymentRing.ToLowerInvariant() -ne "stable") {
-          # npm uses a slightly different version suffix pattern, so calculate that separately.
-          $npmVersionSuffix = $deploymentRing + $vs;
-          "Version Suffix = $npmVersionSuffix";
-          $packageVersion += "-" + $npmVersionSuffix;
-        }
-
-        "Version = $packageVersion";
-        Write-Host "##vso[task.setvariable variable=NpmPackageVersion;]$packageVersion";
-      } else {
-        Write-Host "Missing package.json"
-        exit 1
+      # Configure version suffix based on deployment ring
+      if ($deploymentRing.ToLowerInvariant() -ne "stable") {
+        # npm uses a slightly different version suffix pattern, so calculate that separately.
+        $npmVersionSuffix = $deploymentRing + $vs;
+        "Version Suffix = $npmVersionSuffix";
+        $packageVersion += "-" + $npmVersionSuffix;
       }
+
+      "Version = $packageVersion";
+      Write-Host "##vso[task.setvariable variable=NpmPackageVersion;]$packageVersion";
+    } else {
+      Write-Host "Missing package.json"
+      exit 1
     }
   displayName: 'Resolve package version variables'
   name: SetVersion


### PR DESCRIPTION
### Purpose
When attempting to run the Teams JS daily build, it fails due to NpmPackageVersion not being set in npm-versioning-steps.yml. This is because it only gets set when the component type is 'declarativeAsset' or 'generator', and in this case it needs to also run when component type is 'codeExtension' and language is 'js'.

Given that we only enter into this step when those conditions are true, due to the same check being applied at stage_package_node in component-template.yml, and we should always have a package.json for these cases, the additional condition is redundant, so removing it altogether.

### Changes
- Removing redundant componentType check in npm-versioning-steps.yml.

### Tests
Manually running daily pipeline against this branch. Will verify before merging.

#minor