### PR TITLE
fix: convert switch case condition to stringexpression, per schema definition

### DIFF
--- a/generators/generator-bot-core-assistant/generators/app/templates/botName.dialog
+++ b/generators/generator-bot-core-assistant/generators/app/templates/botName.dialog
@@ -159,7 +159,7 @@
           "$designer": {
             "id": "uCZ5AG"
           },
-          "condition": "=count(dialog.candidates)",
+          "condition": "=string(count(dialog.candidates))",
           "cases": [
             {
               "value": "0",

--- a/generators/generator-bot-enterprise-assistant/generators/app/templates/botName.dialog
+++ b/generators/generator-bot-enterprise-assistant/generators/app/templates/botName.dialog
@@ -184,7 +184,7 @@
           "$designer": {
             "id": "uCZ5AG"
           },
-          "condition": "=count(dialog.candidates)",
+          "condition": "=string(count(dialog.candidates))",
           "cases": [
             {
               "value": "0",


### PR DESCRIPTION
## Description
Per Switch [schema](https://github.com/microsoft/botbuilder-dotnet/blob/402bc02b4cbbd2f4ec359134640e99211367e4a5/libraries/Microsoft.Bot.Builder.Dialogs.Adaptive/Schemas/Actions/Microsoft.SwitchCondition.schema#L17), this conditional is expecting a `StringExpression`,  and I was feeding it an integer. 

Strangely, Composer did not show a validation error on this bug until recently.  Thanks @tdurnford  and @hatpick  for explaining the validation logic in Composer.

With this fix, template doesn't throw anymore errors and bot can be built.

## Task Item
fixes microsoft/botframework-composer#7700 

adding #minor for validation because the linked issue is in another repo