### PR TITLE
port: GetMeetingInfo, meeting start/end events

### DIFF
--- a/packages/Teams/dotnet/Actions/GetMeetingInfo.cs
+++ b/packages/Teams/dotnet/Actions/GetMeetingInfo.cs
@@ -1,0 +1,104 @@
+﻿// Licensed under the MIT License.
+// Copyright (c) Microsoft Corporation. All rights reserved.
+
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using AdaptiveExpressions.Properties;
+using Microsoft.Bot.Builder.Dialogs;
+using Microsoft.Bot.Builder.Teams;
+using Microsoft.Bot.Connector;
+using Newtonsoft.Json;
+
+namespace Microsoft.Bot.Components.Teams.Actions
+{
+    /// <summary>
+    /// Calls TeamsInfo.GetMeetingInfoAsync and sets the result to a memory property.
+    /// </summary>
+    public class GetMeetingInfo : Dialog
+    {
+        /// <summary>
+        /// Class identifier.
+        /// </summary>
+        [JsonProperty("$kind")]
+        public const string Kind = "Teams.GetMeetingInfo";
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="GetMeetingInfo"/> class.
+        /// </summary>
+        /// <param name="callerPath">Optional, source file full path.</param>
+        /// <param name="callerLine">Optional, line number in source file.</param>
+        [JsonConstructor]
+        public GetMeetingInfo([CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
+            : base()
+        {
+            RegisterSourceLocation(callerPath, callerLine);
+        }
+
+        /// <summary>
+        /// Gets or sets an optional expression which if is true will disable this action.
+        /// </summary>
+        /// <example>
+        /// "user.age > 18".
+        /// </example>
+        /// <value>
+        /// A boolean expression. 
+        /// </value>
+        [JsonProperty("disabled")]
+        public BoolExpression Disabled { get; set; }
+
+        /// <summary>
+        /// Gets or sets property path to put the value in.
+        /// </summary>
+        /// <value>
+        /// Property path to put the value in.
+        /// </value>
+        [JsonProperty("property")]
+        public StringExpression Property { get; set; }
+
+        /// <summary>
+        /// Gets or sets the expression to get the value to use for meeting id.
+        /// </summary>
+        /// <value>
+        /// The expression to get the value to use for meeting id. Default value is turn.activity.channelData.meeting.id.
+        /// </value>
+        [JsonProperty("meetingId")]
+        public StringExpression MeetingId { get; set; } = "=turn.activity.channelData.meeting.id";
+
+        /// <inheritdoc/>
+        public override async Task<DialogTurnResult> BeginDialogAsync(DialogContext dc, object options = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (options is CancellationToken)
+            {
+                throw new ArgumentException($"{nameof(options)} cannot be a cancellation token");
+            }
+
+            if (Disabled != null && Disabled.GetValue(dc.State))
+            {
+                return await dc.EndDialogAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
+            }
+
+            if (dc.Context.Activity.ChannelId != Channels.Msteams)
+            {
+                throw new InvalidOperationException($"{Kind} works only on the Teams channel.");
+            }
+
+            string meetingId = MeetingId.GetValueOrNull(dc.State);
+            var result = await TeamsInfo.GetMeetingInfoAsync(dc.Context, meetingId, cancellationToken: cancellationToken).ConfigureAwait(false);
+
+            if (Property != null)
+            {
+                dc.State.SetValue(Property.GetValue(dc.State), result);
+            }
+
+            return await dc.EndDialogAsync(result, cancellationToken: cancellationToken).ConfigureAwait(false);
+        }
+
+        /// <inheritdoc/>
+        protected override string OnComputeId()
+        {
+            return $"{GetType().Name}[{MeetingId?.ToString() ?? string.Empty},{Property?.ToString() ?? string.Empty}]";
+        }
+    }
+}

--- a/packages/Teams/dotnet/Schemas/Actions/Teams.GetMeetingInfo.schema
+++ b/packages/Teams/dotnet/Schemas/Actions/Teams.GetMeetingInfo.schema
@@ -1,0 +1,38 @@
+{
+  "$schema": "https://schemas.botframework.com/schemas/component/v1.0/component.schema",
+  "$role": "implements(Microsoft.IDialog)",
+  "title": "Get meeting information",
+  "description": "Get teams meeting information.",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string",
+      "title": "Id",
+      "description": "Optional id for the dialog"
+    },
+    "property": {
+      "$ref": "schema:#/definitions/stringExpression",
+      "title": "Property",
+      "description": "Property (named location to store information).",
+      "examples": [
+        "dialog.meetingInfo"
+      ]
+    },
+    "meetingId": {
+      "$ref": "schema:#/definitions/stringExpression",
+      "title": "Meeting id",
+      "description": "Meeting Id or expression to a meetingId to use to get the meeting information. Default value is the current turn.activity.channelData.meeting.id.",
+      "examples": [
+        "=turn.activity.channelData.meeting.id"
+      ]
+    },
+    "disabled": {
+      "$ref": "schema:#/definitions/booleanExpression",
+      "title": "Disabled",
+      "description": "Optional condition which if true will disable this action.",
+      "examples": [
+        "=user.age > 3"
+      ]
+    }
+  }
+}

