### PR TITLE
feat: Update to autoconfigure SkillhostEndpoint for bots hosted in Azure Functions (formerly SDK Issue 5207)

### DIFF
--- a/generators/generator-bot-adaptive/generators/app/templates/dotnet/functions/Startup.cs
+++ b/generators/generator-bot-adaptive/generators/app/templates/dotnet/functions/Startup.cs
@@ -1,6 +1,8 @@
 ﻿using System;
+using System.Collections.Generic;
 using Microsoft.Azure.Functions.Extensions.DependencyInjection;
 using Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime.Extensions;
+using Microsoft.Extensions.Configuration;
 
 [assembly: FunctionsStartup(typeof(<%= botName %>.Startup))]
 
@@ -25,6 +27,25 @@ namespace <%= botName %>
                 applicationRoot,
                 settingsDirectory,
                 environmentName);
+
+            var skillHostEndpoint = configurationBuilder.ConfigurationBuilder.Build().GetValue<string>("SkillHostEndpoint");
+
+            // If the skillhostEndpoint isn't set in the appsettings.json file, calculate a value and set it based on 
+            // the WEBSITE_HOST value that gives the host of the running function. Only do this if it's not configured 
+            // as the function may be behind a load balancer or proxy and we can't always rely on autocomputed 
+            // value here.
+            if (string.IsNullOrEmpty(skillHostEndpoint))
+            {
+                var hostname = configurationBuilder.ConfigurationBuilder.Build().GetValue<string>("WEBSITE_HOSTNAME");
+                // for localhost use http rather than https
+                var protocol = hostname.StartsWith("localhost") ? "http" : "https";
+                var skillHostSettings = new Dictionary<string, string>
+                {
+                    { "SkillHostEndpoint", $"{protocol}://{hostname}/api/skills" },
+                };
+                configurationBuilder.ConfigurationBuilder.AddInMemoryCollection(skillHostSettings);
+            }
+
         }
     }
 }


### PR DESCRIPTION
Closes #1158 

### Purpose

Updated the startup.cs code for Azure Function bots to auto compute the SkillHostEndpoint when it's not configured in the appsettings.json file by the user. This is only computed if the value is not set by the user as it may be the user has specifically configured a SkillHostEndpoint behind a load balancer, proxy, or some other advanced setup that the auto compute code can't detect.

### Changes

Added new code to only the startup.cs template for bots hosted as Azure Functions.

### Tests

Tested manually by generating a bot with the new template and running it both in Composer and manually within Visual Studio.

