### PR TITLE
fix: Corrected Skills Trigger to use correct route

### DIFF
--- a/generators/generator-bot-adaptive/generators/app/templates/dotnet/functions/Triggers/SkillsTrigger.cs
+++ b/generators/generator-bot-adaptive/generators/app/templates/dotnet/functions/Triggers/SkillsTrigger.cs
@@ -42,7 +42,7 @@ namespace <%= botName %>.Triggers
         /// </returns>
         [FunctionName("ReplyToActivity")]
         public async Task<IActionResult> RunAsync(
-            [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "api/v3/conversations/{conversationId}/activities/{activityId}")] HttpRequest req,
+            [HttpTrigger(AuthorizationLevel.Anonymous, "post", Route = "api/skills/v3/conversations/{conversationId}/activities/{activityId}")] HttpRequest req,
             string conversationId,
             string activityId)
         {


### PR DESCRIPTION
Fixes #1101 

The Dotnet Skills Trigger used the wrong route.  It didn't contain the "skills" portion of the path.