### PR TITLE
fix: GetManager issue with name entity not set

### DIFF
--- a/generators/generator-bot-enterprise-people/generators/app/templates/dialogs/GetManagerDialog/GetManagerDialog.dialog
+++ b/generators/generator-bot-enterprise-people/generators/app/templates/dialogs/GetManagerDialog/GetManagerDialog.dialog
@@ -33,7 +33,8 @@
           "dialog": "ResolveUserDialog",
           "resultProperty": "turn.UserFound",
           "options": {
-            "UserIdFound": "=$UserIdFound"
+            "UserIdFound": "=$UserIdFound",
+            "NameEntity": "=$NameEntity"
           }
         },
         {

--- a/generators/generator-bot-enterprise-people/generators/app/templates/dialogs/GetManagerDialog/GetManagerDialog.dialog.schema
+++ b/generators/generator-bot-enterprise-people/generators/app/templates/dialogs/GetManagerDialog/GetManagerDialog.dialog.schema
@@ -3,49 +3,9 @@
   "$role": "implements(Microsoft.IDialog)",
   "title": "GetManagerDialog",
   "type": "object",
-  "properties": {
-    "nameEntity": {
-      "description": "Name of the entity to search",
-      "$ref": "#/definitions/stringExpression",
-      "title": "Name Entity"
-    }
-  },
+  "properties": {},
   "$result": {
     "type": "object",
     "properties": {}
-  },
-  "definitions": {
-    "equalsExpression": {
-      "$role": "expression",
-      "type": "string",
-      "title": "Equals Expression",
-      "description": "Expression starting with =.",
-      "pattern": "^=.*\\S.*",
-      "examples": [
-        "=user.name"
-      ]
-    },
-    "stringExpression": {
-      "$role": "expression",
-      "title": "String or expression",
-      "description": "Interpolated string or expression to evaluate.",
-      "oneOf": [
-        {
-          "type": "string",
-          "title": "String",
-          "description": "Interpolated string",
-          "pattern": "^(?!(=)).*",
-          "examples": [
-            "Hello ${user.name}"
-          ]
-        },
-        {
-          "$ref": "#/definitions/equalsExpression",
-          "examples": [
-            "=concat('x','y','z')"
-          ]
-        }
-      ]
-    }
   }
 }

--- a/skills/declarative/People/People/dialogs/GetManagerDialog/GetManagerDialog.dialog
+++ b/skills/declarative/People/People/dialogs/GetManagerDialog/GetManagerDialog.dialog
@@ -33,7 +33,8 @@
           "dialog": "ResolveUserDialog",
           "resultProperty": "turn.UserFound",
           "options": {
-            "UserIdFound": "=$UserIdFound"
+            "UserIdFound": "=$UserIdFound",
+            "NameEntity": "=$NameEntity"
           }
         },
         {

--- a/skills/declarative/People/People/dialogs/GetManagerDialog/GetManagerDialog.dialog.schema
+++ b/skills/declarative/People/People/dialogs/GetManagerDialog/GetManagerDialog.dialog.schema
@@ -3,49 +3,9 @@
   "$role": "implements(Microsoft.IDialog)",
   "title": "GetManagerDialog",
   "type": "object",
-  "properties": {
-    "nameEntity": {
-      "description": "Name of the entity to search",
-      "$ref": "#/definitions/stringExpression",
-      "title": "Name Entity"
-    }
-  },
+  "properties": {},
   "$result": {
     "type": "object",
     "properties": {}
-  },
-  "definitions": {
-    "equalsExpression": {
-      "$role": "expression",
-      "type": "string",
-      "title": "Equals Expression",
-      "description": "Expression starting with =.",
-      "pattern": "^=.*\\S.*",
-      "examples": [
-        "=user.name"
-      ]
-    },
-    "stringExpression": {
-      "$role": "expression",
-      "title": "String or expression",
-      "description": "Interpolated string or expression to evaluate.",
-      "oneOf": [
-        {
-          "type": "string",
-          "title": "String",
-          "description": "Interpolated string",
-          "pattern": "^(?!(=)).*",
-          "examples": [
-            "Hello ${user.name}"
-          ]
-        },
-        {
-          "$ref": "#/definitions/equalsExpression",
-          "examples": [
-            "=concat('x','y','z')"
-          ]
-        }
-      ]
-    }
   }
 }


### PR DESCRIPTION
<!-- This repository only accepts pull requests related to open issues, please link the open issue in description below. -->
<!-- See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. -->
<!-- For example - Close #123: Description goes here. -->

### Purpose

Fixing the get manager intent issue where the name entity is not set for the dialog invocation of ResolveUserDialog. Closes #1108.

### Changes

Update both People project and template.

### Tests

Manually tested the scenario in Emulator.

### Feature Plan

none, release this bug fix as part of R14.