--- a/packages/Teams/dotnet/Schemas/Actions/Teams.GetMeetingInfo.uischema
+++ b/packages/Teams/dotnet/Schemas/Actions/Teams.GetMeetingInfo.uischema
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://schemas.botframework.com/schemas/ui/v1.0/ui.schema",
+  "menu": {
+    "submenu": ["Microsoft Teams", "Get Teams Info"]
+  }
+}

--- a/packages/Teams/dotnet/Schemas/TriggerConditions/Teams.OnMeetingEnd.schema
+++ b/packages/Teams/dotnet/Schemas/TriggerConditions/Teams.OnMeetingEnd.schema
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://schemas.botframework.com/schemas/component/v1.0/component.schema",
+  "$role": [ "implements(Microsoft.ITrigger)", "extends(Microsoft.OnCondition)" ],
+  "title": "On meeting end",
+  "description": "Actions triggered when a Teams Meeting is ended",
+  "type": "object",
+  "required": [
+  ]
+}

--- a/packages/Teams/dotnet/Schemas/TriggerConditions/Teams.OnMeetingEnd.uischema
+++ b/packages/Teams/dotnet/Schemas/TriggerConditions/Teams.OnMeetingEnd.uischema
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://schemas.botframework.com/schemas/ui/v1.0/ui.schema",
+  "trigger": {
+    "submenu": "Microsoft Teams",
+    "label": "On meeting end"
+  }
+}

--- a/packages/Teams/dotnet/Schemas/TriggerConditions/Teams.OnMeetingStart.schema
+++ b/packages/Teams/dotnet/Schemas/TriggerConditions/Teams.OnMeetingStart.schema
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://schemas.botframework.com/schemas/component/v1.0/component.schema",
+  "$role": [ "implements(Microsoft.ITrigger)", "extends(Microsoft.OnCondition)" ],
+  "title": "On meeting start",
+  "description": "Actions triggered when a Teams Meeting is started",
+  "type": "object",
+  "required": [
+  ]
+}

--- a/packages/Teams/dotnet/Schemas/TriggerConditions/Teams.OnMeetingStart.uischema
+++ b/packages/Teams/dotnet/Schemas/TriggerConditions/Teams.OnMeetingStart.uischema
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://schemas.botframework.com/schemas/ui/v1.0/ui.schema",
+  "trigger": {
+    "submenu": "Microsoft Teams",
+    "label": "On meeting start"
+  }
+}

--- a/packages/Teams/dotnet/TeamsBotComponent.cs
+++ b/packages/Teams/dotnet/TeamsBotComponent.cs
@@ -42,6 +42,8 @@ namespace Microsoft.Bot.Components.Teams
             services.AddSingleton<DeclarativeType>(sp => new DeclarativeType<OnTeamsChannelRenamed>(OnTeamsChannelRenamed.Kind));
             services.AddSingleton<DeclarativeType>(sp => new DeclarativeType<OnTeamsChannelRestored>(OnTeamsChannelRestored.Kind));
             services.AddSingleton<DeclarativeType>(sp => new DeclarativeType<OnTeamsFileConsent>(OnTeamsFileConsent.Kind));
+            services.AddSingleton<DeclarativeType>(sp => new DeclarativeType<OnTeamsMeetingStart>(OnTeamsMeetingStart.Kind));
+            services.AddSingleton<DeclarativeType>(sp => new DeclarativeType<OnTeamsMeetingEnd>(OnTeamsMeetingEnd.Kind));
             services.AddSingleton<DeclarativeType>(sp => new DeclarativeType<OnTeamsMECardButtonClicked>(OnTeamsMECardButtonClicked.Kind));
 
             services.AddSingleton<DeclarativeType>(sp => new DeclarativeType<OnTeamsMEConfigQuerySettingUrl>(OnTeamsMEConfigQuerySettingUrl.Kind));
@@ -68,6 +70,7 @@ namespace Microsoft.Bot.Components.Teams
 
             // Actions
 
+            services.AddSingleton<DeclarativeType>(sp => new DeclarativeType<GetMeetingInfo>(GetMeetingInfo.Kind));
             services.AddSingleton<DeclarativeType>(sp => new DeclarativeType<GetMeetingParticipant>(GetMeetingParticipant.Kind));
             services.AddSingleton<DeclarativeType>(sp => new DeclarativeType<GetMember>(GetMember.Kind));
             services.AddSingleton<DeclarativeType>(sp => new DeclarativeType<GetPagedMembers>(GetPagedMembers.Kind));

