### PR TITLE
fix: Install .NET Core SDK for '.NET: Version, Sign & Pack' CI/CD pipeline stage

### DIFF
--- a/build/yaml/templates/component-template.yml
+++ b/build/yaml/templates/component-template.yml
@@ -29,6 +29,7 @@ stages:
       - job: build_test_dotnet
         displayName: Build and test .csproj with dotnet
         steps:
+        - template: dotnet-install-sdk-steps.yml
         - template: dotnet-build-test-steps.yml
 
   - stage: stage_package_nuget
@@ -41,6 +42,7 @@ stages:
         condition: eq(variables.ComponentType, 'codeExtension')
         steps:
         - template: nuget-versioning-steps.yml
+        - template: dotnet-install-sdk-steps.yml
         - template: dotnet-package-steps.yml
         - template: nuget-signing-steps.yml
       - job: job_pack_nuspec

--- a/build/yaml/templates/dotnet-build-test-steps.yml
+++ b/build/yaml/templates/dotnet-build-test-steps.yml
@@ -1,3 +1,4 @@
+steps:
 - task: DotNetCoreCLI@2
   displayName: 'Run `dotnet restore`'
   inputs:

--- a/build/yaml/templates/dotnet-build-test-steps.yml
+++ b/build/yaml/templates/dotnet-build-test-steps.yml
@@ -1,14 +1,3 @@
-steps:
-- task: UseDotNet@2
-  displayName: 'Use .Net Core sdk 2.1.x'
-  inputs:
-    version: 2.1.x
-
-- task: UseDotNet@2
-  displayName: 'Use .Net Core sdk 3.1.x'
-  inputs:
-    version: 3.1.x
-
 - task: DotNetCoreCLI@2
   displayName: 'Run `dotnet restore`'
   inputs:

--- a/build/yaml/templates/dotnet-install-sdk-steps.yml
+++ b/build/yaml/templates/dotnet-install-sdk-steps.yml
@@ -1,0 +1,10 @@
+steps:
+- task: UseDotNet@2
+  displayName: 'Use .Net Core sdk 2.1.x'
+  inputs:
+    version: 2.1.x
+
+- task: UseDotNet@2
+  displayName: 'Use .Net Core sdk 3.1.x'
+  inputs:
+    version: 3.1.x

--- a/packages/Microsoft.Bot.Components.sln
+++ b/packages/Microsoft.Bot.Components.sln
@@ -9,11 +9,6 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Components.Ad
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Bot.Components.Teams", "Teams\dotnet\Microsoft.Bot.Components.Teams.csproj", "{FD29CBA6-C18F-498B-9F00-A3C34C1BEC5F}"
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{D20741C5-65FD-45BF-98A1-5A82D290743F}"
-	ProjectSection(SolutionItems) = preProject
-		.editorconfig = .editorconfig
-	EndProjectSection
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU


### PR DESCRIPTION
### Purpose
Running the .NET: Version, Sign & Pack stage (job: job_pack_dotnet) is currently failing in Daily builds against main. This appears to be caused by build properties picked up from .NET 5 SDK which are clobbering ours defined in packages/Directory.Build.props.

This error is not occurring during the .NET: Build & Test stage, where the dotnet CLI Version being used is 3.1.x.

### Changes
- Update the .NET: Version, Sign & Pack stage to explicitly install .NET Core 2.1.x and 3.1.x SDKs for the job_pack_dotnet job to match behavior in .NET: Build & Test stage and not default to .NET 5.
- Removing reference to non-existent .editorconfig file in Microsoft.Bot.Components.sln.

### Tests
Running daily pipelines manually against branch to verify.

#minor