### PR TITLE
fix: Include needed files and run settings for Azure Functions build

### DIFF
--- a/generators/generator-bot-adaptive/generators/app/templates/dotnet/functions/botName.csproj
+++ b/generators/generator-bot-adaptive/generators/app/templates/dotnet/functions/botName.csproj
@@ -3,8 +3,11 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <AzureFunctionsVersion>v3</AzureFunctionsVersion>
   </PropertyGroup>
+  <PropertyGroup>
+    <_FunctionsSkipCleanOutput>true</_FunctionsSkipCleanOutput>
+  </PropertyGroup>
   <ItemGroup>
-    <Content Include="**/*.blu;**/*.dialog;**/*.lg;**/*.lu;**/*.onnx;**/*.qna;**/*.txt" Exclude="$(BaseOutputPath)/**;$(BaseIntermediateOutputPath)/**;wwwroot/**">
+    <Content Include="**/*.blu;**/*.dialog;**/*.lg;**/*.lu;**/*.onnx;**/*.qna;**/*.txt;**/generated/*.json" Exclude="$(BaseOutputPath)/**;$(BaseIntermediateOutputPath)/**;wwwroot/**">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
@@ -26,7 +29,7 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <CopyToPublishDirectory>Never</CopyToPublishDirectory>
     </None>
-    <None Include="<%- settingsIncludePath %>appsettings.json">
+    <None Include="<%- settingsIncludePath %>\*.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Include="www\**\*.*">


### PR DESCRIPTION
Fixes #1063

This appears to be a long winded way to:
1) Include all files in settings folder
2) Include all json files in generated folder
3) Include host.json, but NOT local.settings.json for publish builds.