--- a/packages/Teams/dotnet/TriggerConditions/OnTeamsMeetingEnd.cs
+++ b/packages/Teams/dotnet/TriggerConditions/OnTeamsMeetingEnd.cs
@@ -1,0 +1,37 @@
+﻿// Licensed under the MIT License.
+// Copyright (c) Microsoft Corporation. All rights reserved.
+
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using AdaptiveExpressions;
+using Microsoft.Bot.Builder.Dialogs;
+using Microsoft.Bot.Builder.Dialogs.Adaptive.Conditions;
+using Microsoft.Bot.Connector;
+using Newtonsoft.Json;
+
+namespace Microsoft.Bot.Components.Teams.Conditions
+{
+    /// <summary>
+    /// Actions triggered when a Teams Meeting End event is received.
+    /// </summary>
+    /// <remarks>
+    /// turn.activity.value has meeting data.
+    /// </remarks>
+    public class OnTeamsMeetingEnd : OnEventActivity
+    {
+        [JsonProperty("$kind")]
+        public new const string Kind = "Teams.OnMeetingEnd";
+
+        [JsonConstructor]
+        public OnTeamsMeetingEnd(List<Dialog> actions = null, string condition = null, [CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
+            : base(actions: actions, condition: condition, callerPath: callerPath, callerLine: callerLine)
+        {
+        }
+
+        /// <inheritdoc/>
+        protected override Expression CreateExpression()
+        {
+            return Expression.AndExpression(Expression.Parse($"{TurnPath.Activity}.channelId == '{Channels.Msteams}' && {TurnPath.Activity}.name == 'application/vnd.microsoft.meetingEnd'"), base.CreateExpression());
+        }
+    }
+}

--- a/packages/Teams/dotnet/TriggerConditions/OnTeamsMeetingStart.cs
+++ b/packages/Teams/dotnet/TriggerConditions/OnTeamsMeetingStart.cs
@@ -1,0 +1,37 @@
+﻿// Licensed under the MIT License.
+// Copyright (c) Microsoft Corporation. All rights reserved.
+
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using AdaptiveExpressions;
+using Microsoft.Bot.Builder.Dialogs;
+using Microsoft.Bot.Builder.Dialogs.Adaptive.Conditions;
+using Microsoft.Bot.Connector;
+using Newtonsoft.Json;
+
+namespace Microsoft.Bot.Components.Teams.Conditions
+{
+    /// <summary>
+    /// Actions triggered when a Teams Meeting Start event is received.
+    /// </summary>
+    /// <remarks>
+    /// turn.activity.value has meeting data.
+    /// </remarks>
+    public class OnTeamsMeetingStart : OnEventActivity
+    {
+        [JsonProperty("$kind")]
+        public new const string Kind = "Teams.OnMeetingStart";
+
+        [JsonConstructor]
+        public OnTeamsMeetingStart(List<Dialog> actions = null, string condition = null, [CallerFilePath] string callerPath = "", [CallerLineNumber] int callerLine = 0)
+            : base(actions: actions, condition: condition, callerPath: callerPath, callerLine: callerLine)
+        {
+        }
+
+        /// <inheritdoc/>
+        protected override Expression CreateExpression()
+        {
+            return Expression.AndExpression(Expression.Parse($"{TurnPath.Activity}.channelId == '{Channels.Msteams}' && {TurnPath.Activity}.name == 'application/vnd.microsoft.meetingStart'"), base.CreateExpression());
+        }
+    }
+}


### PR DESCRIPTION
Note: CI tests fail because it relies on unpublished packages.

Addresses .NET: #1138 
Addresses .NET: #1139

#minor (have to include since this doesn't fully fix an issue)

### Purpose

Add the action, `GetMeetingInfo()`
Adds the Triggers, `OnTeamsMeetingStart`() and `OnTeamsMeetingEnd()`

### Tests

I triggered `GetMeetingInfo()` to send on Unknown Intent:

![image](https://user-images.githubusercontent.com/40401643/123716055-823c0980-d82e-11eb-9ec7-25181452a993.png)

Meeting start/end events (data is on `activity.value`):

![image](https://user-images.githubusercontent.com/40401643/123716111-a992d680-d82e-11eb-9fa8-44cc6a294f01.png)


### Feature Plan

This relies on updating to v4.14 of the SDK (which this PR does not do--it's meant to be ready-to-go after that update gets pushed)

I'll start working on the JS versions. Should be ready to review by Wednesday.