### PR TITLE
fix: Update .NET Functions to use wwwroot dir for static files

### DIFF
--- a/generators/generator-bot-adaptive/generators/app/index.js
+++ b/generators/generator-bot-adaptive/generators/app/index.js
@@ -249,7 +249,7 @@ module.exports = class extends BaseGenerator {
   _writeJsPackageJson() {
     const { botName, integration } = this.options;
 
-    const sdkVersion = '~4.13.3-preview';
+    const sdkVersion = '4.13.3-preview';
 
     const dependencies = {
       [integrations.functions]: {

--- a/generators/generator-bot-adaptive/generators/app/index.js
+++ b/generators/generator-bot-adaptive/generators/app/index.js
@@ -249,7 +249,7 @@ module.exports = class extends BaseGenerator {
   _writeJsPackageJson() {
     const { botName, integration } = this.options;
 
-    const sdkVersion = '~4.13.2-preview';
+    const sdkVersion = '~4.13.3-preview';
 
     const dependencies = {
       [integrations.functions]: {

--- a/generators/generator-bot-adaptive/generators/app/templates/dotnet/functions/Triggers/StaticFilesTrigger.cs
+++ b/generators/generator-bot-adaptive/generators/app/templates/dotnet/functions/Triggers/StaticFilesTrigger.cs
@@ -10,7 +10,7 @@ namespace <%= botName %>.Triggers
 {
     public class StaticFilesTrigger
     {
-        private const string StaticFilesDirectory = "www";
+        private const string StaticFilesDirectory = "wwwroot";
 
         private readonly FileExtensionContentTypeProvider _provider;
 

--- a/generators/generator-bot-adaptive/generators/app/templates/dotnet/functions/botName.csproj
+++ b/generators/generator-bot-adaptive/generators/app/templates/dotnet/functions/botName.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Content Include="**/*.blu;**/*.dialog;**/*.json;**/*.lg;**/*.lu;**/*.onnx;**/*.qna;**/*.txt"
-             Exclude="$(AppDesignerFolder)/**;$(BaseOutputPath)/**;$(BaseIntermediateOutputPath)/**;www/**;**/function.json">
+             Exclude="$(AppDesignerFolder)/**;$(BaseOutputPath)/**;$(BaseIntermediateOutputPath)/**;wwwroot/**;**/function.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
@@ -24,7 +24,7 @@
     <Content Update="local.settings.json">
       <CopyToPublishDirectory>Never</CopyToPublishDirectory>
     </Content>
-    <None Include="www/**/*.*">
+    <None Include="wwwroot/**/*.*">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>


### PR DESCRIPTION
### Purpose
Fixes #1112.

### Changes
- Update .NET Functions template files in @microsoft/generator-bot-adaptive to use wwwroot as the directory to serve static files from.
- Update JS SDK dependency version to 4.13.3-preview.

### Tests
N/A