### PR TITLE
fix: run build script if present

### DIFF
--- a/build/yaml/templates/npm-build-steps.yml
+++ b/build/yaml/templates/npm-build-steps.yml
@@ -9,4 +9,9 @@ steps:
   displayName: 'Install dependencies'
   workingDirectory: '$(WorkingDirectory)'
 
+- script: |
+    yarn exec npm run --if-present build
+  displayName: 'Run build if it exists'
+  workingDirectory: '$(WorkingDirectory)'
+
 - template: debug-workspace-steps.yml


### PR DESCRIPTION
### Purpose
Run build script if defined in `package.json`

### Changes
Some packages may define a `build` script that should be executed as part of the publish. This ensures the script is executed.

#minor