### PR TITLE
fix: add rewrite rule for manifest files for js webapps

### DIFF
--- a/generators/generator-bot-adaptive/generators/app/templates/js/webapp/web.config
+++ b/generators/generator-bot-adaptive/generators/app/templates/js/webapp/web.config
@@ -15,6 +15,11 @@
     </handlers>
     <rewrite>
       <rules>
+        <!-- Make sure skill manifest files are served by the app's static path in wwwroot/ -->
+        <rule name="manifests">
+          <match url="manifests/*" />
+          <action type="Rewrite" url="index.js" />
+        </rule>
         <!-- All other URLs are mapped to the node.js site entry point -->
         <rule name="DynamicContent">
           <conditions>


### PR DESCRIPTION
Fixes #7776  (In Composer repo)

### Purpose

This configures the iisnode to send requests for the manifests file to the webapp, which can then serve them through the wwwroot/manifests folder.

OTHERWISE, iisnode sees the root /manifests folder and gets confused, resulting in an internal server error and a 404 to the client.

### Changes

* Add rewrite rule for manifests for web.config file
