### PR TITLE
fix: .NET Functions .csproj template fixes

### DIFF
--- a/generators/generator-bot-adaptive/generators/app/templates/dotnet/functions/botName.csproj
+++ b/generators/generator-bot-adaptive/generators/app/templates/dotnet/functions/botName.csproj
@@ -5,7 +5,8 @@
     <_FunctionsSkipCleanOutput>true</_FunctionsSkipCleanOutput>
   </PropertyGroup>
   <ItemGroup>
-    <Content Include="**/*.blu;**/*.dialog;**/*.json;**/*.lg;**/*.lu;**/*.onnx;**/*.qna;**/*.txt" Exclude="$(BaseOutputPath)/**;$(BaseIntermediateOutputPath)/**;www/**">
+    <Content Include="**/*.blu;**/*.dialog;**/*.json;**/*.lg;**/*.lu;**/*.onnx;**/*.qna;**/*.txt"
+             Exclude="$(AppDesignerFolder)/**;$(BaseOutputPath)/**;$(BaseIntermediateOutputPath)/**;www/**;**/function.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>

--- a/generators/generator-bot-adaptive/generators/app/templates/dotnet/functions/botName.csproj
+++ b/generators/generator-bot-adaptive/generators/app/templates/dotnet/functions/botName.csproj
@@ -2,9 +2,10 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <AzureFunctionsVersion>v3</AzureFunctionsVersion>
+    <_FunctionsSkipCleanOutput>true</_FunctionsSkipCleanOutput>
   </PropertyGroup>
   <ItemGroup>
-    <Content Include="**/*.blu;**/*.dialog;**/*.lg;**/*.lu;**/*.onnx;**/*.qna;**/*.txt" Exclude="$(BaseOutputPath)/**;$(BaseIntermediateOutputPath)/**;wwwroot/**">
+    <Content Include="**/*.blu;**/*.dialog;**/*.json;**/*.lg;**/*.lu;**/*.onnx;**/*.qna;**/*.txt" Exclude="$(BaseOutputPath)/**;$(BaseIntermediateOutputPath)/**;www/**">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
@@ -19,17 +20,10 @@
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.7" /><%- packageReferences %>
   </ItemGroup>
   <ItemGroup>
-    <None Update="host.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Update="local.settings.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    <Content Update="local.settings.json">
       <CopyToPublishDirectory>Never</CopyToPublishDirectory>
     </None>
-    <None Include="<%- settingsIncludePath %>appsettings.json">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-    <None Include="www\**\*.*">
+    <None Include="www/**/*.*">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>


### PR DESCRIPTION
### Purpose
Fixes #1063.

### Changes
- Updating .NET Functions .csproj template to include all *.json files (except in www directory) as content.
- `local.settings.json` continues to not excluded in publish output.
- Fix www item include to use POSIX-style path separators.
- Add `_FunctionsSkipCleanOutput` to PropertyGroup with value set to `true`.

### Tests
Testing still required - WIP.