### PR TITLE
chore: restore Teams package unit tests

### DIFF
--- a/tests/unit/packages/Microsoft.Bot.Components.Teams.Tests/ActionTests.cs
+++ b/tests/unit/packages/Microsoft.Bot.Components.Teams.Tests/ActionTests.cs
@@ -1,0 +1,592 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Bot.Builder;
+using Microsoft.Bot.Builder.Dialogs;
+using Microsoft.Bot.Builder.Dialogs.Adaptive;
+using Microsoft.Bot.Builder.Dialogs.Adaptive.Testing;
+using Microsoft.Bot.Builder.Dialogs.Declarative;
+using Microsoft.Bot.Builder.Dialogs.Declarative.Obsolete;
+using Microsoft.Bot.Connector;
+using Microsoft.Bot.Connector.Authentication;
+using Microsoft.Bot.Schema;
+using Microsoft.Bot.Schema.Teams;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace Microsoft.Bot.Components.Teams.Tests
+{
+    [CollectionDefinition("Dialogs.Adaptive")]
+    public class ActionTests : IClassFixture<ResourceExplorerFixture>
+    {
+        private readonly ResourceExplorerFixture _resourceExplorerFixture;
+
+        public ActionTests(ResourceExplorerFixture resourceExplorerFixture)
+        {
+            ComponentRegistration.Add(new DeclarativeComponentRegistration());
+            ComponentRegistration.Add(new DialogsComponentRegistration());
+            ComponentRegistration.Add(new AdaptiveComponentRegistration());
+            ComponentRegistration.Add(new LanguageGenerationComponentRegistration());
+            ComponentRegistration.Add(new AdaptiveTestingComponentRegistration());
+            ComponentRegistration.Add(new DeclarativeComponentRegistrationBridge<TeamsBotComponent>());
+
+            _resourceExplorerFixture = resourceExplorerFixture.Initialize(nameof(ActionTests));
+        }
+
+        [Fact]
+        public async Task Action_GetMeetingParticipant()
+        {
+            var participantResult = GetParticipant().ToString();
+
+            var uriToContent = new Dictionary<string, string>()
+                {
+                    { "/v1/meetings/meeting-id-1/participants/participant-aad-id-1?tenantId=tenant-id-1", participantResult },
+                    { "/v1/meetings/customMeetingId/participants/customParticipantId?tenantId=customTenantId", participantResult }
+                };
+
+            var teamsMiddleware = GetTeamsMiddleware(uriToContent);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer, middleware: new[] { teamsMiddleware });
+        }
+
+        [Fact]
+        public async Task Action_GetMeetingParticipantError()
+        {
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer, adapterChannel: Channels.Test);
+        }
+
+        [Fact]
+        public async Task Action_GetMeetingParticipantErrorWithAdapter()
+        {
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
+        }
+
+        [Fact]
+        public async Task Action_GetMember()
+        {
+            var participantResult = GetParticipant().ToString();
+            var uriToContent = new Dictionary<string, string>()
+                {
+                    { "/v3/conversations/Action_GetMember/members/member-id", participantResult },
+                    { "/v3/conversations/Action_GetMember/members/customMemberId", participantResult }
+                };
+
+            var teamsMiddleware = GetTeamsMiddleware(uriToContent);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer, middleware: new[] { teamsMiddleware });
+        }
+
+        [Fact]
+        public async Task Action_GetMemberError()
+        {
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer, adapterChannel: Channels.Test);
+        }
+
+        [Fact]
+        public async Task Action_GetMemberErrorWithAdapter()
+        {
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
+        }
+
+        [Fact]
+        public async Task Action_GetPagedMembers()
+        {
+            var threeMembers = GenerateTeamMembers(3);
+            threeMembers.ContinuationToken = "customToken";
+
+            var twoMembers = GenerateTeamMembers(2);
+            twoMembers.ContinuationToken = "token";
+
+            var uriToContent = new Dictionary<string, string>()
+                {
+                    { "/v3/conversations/Action_GetPagedMembers/pagedmembers", JObject.FromObject(threeMembers).ToString() },
+                    { "/v3/conversations/Action_GetPagedMembers/pagedmembers?pageSize=2&continuationToken=token", JObject.FromObject(twoMembers).ToString() }
+                };
+
+            var teamsMiddleware = GetTeamsMiddleware(uriToContent);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer, middleware: new[] { teamsMiddleware });
+        }
+
+        [Fact]
+        public async Task Action_GetPagedMembersError()
+        {
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer, adapterChannel: Channels.Test);
+        }
+
+        [Fact]
+        public async Task Action_GetPagedTeamMembers()
+        {
+            var threeMembers = GenerateTeamMembers(3);
+            threeMembers.ContinuationToken = "token";
+
+            var twoMembers = GenerateTeamMembers(2);
+            twoMembers.ContinuationToken = "token";
+
+            var uriToContent = new Dictionary<string, string>()
+                {
+                    { "/v3/conversations/team-id-1/pagedmembers", JObject.FromObject(threeMembers).ToString() },
+                    { "/v3/conversations/team-id-1/pagedmembers?pageSize=2&continuationToken=token", JObject.FromObject(twoMembers).ToString() }
+                };
+
+            var teamsMiddleware = GetTeamsMiddleware(uriToContent);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer, middleware: new[] { teamsMiddleware });
+        }
+
+        [Fact]
+        public async Task Action_GetPagedTeamMembersError()
+        {
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer, adapterChannel: Channels.Test);
+        }
+
+        [Fact]
+        public async Task Action_GetTeamChannels()
+        {
+            var conversations = JObject.FromObject(new ConversationList
+            {
+                Conversations = new List<ChannelInfo>()
+                    {
+                        new ChannelInfo { Id = "19:ChannelIdgeneralChannelId@thread.skype", Name = "Testing0" },
+                        new ChannelInfo { Id = "19:somechannelId2e5ab3df9ae9b594bdb@thread.skype", Name = "Testing1" },
+                        new ChannelInfo { Id = "19:somechannelId388ade16aa4dd375e69@thread.skype", Name = "Testing2" },
+                    }
+            }).ToString();
+
+            var uriToContent = new Dictionary<string, string>()
+                {
+                    { "/v3/teams/team-id-1/conversations", conversations },
+                    { "/v3/teams/customTeamId/conversations", conversations }
+                };
+
+            var teamsMiddleware = GetTeamsMiddleware(uriToContent);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer, middleware: new[] { teamsMiddleware });
+        }
+
+        [Fact]
+        public async Task Action_GetTeamChannelsError()
+        {
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer, adapterChannel: Channels.Test);
+        }
+
+        [Fact]
+        public async Task Action_GetTeamDetails()
+        {
+            var details = JObject.FromObject(new TeamDetails
+            {
+                Id = "19:generalChannelIdgeneralChannelId@thread.skype",
+                Name = "TeamName",
+                AadGroupId = "Team-aadGroupId"
+            }).ToString();
+
+            var uriToContent = new Dictionary<string, string>()
+                {
+                    { "/v3/teams/team-id-1/team-id-1", details },
+                    { "/v3/teams/customTeamId", details }
+                };
+
+            var teamsMiddleware = GetTeamsMiddleware(uriToContent);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer, middleware: new[] { teamsMiddleware });
+        }
+
+        [Fact]
+        public async Task Action_GetTeamDetailsError()
+        {
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer, adapterChannel: Channels.Test);
+        }
+
+        [Fact]
+        public async Task Action_GetTeamMember()
+        {
+            var member = JObject.FromObject(GenerateTeamMembers(1).Members.First()).ToString();
+
+            var uriToContent = new Dictionary<string, string>()
+                {
+                    { "/v3/conversations/team-id-1/members/user1", member },
+                    { "/v3/conversations/customTeamId/members/customMemberId", member }
+                };
+
+            var teamsMiddleware = GetTeamsMiddleware(uriToContent);
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer, middleware: new[] { teamsMiddleware });
+        }
+
+        [Fact]
+        public async Task Action_GetTeamMemberError()
+        {
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer, adapterChannel: Channels.Test);
+        }
+
+        [Fact]
+        public async Task Action_GetTeamMemberErrorWithAdapter()
+        {
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
+        }
+
+        [Fact]
+        public async Task Action_SendAppBasedLinkQueryResponse()
+        {
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
+        }
+
+        [Fact]
+        public async Task Action_SendAppBasedLinkQueryResponseError()
+        {
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer, adapterChannel: Channels.Test);
+        }
+
+        //[Fact]
+        //public async Task Action_SendMessageToTeamsChannel()
+        //{
+        //    NOTE: Current test adapter is not a BotFrameworkAdapter,
+        //           and does not support mocking SendMessageToTeamsChannel
+        //    var teamsMiddleware = GetTeamsMiddleware(new JObject(), "/v3/conversations");
+        //    await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer, middleware: new[] { teamsMiddleware });
+        //}
+        
+        [Fact]
+        public async Task Action_SendMessageToTeamsChannelError()
+        {
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer, adapterChannel: Channels.Test);
+        }
+
+        [Fact]
+        public async Task Action_SendMEActionResponse()
+        {
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
+        }
+
+        [Fact]
+        public async Task Action_SendMEActionResponseError()
+        {
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
+        }
+
+        [Fact]
+        public async Task Action_SendMEAttachmentsResponse()
+        {
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
+        }
+
+        [Fact]
+        public async Task Action_SendMEAttachmentsResponseError()
+        {
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer, adapterChannel: Channels.Test);
+        }
+
+        [Fact]
+        public async Task Action_SendMEAuthResponse()
+        {
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
+        }
+
+        //[Fact]
+        //public async Task Action_SendMEAuthResponseError()
+        //{
+        //      NOTE: Current test adapter is not a BotFrameworkAdapter,
+        //    await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
+        //}
+
+        [Fact]
+        public async Task Action_SendMEAuthResponseErrorWithAdapter()
+        {
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer, adapterChannel: Channels.Test);
+        }
+
+        [Fact]
+        public async Task Action_SendMEBotMessagePreviewResponse()
+        {
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
+        }
+
+        [Fact]
+        public async Task Action_SendMEBotMessagePreviewResponseError()
+        {
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer, adapterChannel: Channels.Test);
+        }
+
+        [Fact]
+        public async Task Action_SendMEConfigQuerySettingUrlResponse()
+        {
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
+        }
+
+        [Fact]
+        public async Task Action_SendMEConfigQuerySettingUrlResponseError()
+        {
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer, adapterChannel: Channels.Test);
+        }
+
+        [Fact]
+        public async Task Action_SendMEMessageResponse()
+        {
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
+        }
+
+        [Fact]
+        public async Task Action_SendMEMessageResponseError()
+        {
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer, adapterChannel: Channels.Test);
+        }
+
+        [Fact]
+        public async Task Action_SendMESelectItemResponse()
+        {
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
+        }
+
+        [Fact]
+        public async Task Action_SendMESelectItemResponseError()
+        {
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer, adapterChannel: Channels.Test);
+        }
+
+        [Fact]
+        public async Task Action_SendTaskModuleCardResponse()
+        {
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
+        }
+
+        [Fact]
+        public async Task Action_SendTaskModuleCardResponseError()
+        {
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer, adapterChannel: Channels.Test);
+        }
+
+        [Fact]
+        public async Task Action_SendTaskModuleMessageResponse()
+        {
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
+        }
+
+        [Fact]
+        public async Task Action_SendTaskModuleUrlResponse()
+        {
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
+        }
+
+        [Fact]
+        public async Task Action_SendTaskModuleUrlResponseError()
+        {
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
+        }
+
+        [Fact]
+        public async Task Action_SendTabCardResponseError()
+        {
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
+        }
+        
+        [Fact]
+        public async Task Action_SendTabCardResponse()
+        {
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
+        }
+        
+        [Fact]
+        public async Task Action_SendTabAuthResponseErrorWithAdapter()
+        {
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
+        }
+
+        //[Fact]
+        //public async Task Action_SendTabAuthResponseError()
+        //{
+        //      NOTE: Current test adapter is not a BotFrameworkAdapter,
+        //    await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer);
+        //}
+
+        private IMiddleware GetErrorTeamsMiddleware(string exception)
+        {
+            // Create a connector client, setup with a custom httpclient which will 
+            // throw an exception when the connectorclient's outgoing pipeline's SendAsync
+            // is called
+            var messageHandler = new ErrorHttpMessageHandler(exception);
+            return GetTestConnectorClientMiddleware(messageHandler);
+        }
+
+        private ConversationReference GetGroupConversation()
+        {
+            return new ConversationReference
+            {
+                ChannelId = Channels.Msteams,
+                User = new ChannelAccount
+                {
+                    Id = "29:User-Id",
+                    Name = "User Name",
+                    AadObjectId = "participant-aad-id"
+                },
+                Conversation = new ConversationAccount
+                {
+                    ConversationType = "groupChat",
+                    TenantId = "tenantId-Guid",
+                    Name = "group",
+                    IsGroup = true,
+                    Id = "19:groupChatId@thread.v2"
+                }
+            };
+        }
+
+        private TeamsPagedMembersResult GenerateTeamMembers(int total)
+        {
+            var accounts = new List<TeamsChannelAccount>();
+
+            for (int count = 0; count < total; count++)
+            {
+                accounts.Add(new TeamsChannelAccount
+                {
+                    Id = $"29:User-Id-{count}",
+                    Name = $"User Name-{count}",
+                    AadObjectId = $"User-{count}-Object-Id",
+                    Surname = $"Surname-{count}",
+                    Email = $"User.{count}@microsoft.com",
+                    UserPrincipalName = $"user{count}@microsoft.com",
+                    TenantId = "tenant-id-1",
+                    GivenName = "User"
+                });
+            }
+
+            return new TeamsPagedMembersResult() { Members = accounts };
+        }
+
+        private JObject GetParticipant(bool groupConversation = false)
+        {
+            return JObject.FromObject(new
+            {
+                id = "29:User-Id-0",
+                objectId = "User-0-Object-Id",
+                name = "User Name-0",
+                meeting = new { role = "Organizer" },
+                surname = "Surname-0",
+                tenantId = "tenant-id-1",
+                userPrincipalName = "user0@microsoft.com",
+                user = new
+                {
+                    userPrincipalName = "userPrincipalName-1",
+                },
+                email = "User.0@microsoft.com",
+                givenName = "User",
+                conversation = new
+                {
+                    id = groupConversation ? "19:groupChatId@thread.v2" : "a:oneOnOneConversationId",
+                    name = groupConversation ? "group" : "oneOnOne",
+                    tenantId = "tenantId-Guid",
+                    conversationType = groupConversation ? "groupChat" : "personal",
+                    isGroup = groupConversation,
+                }
+            });
+        }
+
+        private IMiddleware GetTeamsMiddleware(JObject result, string path = null)
+        {
+            // Create a connector client, setup with a custom httpclient which will return
+            // the desired result through the TestHttpMessageHandler.
+            TestsHttpMessageHandler messageHandler;
+            if (!string.IsNullOrEmpty(path))
+            {
+                messageHandler = new TestsHttpMessageHandler(path, result.ToString());
+            }
+            else
+            {
+                messageHandler = new TestsHttpMessageHandler(result.ToString());
+            }
+
+            return GetTestConnectorClientMiddleware(messageHandler);
+        }
+
+        private IMiddleware GetTeamsMiddleware(Dictionary<string, string> results)
+        {
+            // Create a connector client, setup with a custom httpclient which will return
+            // the desired result through the TestHttpMessageHandler.
+            var messageHandler = new TestsHttpMessageHandler(results);
+            return GetTestConnectorClientMiddleware(messageHandler);
+        }
+
+        private TestConnectorClientMiddleware GetTestConnectorClientMiddleware(HttpMessageHandler messageHandler)
+        {
+            var testHttpClient = new HttpClient(messageHandler);
+            testHttpClient.BaseAddress = new Uri("https://localhost.coffee");
+            var testConnectorClient = new ConnectorClient(new Uri("http://localhost.coffee/"), new MicrosoftAppCredentials(string.Empty, string.Empty), testHttpClient);
+            return new TestConnectorClientMiddleware(testConnectorClient);
+        }
+
+        // This middleware sets the turnstate's connector client, 
+        // so it will be found by the adapter, and a new one not created.
+        private class TestConnectorClientMiddleware : IMiddleware
+        {
+            private IConnectorClient _connectorClient;
+
+            public TestConnectorClientMiddleware(IConnectorClient connectorClient)
+            {
+                _connectorClient = connectorClient;
+            }
+
+            public Task OnTurnAsync(ITurnContext turnContext, NextDelegate next, CancellationToken cancellationToken = default)
+            {
+                turnContext.TurnState.Add<IConnectorClient>(_connectorClient);
+                return next(cancellationToken);
+            }
+        }
+
+        private class ErrorHttpMessageHandler : HttpMessageHandler
+        {
+            private readonly string _error;
+
+            public ErrorHttpMessageHandler(string error)
+            {
+                _error = error;
+            }
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                throw new Exception(_error);
+            }
+        }
+
+        // Message handler to mock returning a specific object when requested from a specified path.
+        private class TestsHttpMessageHandler : HttpMessageHandler
+        {
+            private Dictionary<string, string> _uriToContent;
+            private string _content;
+
+            public TestsHttpMessageHandler(string url, string content)
+                : this(new Dictionary<string, string>() { { url, content } })
+            {
+            }
+
+            public TestsHttpMessageHandler(string content)
+            {
+                _content = content;
+            }
+
+            public TestsHttpMessageHandler(Dictionary<string, string> uriToContent)
+            {
+                _uriToContent = uriToContent;
+            }
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+            {
+                var response = new HttpResponseMessage(HttpStatusCode.OK);
+                if (!string.IsNullOrEmpty(_content))
+                {
+                    response.Content = new StringContent(_content);
+                }
+                else
+                {
+                    var path = request.RequestUri.PathAndQuery;
+                    foreach (var urlAndContent in _uriToContent)
+                    {
+                        if (urlAndContent.Key.Contains(path, System.StringComparison.OrdinalIgnoreCase))
+                        {
+                            response.Content = new StringContent(urlAndContent.Value);
+                        }
+                    }
+                }
+
+                return Task.FromResult(response);
+            }
+        }
+    }
+}

--- a/tests/unit/packages/Microsoft.Bot.Components.Teams.Tests/ConditionalTests.cs
+++ b/tests/unit/packages/Microsoft.Bot.Components.Teams.Tests/ConditionalTests.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.IO;
+using System.Threading.Tasks;
+using Microsoft.Bot.Builder;
+using Microsoft.Bot.Builder.Dialogs;
+using Microsoft.Bot.Builder.Dialogs.Adaptive;
+using Microsoft.Bot.Builder.Dialogs.Adaptive.Testing;
+using Microsoft.Bot.Builder.Dialogs.Declarative;
+using Microsoft.Bot.Builder.Dialogs.Declarative.Obsolete;
+using Microsoft.Bot.Builder.Dialogs.Declarative.Resources;
+using Xunit;
+
+namespace Microsoft.Bot.Components.Teams.Tests
+{
+    public class ConditionalTests
+    {
+        public ConditionalTests()
+        {
+            ComponentRegistration.Add(new DeclarativeComponentRegistration());
+            ComponentRegistration.Add(new DialogsComponentRegistration());
+            ComponentRegistration.Add(new AdaptiveComponentRegistration());
+            ComponentRegistration.Add(new LanguageGenerationComponentRegistration());
+            ComponentRegistration.Add(new AdaptiveTestingComponentRegistration());
+            ComponentRegistration.Add(new DeclarativeComponentRegistrationBridge<TeamsBotComponent>());
+
+            ResourceExplorer = new ResourceExplorer()
+                .AddFolder(Path.Combine(TestUtils.GetProjectPath(), "Tests", nameof(ConditionalTests)), monitorChanges: false);
+        }
+
+        public static ResourceExplorer ResourceExplorer { get; set; }
+
+        [Fact]
+        public async Task ConditionalsTests_OnTeamsActivityTypes()
+        {
+            await TestUtils.RunTestScript(ResourceExplorer);
+        }
+    }
+}

--- a/tests/unit/packages/Microsoft.Bot.Components.Teams.Tests/Microsoft.Bot.Components.Teams.Tests.csproj
+++ b/tests/unit/packages/Microsoft.Bot.Components.Teams.Tests/Microsoft.Bot.Components.Teams.Tests.csproj
@@ -1,0 +1,35 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp21'">netcoreapp2.1</TargetFramework>
+    <TargetFramework Condition="'$(BuildTarget)' == 'netcoreapp31'">netcoreapp3.1</TargetFramework>
+    <TargetFrameworks Condition="'$(BuildTarget)' == ''">netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <IsPackable>false</IsPackable>
+    <Configurations>Debug;Release</Configurations>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive.Testing" Version="4.13.2-preview" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Declarative" Version="4.13.2" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.1.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\packages\Teams\dotnet\Microsoft.Bot.Components.Teams.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="appsettings.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+
+</Project>

--- a/tests/unit/packages/Microsoft.Bot.Components.Teams.Tests/ResourceExplorerFixture.cs
+++ b/tests/unit/packages/Microsoft.Bot.Components.Teams.Tests/ResourceExplorerFixture.cs
@@ -1,0 +1,38 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.IO;
+using Microsoft.Bot.Builder.Dialogs.Declarative.Resources;
+
+namespace Microsoft.Bot.Components.Teams.Tests
+{
+    public class ResourceExplorerFixture : IDisposable
+    {
+        private string _folderPath = string.Empty;
+
+        public ResourceExplorerFixture()
+        {
+            ResourceExplorer = new ResourceExplorer();
+        }
+
+        public ResourceExplorer ResourceExplorer { get; private set; }
+
+        public ResourceExplorerFixture Initialize(string resourceFolder)
+        {
+            if (_folderPath.Length == 0)
+            {
+                _folderPath = Path.Combine(TestUtils.GetProjectPath(), "Tests", resourceFolder);
+                ResourceExplorer = ResourceExplorer.AddFolder(_folderPath, monitorChanges: false);
+            }
+
+            return this;
+        }
+
+        public void Dispose()
+        {
+            _folderPath = string.Empty;
+            ResourceExplorer.Dispose();
+        }
+    }
+}

--- a/tests/unit/packages/Microsoft.Bot.Components.Teams.Tests/TestUtils.cs
+++ b/tests/unit/packages/Microsoft.Bot.Components.Teams.Tests/TestUtils.cs
@@ -1,0 +1,98 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using Microsoft.Bot.Builder;
+using Microsoft.Bot.Builder.Adapters;
+using Microsoft.Bot.Builder.Dialogs.Adaptive.Testing;
+using Microsoft.Bot.Builder.Dialogs.Declarative.Resources;
+using Microsoft.Bot.Connector;
+using Microsoft.Bot.Schema;
+using Microsoft.Extensions.Configuration;
+
+namespace Microsoft.Bot.Components.Teams.Tests
+{
+    public class TestUtils
+    {
+        public static IConfiguration DefaultConfiguration { get; set; } = new ConfigurationBuilder().AddInMemoryCollection().Build();
+
+        public static string RootFolder { get; set; } = GetProjectPath();
+
+        public static IEnumerable<object[]> GetTestScripts(string relativeFolder)
+        {
+            var testFolder = Path.GetFullPath(Path.Combine(RootFolder, PathUtils.NormalizePath(relativeFolder)));
+            return Directory.EnumerateFiles(testFolder, "*.test.dialog", SearchOption.AllDirectories).Select(s => new object[] { Path.GetFileName(s) }).ToArray();
+        }
+
+        public static async Task RunTestScript(ResourceExplorer resourceExplorer, string resourceId = null, IConfiguration configuration = null, [CallerMemberName] string testName = null, IEnumerable<IMiddleware> middleware = null, string adapterChannel = Channels.Msteams)
+        {
+            var storage = new MemoryStorage();
+            var convoState = new ConversationState(storage);
+            var userState = new UserState(storage);
+
+            var adapter = (TestAdapter)new TestAdapter(CreateConversation(adapterChannel, testName));
+
+            if (middleware != null)
+            {
+                foreach (var m in middleware)
+                {
+                    adapter.Use(m);
+                }
+            }
+
+            adapter.Use(new RegisterClassMiddleware<IConfiguration>(DefaultConfiguration))
+                .UseStorage(storage)
+                .UseBotState(userState, convoState)
+                .Use(new TranscriptLoggerMiddleware(new TraceTranscriptLogger(traceActivity: false)));
+
+            adapter.OnTurnError += async (context, err) =>
+            {
+                if (err.Message.EndsWith("MemoryAssertion failed"))
+                {
+                    throw err;
+                }
+
+                await context.SendActivityAsync(err.Message);
+            };
+
+            var script = resourceExplorer.LoadType<TestScript>(resourceId ?? $"{testName}.test.dialog");
+            script.Configuration = configuration ?? new ConfigurationBuilder().AddInMemoryCollection().Build();
+            script.Description ??= resourceId;
+            await script.ExecuteAsync(adapter: adapter, testName: testName, resourceExplorer: resourceExplorer).ConfigureAwait(false);
+        }
+
+        public static string GetProjectPath()
+        {
+            var parent = Environment.CurrentDirectory;
+            while (!string.IsNullOrEmpty(parent))
+            {
+                if (Directory.EnumerateFiles(parent, "*proj").Any())
+                {
+                    break;
+                }
+
+                parent = Path.GetDirectoryName(parent);
+            }
+
+            return parent;
+        }
+
+        public static ConversationReference CreateConversation(string channel, string conversationName)
+        {
+            return new ConversationReference
+            {
+                ChannelId = channel ?? Channels.Test,
+                ServiceUrl = "https://test.com",
+                User = new ChannelAccount("user1", "User1"),
+                Bot = new ChannelAccount("bot", "Bot"),
+                Conversation = new ConversationAccount(false, "personal", conversationName),
+                Locale = "en-US",
+            };
+        }
+    }
+}

--- a/tests/unit/packages/Microsoft.Bot.Components.Teams.Tests/Tests/ActionTests/Action_GetMeetingParticipant.test.dialog
+++ b/tests/unit/packages/Microsoft.Bot.Components.Teams.Tests/Tests/ActionTests/Action_GetMeetingParticipant.test.dialog
@@ -1,0 +1,66 @@
+{
+    "$schema": "../../../tests.schema",
+    "$kind": "Microsoft.Test.Script",
+    "dialog": {
+        "$kind": "Microsoft.AdaptiveDialog",
+        "id": "planningTest",
+        "triggers": [
+            {
+                "$kind": "Microsoft.OnUnknownIntent",
+                "actions": [
+                    {
+                        "$kind": "Teams.GetMeetingParticipant",
+                        "property": "conversation.result"
+                    },
+                    {
+                        "$kind": "Teams.GetMeetingParticipant",
+                        "property": "conversation.resultWithCustomProperties",
+                        "meetingId": "customMeetingId",
+                        "participantId": "customParticipantId",
+                        "tenantId": "customTenantId"
+                    }
+                ]
+            }
+        ]
+    },
+    "script": [
+        {
+            "$kind": "Microsoft.Test.UserActivity",
+            "activity": {
+                "type": "message",
+              "text": "hi",
+              "from": {
+                  "id": "participant-id",
+                  "aadObjectId": "participant-aad-id-1"
+              },
+              "channelData": {
+                  "tenant": {
+                      "id": "tenant-id-1"
+                  },
+                  "meeting": {
+                      "id": "meeting-id-1"
+                  }
+              }
+            }
+        },
+        {
+            "$kind": "Microsoft.Test.MemoryAssertions",
+            "assertions": [
+                "conversation.result.conversation.conversationType == 'personal'",
+                "conversation.result.conversation.id == 'a:oneOnOneConversationId'",
+                "conversation.result.conversation.isGroup == false",
+                "conversation.result.conversation.name == 'oneOnOne'",
+                "conversation.result.conversation.tenantId == 'tenantId-Guid'",
+                "conversation.result.meeting.role == 'Organizer'",
+                "conversation.result.user.userPrincipalName == 'userPrincipalName-1'",
+                "conversation.resultWithCustomProperties.conversation.conversationType == 'personal'",
+                "conversation.resultWithCustomProperties.conversation.id == 'a:oneOnOneConversationId'",
+                "conversation.resultWithCustomProperties.conversation.isGroup == false",
+                "conversation.resultWithCustomProperties.conversation.name == 'oneOnOne'",
+                "conversation.resultWithCustomProperties.conversation.tenantId == 'tenantId-Guid'",
+                "conversation.resultWithCustomProperties.meeting.role == 'Organizer'",
+                "conversation.resultWithCustomProperties.user.userPrincipalName == 'userPrincipalName-1'"
+            ]
+        }
+    ]
+}

--- a/tests/unit/packages/Microsoft.Bot.Components.Teams.Tests/Tests/ActionTests/Action_GetMeetingParticipantError.test.dialog
+++ b/tests/unit/packages/Microsoft.Bot.Components.Teams.Tests/Tests/ActionTests/Action_GetMeetingParticipantError.test.dialog
@@ -1,0 +1,42 @@
+{
+    "$schema": "../../../tests.schema",
+    "$kind": "Microsoft.Test.Script",
+    "dialog": {
+        "$kind": "Microsoft.AdaptiveDialog",
+        "id": "planningTest",
+        "triggers": [
+            {
+                "$kind": "Microsoft.OnUnknownIntent",
+                "actions": [
+                    {
+                        "$kind": "Teams.GetMeetingParticipant",
+                        "property": "$result"
+                    },
+                    {
+                        "$kind": "Microsoft.SendActivity",
+                        "activity": "${$result}"
+                    }
+                ]
+            },
+            {
+                "$kind": "Microsoft.OnError",
+                "actions": [
+                    {
+                        "$kind": "Microsoft.SendActivity",
+                        "activity": "${turn.dialogEvent.value.message}"
+                    }
+                ]
+            }
+        ]
+    },
+    "script": [
+        {
+            "$kind": "Microsoft.Test.UserSays",
+            "text": "hi"
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "Teams.GetMeetingParticipant works only on the Teams channel."
+        }
+    ]
+}

--- a/tests/unit/packages/Microsoft.Bot.Components.Teams.Tests/Tests/ActionTests/Action_GetMeetingParticipantErrorWithAdapter.test.dialog
+++ b/tests/unit/packages/Microsoft.Bot.Components.Teams.Tests/Tests/ActionTests/Action_GetMeetingParticipantErrorWithAdapter.test.dialog
@@ -1,0 +1,43 @@
+{
+    "$schema": "../../../tests.schema",
+    "$kind": "Microsoft.Test.Script",
+    "dialog": {
+        "$kind": "Microsoft.AdaptiveDialog",
+        "id": "planningTest",
+        "triggers": [
+            {
+                "$kind": "Microsoft.OnUnknownIntent",
+                "actions": [
+                    {
+                        "$kind": "Teams.GetMeetingParticipant",
+                        "property": "$result",
+                        "participantId": "=turn.channelData.doesNotExist"
+                    },
+                    {
+                        "$kind": "Microsoft.SendActivity",
+                        "activity": "${$result}"
+                    }
+                ]
+            },
+            {
+                "$kind": "Microsoft.OnError",
+                "actions": [
+                    {
+                        "$kind": "Microsoft.SendActivity",
+                        "activity": "${turn.dialogEvent.value.message}"
+                    }
+                ]
+            }
+        ]
+    },
+    "script": [
+        {
+            "$kind": "Microsoft.Test.UserSays",
+            "text": "hi"
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "Teams.GetMeetingParticipant could not determine the participant id by expression value provided. participantId is required."
+        }
+    ]
+}

--- a/tests/unit/packages/Microsoft.Bot.Components.Teams.Tests/Tests/ActionTests/Action_GetMember.test.dialog
+++ b/tests/unit/packages/Microsoft.Bot.Components.Teams.Tests/Tests/ActionTests/Action_GetMember.test.dialog
@@ -1,0 +1,65 @@
+{
+    "$schema": "../../../tests.schema",
+    "$kind": "Microsoft.Test.Script",
+    "dialog": {
+        "$kind": "Microsoft.AdaptiveDialog",
+        "id": "planningTest",
+        "triggers": [
+            {
+                "$kind": "Microsoft.OnUnknownIntent",
+                "actions": [
+                    {
+                        "$kind": "Teams.GetMember",
+                        "property": "conversation.result"
+                    },
+                    {
+                        "$kind": "Teams.GetMember",
+                        "property": "conversation.resultWithCustomProperties",
+                        "memberId": "customMemberId"
+                    }
+                ]
+            }
+        ]
+    },
+    "script": [
+        {
+            "$kind": "Microsoft.Test.UserActivity",
+            "activity": {
+              "type": "message",
+              "text": "hi",
+              "from": {
+                "id": "member-id"
+              },
+            "channelData": {
+              "tenant": {
+                "id": "tenant-id-1"
+              },
+              "meeting": {
+                "id": "meeting-id-1"
+              }
+            }
+          }
+        },
+        {
+            "$kind": "Microsoft.Test.MemoryAssertions",
+            "assertions": [
+                "conversation.result.email == 'User.0@microsoft.com'",
+                "conversation.result.givenName == 'User'",
+                "conversation.result.id == '29:User-Id-0'",
+                "conversation.result.name == 'User Name-0'",
+                "conversation.result.objectId == 'User-0-Object-Id'",
+                "conversation.result.surname == 'Surname-0'",
+                "conversation.result.tenantId == 'tenant-id-1'",
+                "conversation.result.userPrincipalName == 'user0@microsoft.com'",
+                "conversation.resultWithCustomProperties.email == 'User.0@microsoft.com'",
+                "conversation.resultWithCustomProperties.givenName == 'User'",
+                "conversation.resultWithCustomProperties.id == '29:User-Id-0'",
+                "conversation.resultWithCustomProperties.name == 'User Name-0'",
+                "conversation.resultWithCustomProperties.objectId == 'User-0-Object-Id'",
+                "conversation.resultWithCustomProperties.surname == 'Surname-0'",
+                "conversation.resultWithCustomProperties.tenantId == 'tenant-id-1'",
+                "conversation.resultWithCustomProperties.userPrincipalName == 'user0@microsoft.com'"
+            ]
+        }
+    ]
+}

--- a/tests/unit/packages/Microsoft.Bot.Components.Teams.Tests/Tests/ActionTests/Action_GetMemberError.test.dialog
+++ b/tests/unit/packages/Microsoft.Bot.Components.Teams.Tests/Tests/ActionTests/Action_GetMemberError.test.dialog
@@ -1,0 +1,42 @@
+{
+    "$schema": "../../../tests.schema",
+    "$kind": "Microsoft.Test.Script",
+    "dialog": {
+        "$kind": "Microsoft.AdaptiveDialog",
+        "id": "planningTest",
+        "triggers": [
+            {
+                "$kind": "Microsoft.OnUnknownIntent",
+                "actions": [
+                    {
+                        "$kind": "Teams.GetMember",
+                        "property": "$result"
+                    },
+                    {
+                        "$kind": "Microsoft.SendActivity",
+                        "activity": "${$result}"
+                    }
+                ]
+            },
+            {
+                "$kind": "Microsoft.OnError",
+                "actions": [
+                    {
+                        "$kind": "Microsoft.SendActivity",
+                        "activity": "${turn.dialogEvent.value.message}"
+                    }
+                ]
+            }
+        ]
+    },
+    "script": [
+        {
+            "$kind": "Microsoft.Test.UserSays",
+            "text": "hi"
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "Teams.GetMember works only on the Teams channel."
+        }
+    ]
+}

--- a/tests/unit/packages/Microsoft.Bot.Components.Teams.Tests/Tests/ActionTests/Action_GetMemberErrorWithAdapter.test.dialog
+++ b/tests/unit/packages/Microsoft.Bot.Components.Teams.Tests/Tests/ActionTests/Action_GetMemberErrorWithAdapter.test.dialog
@@ -1,0 +1,43 @@
+{
+    "$schema": "../../../tests.schema",
+    "$kind": "Microsoft.Test.Script",
+    "dialog": {
+        "$kind": "Microsoft.AdaptiveDialog",
+        "id": "planningTest",
+        "triggers": [
+            {
+                "$kind": "Microsoft.OnUnknownIntent",
+                "actions": [
+                    {
+                        "$kind": "Teams.GetMember",
+                        "property": "$result",
+                        "memberId": "=turn.activity.channelData.doesNotExist"
+                    },
+                    {
+                        "$kind": "Microsoft.SendActivity",
+                        "activity": "${$result}"
+                    }
+                ]
+            },
+            {
+                "$kind": "Microsoft.OnError",
+                "actions": [
+                    {
+                        "$kind": "Microsoft.SendActivity",
+                        "activity": "${turn.dialogEvent.value.message}"
+                    }
+                ]
+            }
+        ]
+    },
+    "script": [
+        {
+            "$kind": "Microsoft.Test.UserSays",
+            "text": "hi"
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "Missing MemberId in Teams.GetMember."
+        }
+    ]
+}

--- a/tests/unit/packages/Microsoft.Bot.Components.Teams.Tests/Tests/ActionTests/Action_GetPagedMembers.test.dialog
+++ b/tests/unit/packages/Microsoft.Bot.Components.Teams.Tests/Tests/ActionTests/Action_GetPagedMembers.test.dialog
@@ -1,0 +1,68 @@
+{
+    "$schema": "../../../tests.schema",
+    "$kind": "Microsoft.Test.Script",
+    "dialog": {
+        "$kind": "Microsoft.AdaptiveDialog",
+        "id": "planningTest",
+        "triggers": [
+            {
+                "$kind": "Microsoft.OnUnknownIntent",
+                "actions": [
+                    {
+                        "$kind": "Teams.GetPagedMembers",
+                        "property": "conversation.result"
+                    },
+                    {
+                        "$kind": "Teams.GetPagedMembers",
+                        "property": "conversation.resultWithCustomProperties",
+                        "continuationToken": "token",
+                        "pageSize": 2
+                    }
+                ]
+            }
+        ]
+    },
+    "script": [
+        {
+            "$kind": "Microsoft.Test.UserActivity",
+            "activity": {
+                "type": "message",
+                "text": "hi",
+                "from": {
+                  "id": "member-id"
+                },
+                "channelData": {
+                    "tenant": {
+                        "id": "tenant-id-1"
+                    },
+                    "meeting": {
+                        "id": "meeting-id-1"
+                    }
+                }
+            }
+        },
+        {
+            "$kind": "Microsoft.Test.MemoryAssertions",
+          "assertions": [
+            "conversation.result.continuationToken == 'token'",
+            "conversation.result.members[0].email == 'User.0@microsoft.com'",
+            "conversation.result.members[0].id == '29:User-Id-0'",
+            "conversation.result.members[0].objectId == 'User-0-Object-Id'",
+            "conversation.result.members[1].email == 'User.1@microsoft.com'",
+            "conversation.result.members[1].id == '29:User-Id-1'",
+            "conversation.result.members[1].objectId == 'User-1-Object-Id'",
+            "conversation.result.members[2].email == 'User.2@microsoft.com'",
+            "conversation.result.members[2].id == '29:User-Id-2'",
+            "conversation.result.members[2].objectId == 'User-2-Object-Id'",
+            "conversation.resultWithCustomProperties.continuationToken == 'customToken'",
+            "conversation.resultWithCustomProperties.members[0].email == 'User.0@microsoft.com'",
+            "conversation.resultWithCustomProperties.members[0].id == '29:User-Id-0'",
+            "conversation.resultWithCustomProperties.members[0].objectId == 'User-0-Object-Id'",
+            "conversation.resultWithCustomProperties.members[1].email == 'User.1@microsoft.com'",
+            "conversation.resultWithCustomProperties.members[1].id == '29:User-Id-1'",
+            "conversation.resultWithCustomProperties.members[1].objectId == 'User-1-Object-Id'",
+            "not(exists(conversation.resultWithCustomProperties.members[2]))"
+          ]
+        }
+    ]
+}

--- a/tests/unit/packages/Microsoft.Bot.Components.Teams.Tests/Tests/ActionTests/Action_GetPagedMembersError.test.dialog
+++ b/tests/unit/packages/Microsoft.Bot.Components.Teams.Tests/Tests/ActionTests/Action_GetPagedMembersError.test.dialog
@@ -1,0 +1,42 @@
+{
+    "$schema": "../../../tests.schema",
+    "$kind": "Microsoft.Test.Script",
+    "dialog": {
+        "$kind": "Microsoft.AdaptiveDialog",
+        "id": "planningTest",
+        "triggers": [
+            {
+                "$kind": "Microsoft.OnUnknownIntent",
+                "actions": [
+                    {
+                        "$kind": "Teams.GetPagedMembers",
+                        "property": "$result"
+                    },
+                    {
+                        "$kind": "Microsoft.SendActivity",
+                        "activity": "${$result}"
+                    }
+                ]
+            },
+            {
+                "$kind": "Microsoft.OnError",
+                "actions": [
+                    {
+                        "$kind": "Microsoft.SendActivity",
+                        "activity": "${turn.dialogEvent.value.message}"
+                    }
+                ]
+            }
+        ]
+    },
+    "script": [
+        {
+            "$kind": "Microsoft.Test.UserSays",
+            "text": "hi"
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "Teams.GetPagedMembers works only on the Teams channel."
+        }
+    ]
+}

--- a/tests/unit/packages/Microsoft.Bot.Components.Teams.Tests/Tests/ActionTests/Action_GetPagedTeamMembers.test.dialog
+++ b/tests/unit/packages/Microsoft.Bot.Components.Teams.Tests/Tests/ActionTests/Action_GetPagedTeamMembers.test.dialog
@@ -1,0 +1,65 @@
+{
+    "$schema": "../../../tests.schema",
+    "$kind": "Microsoft.Test.Script",
+    "dialog": {
+        "$kind": "Microsoft.AdaptiveDialog",
+        "id": "planningTest",
+        "triggers": [
+            {
+                "$kind": "Microsoft.OnUnknownIntent",
+                "actions": [
+                    {
+                        "$kind": "Teams.GetPagedTeamMembers",
+                        "property": "conversation.result"
+                    },
+                    {
+                        "$kind": "Teams.GetPagedTeamMembers",
+                        "property": "conversation.resultWithCustomProperties",
+                        "continuationToken": "token",
+                        "pageSize": 2
+                    }
+                ]
+            }
+        ]
+    },
+    "script": [
+        {
+            "$kind": "Microsoft.Test.UserActivity",
+            "activity": {
+                "type": "message",
+                "text": "hi",
+                "channelData": {
+                    "tenant": {
+                        "id": "tenant-id-1"
+                    },
+                    "team": {
+                        "id": "team-id-1"
+                    }
+                }
+            }
+        },
+        {
+            "$kind": "Microsoft.Test.MemoryAssertions",
+            "assertions": [
+                "conversation.result.continuationToken == 'token'",
+                "conversation.result.members[0].email == 'User.0@microsoft.com'",
+                "conversation.result.members[0].id == '29:User-Id-0'",
+                "conversation.result.members[0].objectId == 'User-0-Object-Id'",
+                "conversation.result.members[1].email == 'User.1@microsoft.com'",
+                "conversation.result.members[1].id == '29:User-Id-1'",
+                "conversation.result.members[1].objectId == 'User-1-Object-Id'",
+                "conversation.result.members[2].email == 'User.2@microsoft.com'",
+                "conversation.result.members[2].id == '29:User-Id-2'",
+                "conversation.result.members[2].objectId == 'User-2-Object-Id'",
+                "conversation.resultWithCustomProperties.continuationToken == 'customToken'",
+                "conversation.resultWithCustomProperties.members[0].email == 'User.0@microsoft.com'",
+                "conversation.resultWithCustomProperties.members[0].id == '29:User-Id-0'",
+                "conversation.resultWithCustomProperties.members[0].objectId == 'User-0-Object-Id'",
+                "conversation.resultWithCustomProperties.members[1].email == 'User.1@microsoft.com'",
+                "conversation.resultWithCustomProperties.members[1].id == '29:User-Id-1'",
+                "conversation.resultWithCustomProperties.members[1].objectId == 'User-1-Object-Id'",
+                "not(exists(conversation.resultWithCustomProperties.members[2]))"
+            ]
+        }
+    ]
+}

--- a/tests/unit/packages/Microsoft.Bot.Components.Teams.Tests/Tests/ActionTests/Action_GetPagedTeamMembersError.test.dialog
+++ b/tests/unit/packages/Microsoft.Bot.Components.Teams.Tests/Tests/ActionTests/Action_GetPagedTeamMembersError.test.dialog
@@ -1,0 +1,42 @@
+{
+    "$schema": "../../../tests.schema",
+    "$kind": "Microsoft.Test.Script",
+    "dialog": {
+        "$kind": "Microsoft.AdaptiveDialog",
+        "id": "planningTest",
+        "triggers": [
+            {
+                "$kind": "Microsoft.OnUnknownIntent",
+                "actions": [
+                    {
+                        "$kind": "Teams.GetPagedTeamMembers",
+                        "property": "$result"
+                    },
+                    {
+                        "$kind": "Microsoft.SendActivity",
+                        "activity": "${$result}"
+                    }
+                ]
+            },
+            {
+                "$kind": "Microsoft.OnError",
+                "actions": [
+                    {
+                        "$kind": "Microsoft.SendActivity",
+                        "activity": "${turn.dialogEvent.value.message}"
+                    }
+                ]
+            }
+        ]
+    },
+    "script": [
+        {
+            "$kind": "Microsoft.Test.UserSays",
+            "text": "hi"
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "Teams.GetPagedTeamMembers works only on the Teams channel."
+        }
+    ]
+}

--- a/tests/unit/packages/Microsoft.Bot.Components.Teams.Tests/Tests/ActionTests/Action_GetTeamChannels.test.dialog
+++ b/tests/unit/packages/Microsoft.Bot.Components.Teams.Tests/Tests/ActionTests/Action_GetTeamChannels.test.dialog
@@ -1,0 +1,58 @@
+{
+    "$schema": "../../../tests.schema",
+    "$kind": "Microsoft.Test.Script",
+    "dialog": {
+        "$kind": "Microsoft.AdaptiveDialog",
+        "id": "planningTest",
+        "triggers": [
+            {
+                "$kind": "Microsoft.OnUnknownIntent",
+                "actions": [
+                    {
+                        "$kind": "Teams.GetTeamChannels",
+                        "property": "conversation.result"
+                    },
+                    {
+                        "$kind": "Teams.GetTeamChannels",
+                        "property": "conversation.resultWithCustomProperties",
+                        "teamId": "customTeamId"
+                    }
+                ]
+            }
+        ]
+    },
+    "script": [
+        {
+            "$kind": "Microsoft.Test.UserActivity",
+            "activity": {
+                "type": "message",
+                "text": "hi",
+                "channelData": {
+                    "tenant": {
+                        "id": "tenant-id-1"
+                    },
+                    "team": {
+                        "id": "team-id-1"
+                    }
+                }
+            }
+        },
+        {
+            "$kind": "Microsoft.Test.MemoryAssertions",
+            "assertions": [
+                "conversation.result[0].id == '19:ChannelIdgeneralChannelId@thread.skype'",
+                "conversation.result[0].name == 'Testing0'",
+                "conversation.result[1].id == '19:somechannelId2e5ab3df9ae9b594bdb@thread.skype'",
+                "conversation.result[1].name == 'Testing1'",
+                "conversation.result[2].id == '19:somechannelId388ade16aa4dd375e69@thread.skype'",
+                "conversation.result[2].name == 'Testing2'",
+                "conversation.resultWithCustomProperties[0].id == '19:ChannelIdgeneralChannelId@thread.skype'",
+                "conversation.resultWithCustomProperties[0].name == 'Testing0'",
+                "conversation.resultWithCustomProperties[1].id == '19:somechannelId2e5ab3df9ae9b594bdb@thread.skype'",
+                "conversation.resultWithCustomProperties[1].name == 'Testing1'",
+                "conversation.resultWithCustomProperties[2].id == '19:somechannelId388ade16aa4dd375e69@thread.skype'",
+                "conversation.resultWithCustomProperties[2].name == 'Testing2'"
+            ]
+        }
+    ]
+}

--- a/tests/unit/packages/Microsoft.Bot.Components.Teams.Tests/Tests/ActionTests/Action_GetTeamChannelsError.test.dialog
+++ b/tests/unit/packages/Microsoft.Bot.Components.Teams.Tests/Tests/ActionTests/Action_GetTeamChannelsError.test.dialog
@@ -1,0 +1,42 @@
+{
+    "$schema": "../../../tests.schema",
+    "$kind": "Microsoft.Test.Script",
+    "dialog": {
+        "$kind": "Microsoft.AdaptiveDialog",
+        "id": "planningTest",
+        "triggers": [
+            {
+                "$kind": "Microsoft.OnUnknownIntent",
+                "actions": [
+                    {
+                        "$kind": "Teams.GetTeamChannels",
+                        "property": "$result"
+                    },
+                    {
+                        "$kind": "Microsoft.SendActivity",
+                        "activity": "${$result}"
+                    }
+                ]
+            },
+            {
+                "$kind": "Microsoft.OnError",
+                "actions": [
+                    {
+                        "$kind": "Microsoft.SendActivity",
+                        "activity": "${turn.dialogEvent.value.message}"
+                    }
+                ]
+            }
+        ]
+    },
+    "script": [
+        {
+            "$kind": "Microsoft.Test.UserSays",
+            "text": "hi"
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "Teams.GetTeamChannels works only on the Teams channel."
+        }
+    ]
+}

--- a/tests/unit/packages/Microsoft.Bot.Components.Teams.Tests/Tests/ActionTests/Action_GetTeamDetails.test.dialog
+++ b/tests/unit/packages/Microsoft.Bot.Components.Teams.Tests/Tests/ActionTests/Action_GetTeamDetails.test.dialog
@@ -1,0 +1,52 @@
+{
+    "$schema": "../../../tests.schema",
+    "$kind": "Microsoft.Test.Script",
+    "dialog": {
+        "$kind": "Microsoft.AdaptiveDialog",
+        "id": "planningTest",
+        "triggers": [
+            {
+                "$kind": "Microsoft.OnUnknownIntent",
+                "actions": [
+                    {
+                        "$kind": "Teams.GetTeamDetails",
+                        "property": "conversation.result"
+                    },
+                    {
+                        "$kind": "Teams.GetTeamDetails",
+                        "property": "conversation.resultWithCustomProperties",
+                        "teamId": "customTeamId"
+                    }
+                ]
+            }
+        ]
+    },
+    "script": [
+        {
+            "$kind": "Microsoft.Test.UserActivity",
+            "activity": {
+                "type": "message",
+                "text": "hi",
+                "channelData": {
+                    "tenant": {
+                        "id": "tenant-id-1"
+                    },
+                    "team": {
+                        "id": "team-id-1"
+                    }
+                }
+            }
+        },
+        {
+            "$kind": "Microsoft.Test.MemoryAssertions",
+            "assertions": [
+                "conversation.result.aadGroupId == 'Team-aadGroupId'",
+                "conversation.result.id == '19:generalChannelIdgeneralChannelId@thread.skype'",
+                "conversation.result.name == 'TeamName'",
+                "conversation.resultWithCustomProperties.aadGroupId == 'Team-aadGroupId'",
+                "conversation.resultWithCustomProperties.id == '19:generalChannelIdgeneralChannelId@thread.skype'",
+                "conversation.resultWithCustomProperties.name == 'TeamName'"
+            ]
+        }
+    ]
+}

--- a/tests/unit/packages/Microsoft.Bot.Components.Teams.Tests/Tests/ActionTests/Action_GetTeamDetailsError.test.dialog
+++ b/tests/unit/packages/Microsoft.Bot.Components.Teams.Tests/Tests/ActionTests/Action_GetTeamDetailsError.test.dialog
@@ -1,0 +1,42 @@
+{
+    "$schema": "../../../tests.schema",
+    "$kind": "Microsoft.Test.Script",
+    "dialog": {
+        "$kind": "Microsoft.AdaptiveDialog",
+        "id": "planningTest",
+        "triggers": [
+            {
+                "$kind": "Microsoft.OnUnknownIntent",
+                "actions": [
+                    {
+                        "$kind": "Teams.GetTeamDetails",
+                        "property": "$result"
+                    },
+                    {
+                        "$kind": "Microsoft.SendActivity",
+                        "activity": "${$result}"
+                    }
+                ]
+            },
+            {
+                "$kind": "Microsoft.OnError",
+                "actions": [
+                    {
+                        "$kind": "Microsoft.SendActivity",
+                        "activity": "${turn.dialogEvent.value.message}"
+                    }
+                ]
+            }
+        ]
+    },
+    "script": [
+        {
+            "$kind": "Microsoft.Test.UserSays",
+            "text": "hi"
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "Teams.GetTeamDetails works only on the Teams channel."
+        }
+    ]
+}

--- a/tests/unit/packages/Microsoft.Bot.Components.Teams.Tests/Tests/ActionTests/Action_GetTeamMember.test.dialog
+++ b/tests/unit/packages/Microsoft.Bot.Components.Teams.Tests/Tests/ActionTests/Action_GetTeamMember.test.dialog
@@ -1,0 +1,64 @@
+{
+    "$schema": "../../../tests.schema",
+    "$kind": "Microsoft.Test.Script",
+    "enableTrace": true,
+    "dialog": {
+        "$kind": "Microsoft.AdaptiveDialog",
+        "id": "planningTest",
+        "triggers": [
+            {
+                "$kind": "Microsoft.OnUnknownIntent",
+                "actions": [
+                    {
+                        "$kind": "Teams.GetTeamMember",
+                        "property": "conversation.result"
+                    },
+                    {
+                        "$kind": "Teams.GetTeamMember",
+                        "property": "conversation.resultWithCustomProperties",
+                        "memberId": "customMemberId",
+                        "teamId": "customTeamId"
+                    }
+                ]
+            }
+        ]
+    },
+    "script": [
+        {
+            "$kind": "Microsoft.Test.UserActivity",
+            "activity": {
+                "type": "message",
+                "text": "hi",
+                "channelData": {
+                    "tenant": {
+                        "id": "tenant-id-1"
+                    },
+                    "team": {
+                        "id": "team-id-1"
+                    }
+                }
+            }
+        },
+        {
+            "$kind": "Microsoft.Test.MemoryAssertions",
+          "assertions": [
+            "conversation.result.email == 'User.0@microsoft.com'",
+            "conversation.result.givenName == 'User'",
+            "conversation.result.id == '29:User-Id-0'",
+            "conversation.result.name == 'User Name-0'",
+            "conversation.result.objectId == 'User-0-Object-Id'",
+            "conversation.result.surname == 'Surname-0'",
+            "conversation.result.tenantId == 'tenant-id-1'",
+            "conversation.result.userPrincipalName == 'user0@microsoft.com'",
+            "conversation.resultWithCustomProperties.email == 'User.0@microsoft.com'",
+            "conversation.resultWithCustomProperties.givenName == 'User'",
+            "conversation.resultWithCustomProperties.id == '29:User-Id-0'",
+            "conversation.resultWithCustomProperties.name == 'User Name-0'",
+            "conversation.resultWithCustomProperties.objectId == 'User-0-Object-Id'",
+            "conversation.resultWithCustomProperties.surname == 'Surname-0'",
+            "conversation.resultWithCustomProperties.tenantId == 'tenant-id-1'",
+            "conversation.resultWithCustomProperties.userPrincipalName == 'user0@microsoft.com'"
+          ]
+        }
+    ]
+}

--- a/tests/unit/packages/Microsoft.Bot.Components.Teams.Tests/Tests/ActionTests/Action_GetTeamMemberError.test.dialog
+++ b/tests/unit/packages/Microsoft.Bot.Components.Teams.Tests/Tests/ActionTests/Action_GetTeamMemberError.test.dialog
@@ -1,0 +1,42 @@
+{
+    "$schema": "../../../tests.schema",
+    "$kind": "Microsoft.Test.Script",
+    "dialog": {
+        "$kind": "Microsoft.AdaptiveDialog",
+        "id": "planningTest",
+        "triggers": [
+            {
+                "$kind": "Microsoft.OnUnknownIntent",
+                "actions": [
+                    {
+                        "$kind": "Teams.GetTeamMember",
+                        "property": "$result"
+                    },
+                    {
+                        "$kind": "Microsoft.SendActivity",
+                        "activity": "${$result}"
+                    }
+                ]
+            },
+            {
+                "$kind": "Microsoft.OnError",
+                "actions": [
+                    {
+                        "$kind": "Microsoft.SendActivity",
+                        "activity": "${turn.dialogEvent.value.message}"
+                    }
+                ]
+            }
+        ]
+    },
+    "script": [
+        {
+            "$kind": "Microsoft.Test.UserSays",
+            "text": "hi"
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "Teams.GetTeamMember works only on the Teams channel."
+        }
+    ]
+}

--- a/tests/unit/packages/Microsoft.Bot.Components.Teams.Tests/Tests/ActionTests/Action_GetTeamMemberErrorWithAdapter.test.dialog
+++ b/tests/unit/packages/Microsoft.Bot.Components.Teams.Tests/Tests/ActionTests/Action_GetTeamMemberErrorWithAdapter.test.dialog
@@ -1,0 +1,43 @@
+{
+    "$schema": "../../../tests.schema",
+    "$kind": "Microsoft.Test.Script",
+    "dialog": {
+        "$kind": "Microsoft.AdaptiveDialog",
+        "id": "planningTest",
+        "triggers": [
+            {
+                "$kind": "Microsoft.OnUnknownIntent",
+                "actions": [
+                    {
+                        "$kind": "Teams.GetTeamMember",
+                        "property": "$result",
+                        "memberId": "=turn.activity.channelData.doesNotExist"
+                    },
+                    {
+                        "$kind": "Microsoft.SendActivity",
+                        "activity": "${$result}"
+                    }
+                ]
+            },
+            {
+                "$kind": "Microsoft.OnError",
+                "actions": [
+                    {
+                        "$kind": "Microsoft.SendActivity",
+                        "activity": "${turn.dialogEvent.value.message}"
+                    }
+                ]
+            }
+        ]
+    },
+    "script": [
+        {
+            "$kind": "Microsoft.Test.UserSays",
+            "text": "hi"
+        },
+        {
+          "$kind": "Microsoft.Test.AssertReply",
+          "text": "Missing MemberId in Teams.GetTeamMember."
+        }
+    ]
+}

--- a/tests/unit/packages/Microsoft.Bot.Components.Teams.Tests/Tests/ActionTests/Action_SendAppBasedLinkQueryResponse.test.dialog
+++ b/tests/unit/packages/Microsoft.Bot.Components.Teams.Tests/Tests/ActionTests/Action_SendAppBasedLinkQueryResponse.test.dialog
@@ -1,0 +1,50 @@
+{
+    "$schema": "../../../tests.schema",
+    "$kind": "Microsoft.Test.Script",
+    "dialog": {
+        "$kind": "Microsoft.AdaptiveDialog",
+        "id": "planningTest",
+        "triggers": [
+            {
+                "$kind": "Microsoft.OnUnknownIntent",
+                "actions": [
+                    {
+                        "$kind": "Teams.SendAppBasedLinkQueryResponse",
+                        "card": {
+                            "type": "message",
+                            "attachments": [
+                                {
+                                    "contentType": "application/vnd.microsoft.card.thumbnail",
+                                    "content": {
+                                        "title": "card-title"
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        ]
+    },
+    "script": [
+        {
+            "$kind": "Microsoft.Test.UserActivity",
+            "activity": {
+                "type": "message",
+                "text": "hi",
+                "name": "composeExtension/queryLink"
+            }
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReplyActivity",
+          "assertions": [
+            "type == 'invokeResponse'",
+            "conversation.id == 'Action_SendAppBasedLinkQueryResponse'",
+            "value.body.composeExtension.attachmentLayout == 'list'",
+            "value.body.composeExtension.type == 'result'",
+            "value.body.composeExtension.attachments[0].contentType == 'application/vnd.microsoft.card.thumbnail'",
+            "value.body.composeExtension.attachments[0].content.title == 'card-title'"
+          ]
+        }
+    ]
+}

--- a/tests/unit/packages/Microsoft.Bot.Components.Teams.Tests/Tests/ActionTests/Action_SendAppBasedLinkQueryResponseError.test.dialog
+++ b/tests/unit/packages/Microsoft.Bot.Components.Teams.Tests/Tests/ActionTests/Action_SendAppBasedLinkQueryResponseError.test.dialog
@@ -1,0 +1,79 @@
+{
+    "$schema": "../../../tests.schema",
+    "$kind": "Microsoft.Test.Script",
+    "dialog": {
+        "$kind": "Microsoft.AdaptiveDialog",
+        "id": "planningTest",
+        "recognizer": {
+            "$kind": "Microsoft.RegexRecognizer",
+            "intents": [
+                {
+                    "intent": "NoCard",
+                    "pattern": "NoCard"
+                },
+                {
+                    "intent": "NoAttachments",
+                    "pattern": "NoAttachments"
+                }
+            ]
+        },
+        "triggers": [
+            {
+                "$kind": "Microsoft.OnIntent",
+                "intent": "NoCard",
+                "actions": [
+                    {
+                        "$kind": "Teams.SendAppBasedLinkQueryResponse"
+                    }
+                ]
+            },
+            {
+                "$kind": "Microsoft.OnIntent",
+                "intent": "NoAttachments",
+                "actions": [
+                    {
+                        "$kind": "Teams.SendAppBasedLinkQueryResponse",
+                        "card": {
+                            "type": "message"
+                        }
+                    }
+                ]
+            },
+            {
+                "$kind": "Microsoft.OnError",
+                "actions": [
+                    {
+                        "$kind": "Microsoft.SendActivity",
+                        "activity": "${turn.dialogEvent.value.message}"
+                    }
+                ]
+            }
+        ]
+    },
+    "script": [
+        {
+            "$kind": "Microsoft.Test.UserActivity",
+            "activity": {
+                "type": "message",
+                "text": "NoCard",
+                "name": "composeExtension/queryLink"
+            }
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "An activity with attachments is required for Teams.SendAppBasedLinkQueryResponse."
+        },
+        {
+            "$kind": "Microsoft.Test.UserActivity",
+            "activity": {
+                "type": "message",
+                "text": "NoAttachments",
+                "name": "composeExtension/queryLink"
+            }
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "Invalid activity. An attachment is required for Teams.SendAppBasedLinkQueryResponse."
+        }
+    ]
+}

--- a/tests/unit/packages/Microsoft.Bot.Components.Teams.Tests/Tests/ActionTests/Action_SendMEActionResponse.test.dialog
+++ b/tests/unit/packages/Microsoft.Bot.Components.Teams.Tests/Tests/ActionTests/Action_SendMEActionResponse.test.dialog
@@ -1,0 +1,56 @@
+{
+    "$schema": "../../../tests.schema",
+    "$kind": "Microsoft.Test.Script",
+    "dialog": {
+        "$kind": "Microsoft.AdaptiveDialog",
+        "id": "planningTest",
+        "triggers": [
+            {
+                "$kind": "Microsoft.OnUnknownIntent",
+                "actions": [
+                    {
+                        "$kind": "Teams.SendMEActionResponse",
+                        "title": "some title",
+                        "height": 1,
+                        "width": 2,
+                        "completionBotId": "someBotId",
+                        "card": {
+                            "type": "message",
+                            "attachments": [
+                                {
+                                    "contentType": "application/vnd.microsoft.card.thumbnail",
+                                    "content": {
+                                        "title": "card-title"
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        ]
+    },
+    "script": [
+        {
+            "$kind": "Microsoft.Test.UserActivity",
+            "activity": {
+                "type": "message",
+                "text": "hi",
+                "name": "composeExtension/queryLink"
+            }
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReplyActivity",
+          "assertions": [
+            "type == 'invokeResponse'",
+            "conversation.id == 'Action_SendMEActionResponse'",
+            "value.body.task.value.completionBotId == 'someBotId'",
+            "value.body.task.value.height == 1",
+            "value.body.task.value.title == 'some title'",
+            "value.body.task.value.width == 2",
+            "value.body.task.value.card.contentType == 'application/vnd.microsoft.card.thumbnail'",
+            "value.body.task.value.card.content.title == 'card-title'"
+          ]
+        }
+    ]
+}

--- a/tests/unit/packages/Microsoft.Bot.Components.Teams.Tests/Tests/ActionTests/Action_SendMEActionResponseError.test.dialog
+++ b/tests/unit/packages/Microsoft.Bot.Components.Teams.Tests/Tests/ActionTests/Action_SendMEActionResponseError.test.dialog
@@ -1,0 +1,54 @@
+{
+    "$schema": "../../../tests.schema",
+    "$kind": "Microsoft.Test.Script",
+    "dialog": {
+        "$kind": "Microsoft.AdaptiveDialog",
+        "id": "planningTest",
+        "recognizer": {
+            "$kind": "Microsoft.RegexRecognizer",
+            "intents": [
+                {
+                    "intent": "NoAttachments",
+                    "pattern": "NoAttachments"
+                }
+            ]
+        },
+        "triggers": [
+            {
+                "$kind": "Microsoft.OnIntent",
+                "intent": "NoAttachments",
+                "actions": [
+                    {
+                        "$kind": "Teams.SendMEActionResponse",
+                        "card": {
+                            "type": "message"
+                        }
+                    }
+                ]
+            },
+            {
+                "$kind": "Microsoft.OnError",
+                "actions": [
+                    {
+                        "$kind": "Microsoft.SendActivity",
+                        "activity": "${turn.dialogEvent.value.message}"
+                    }
+                ]
+            }
+        ]
+    },
+    "script": [
+        {
+            "$kind": "Microsoft.Test.UserActivity",
+            "activity": {
+                "type": "message",
+                "text": "NoAttachments",
+                "name": "composeExtension/queryLink"
+            }
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "Missing attachments in Teams.SendMEActionResponse."
+        }
+    ]
+}

--- a/tests/unit/packages/Microsoft.Bot.Components.Teams.Tests/Tests/ActionTests/Action_SendMEAttachmentsResponse.test.dialog
+++ b/tests/unit/packages/Microsoft.Bot.Components.Teams.Tests/Tests/ActionTests/Action_SendMEAttachmentsResponse.test.dialog
@@ -1,0 +1,50 @@
+{
+    "$schema": "../../../tests.schema",
+    "$kind": "Microsoft.Test.Script",
+    "dialog": {
+        "$kind": "Microsoft.AdaptiveDialog",
+        "id": "planningTest",
+        "triggers": [
+            {
+                "$kind": "Microsoft.OnUnknownIntent",
+                "actions": [
+                    {
+                        "$kind": "Teams.SendMEAttachmentsResponse",
+                        "attachments": {
+                            "type": "message",
+                            "attachments": [
+                                {
+                                    "contentType": "application/vnd.microsoft.card.thumbnail",
+                                    "content": {
+                                        "title": "card-title"
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        ]
+    },
+    "script": [
+        {
+            "$kind": "Microsoft.Test.UserActivity",
+            "activity": {
+                "type": "message",
+                "text": "hi",
+                "name": "composeExtension/queryLink"
+            }
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReplyActivity",
+          "assertions": [
+            "type == 'invokeResponse'",
+            "conversation.id == 'Action_SendMEAttachmentsResponse'",
+            "value.body.composeExtension.attachmentLayout == 'list'",
+            "value.body.composeExtension.type == 'result'",
+            "value.body.composeExtension.attachments[0].contentType == 'application/vnd.microsoft.card.thumbnail'",
+            "value.body.composeExtension.attachments[0].content.title == 'card-title'"
+          ]
+        }
+    ]
+}

--- a/tests/unit/packages/Microsoft.Bot.Components.Teams.Tests/Tests/ActionTests/Action_SendMEAttachmentsResponseError.test.dialog
+++ b/tests/unit/packages/Microsoft.Bot.Components.Teams.Tests/Tests/ActionTests/Action_SendMEAttachmentsResponseError.test.dialog
@@ -1,0 +1,44 @@
+{
+    "$schema": "../../../tests.schema",
+    "$kind": "Microsoft.Test.Script",
+    "dialog": {
+        "$kind": "Microsoft.AdaptiveDialog",
+        "id": "planningTest",
+        "triggers": [
+            {
+                "$kind": "Microsoft.OnUnknownIntent",
+                "actions": [
+                    {
+                        "$kind": "Teams.SendMEAttachmentsResponse",
+                        "attachments": {
+                            "type": "message"
+                        }
+                    }
+                ]
+            },
+            {
+                "$kind": "Microsoft.OnError",
+                "actions": [
+                    {
+                        "$kind": "Microsoft.SendActivity",
+                        "activity": "${turn.dialogEvent.value.message}"
+                    }
+                ]
+            }
+        ]
+    },
+    "script": [
+        {
+            "$kind": "Microsoft.Test.UserActivity",
+            "activity": {
+                "type": "message",
+                "text": "hi",
+                "name": "composeExtension/queryLink"
+            }
+        },
+      {
+        "$kind": "Microsoft.Test.AssertReply",
+        "text": "Missing attachments in Teams.SendMEAttachmentsResponse."
+      }
+    ]
+}

--- a/tests/unit/packages/Microsoft.Bot.Components.Teams.Tests/Tests/ActionTests/Action_SendMEAuthResponse.test.dialog
+++ b/tests/unit/packages/Microsoft.Bot.Components.Teams.Tests/Tests/ActionTests/Action_SendMEAuthResponse.test.dialog
@@ -1,0 +1,41 @@
+{
+    "$schema": "../../../tests.schema",
+    "$kind": "Microsoft.Test.Script",
+    "dialog": {
+        "$kind": "Microsoft.AdaptiveDialog",
+        "id": "planningTest",
+        "triggers": [
+            {
+                "$kind": "Microsoft.OnUnknownIntent",
+                "actions": [
+                    {
+                        "$kind": "Teams.SendMEAuthResponse",
+                        "connectionName": "testConnection",
+                        "title": "test title"
+                    }
+                ]
+            }
+        ]
+    },
+    "script": [
+        {
+            "$kind": "Microsoft.Test.UserActivity",
+            "activity": {
+                "type": "message",
+                "text": "hi",
+                "name": "composeExtension/queryLink"
+            }
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReplyActivity",
+          "assertions": [
+            "type == 'invokeResponse'",
+            "conversation.id == 'Action_SendMEAuthResponse'",
+            "value.body.composeExtension.type == 'auth'",
+            "value.body.composeExtension.suggestedActions.actions[0].title == 'test title'",
+            "value.body.composeExtension.suggestedActions.actions[0].type == 'openUrl'",
+            "startsWith(value.body.composeExtension.suggestedActions.actions[0].value, 'https://fake.com/oauthsignin/testConnection')"
+          ]
+        }
+    ]
+}

--- a/tests/unit/packages/Microsoft.Bot.Components.Teams.Tests/Tests/ActionTests/Action_SendMEAuthResponseError.test.dialog
+++ b/tests/unit/packages/Microsoft.Bot.Components.Teams.Tests/Tests/ActionTests/Action_SendMEAuthResponseError.test.dialog
@@ -1,0 +1,43 @@
+{
+    "$schema": "../../../tests.schema",
+    "$kind": "Microsoft.Test.Script",
+    "dialog": {
+        "$kind": "Microsoft.AdaptiveDialog",
+        "id": "planningTest",
+        "triggers": [
+            {
+                "$kind": "Microsoft.OnUnknownIntent",
+                "actions": [
+                    {
+                        "$kind": "Teams.SendMEAuthResponse",
+                        "connectionName": "someConnection",
+                        "title": "someTitle"
+                    }
+                ]
+            },
+            {
+                "$kind": "Microsoft.OnError",
+                "actions": [
+                    {
+                        "$kind": "Microsoft.SendActivity",
+                        "activity": "${turn.dialogEvent.value.message}"
+                    }
+                ]
+            }
+        ]
+    },
+    "script": [
+        {
+            "$kind": "Microsoft.Test.UserActivity",
+            "activity": {
+                "type": "message",
+                "text": "NoConnectionName",
+                "name": "composeExtension/queryLink"
+            }
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "Teams.SendMEAuthResponse: not supported by the current adapter."
+        }
+    ]
+}

--- a/tests/unit/packages/Microsoft.Bot.Components.Teams.Tests/Tests/ActionTests/Action_SendMEAuthResponseErrorWithAdapter.test.dialog
+++ b/tests/unit/packages/Microsoft.Bot.Components.Teams.Tests/Tests/ActionTests/Action_SendMEAuthResponseErrorWithAdapter.test.dialog
@@ -1,0 +1,88 @@
+{
+    "$schema": "../../../tests.schema",
+    "$kind": "Microsoft.Test.Script",
+    "dialog": {
+        "$kind": "Microsoft.AdaptiveDialog",
+        "id": "planningTest",
+        "recognizer": {
+            "$kind": "Microsoft.RegexRecognizer",
+            "intents": [
+                {
+                    "intent": "NoConnectionName",
+                    "pattern": "NoConnectionName"
+                },
+                {
+                    "intent": "NoTitle",
+                    "pattern": "NoTitle"
+                }
+            ]
+        },
+        "triggers": [
+            {
+                "$kind": "Microsoft.OnIntent",
+                "intent": "NoConnectionName",
+                "actions": [
+                    {
+                        "$kind": "Teams.SendMEAuthResponse",
+                        "connectionName": "=turn.channelData.DoesNotExist"
+                    }
+                ]
+            },
+            {
+                "$kind": "Microsoft.OnIntent",
+                "intent": "NoTitle",
+                "actions": [
+                    {
+                        "$kind": "Teams.SendMEAuthResponse",
+                        "connectionName": "testConnection",
+                        "title": "=turn.channelData.doesNotExist"
+                    }
+                ]
+            },
+            {
+                "$kind": "Microsoft.OnIntent",
+                "intent": "NoAttachments",
+                "actions": [
+                    {
+                        "$kind": "Teams.SendMEAuthResponse"
+                    }
+                ]
+            },
+            {
+                "$kind": "Microsoft.OnError",
+                "actions": [
+                    {
+                        "$kind": "Microsoft.SendActivity",
+                        "activity": "${turn.dialogEvent.value.message}"
+                    }
+                ]
+            }
+        ]
+    },
+    "script": [
+        {
+            "$kind": "Microsoft.Test.UserActivity",
+            "activity": {
+                "type": "message",
+                "text": "NoConnectionName",
+                "name": "composeExtension/queryLink"
+            }
+        },
+        {
+          "$kind": "Microsoft.Test.AssertReply",
+          "text": "A valid ConnectionName is required for auth responses."
+        },
+        {
+            "$kind": "Microsoft.Test.UserActivity",
+            "activity": {
+                "type": "message",
+                "text": "NoTitle",
+                "name": "composeExtension/queryLink"
+            }
+        },
+        {
+          "$kind": "Microsoft.Test.AssertReply",
+          "text": "A valid Title is required for auth responses."
+        }
+    ]
+}

--- a/tests/unit/packages/Microsoft.Bot.Components.Teams.Tests/Tests/ActionTests/Action_SendMEBotMessagePreviewResponse.test.dialog
+++ b/tests/unit/packages/Microsoft.Bot.Components.Teams.Tests/Tests/ActionTests/Action_SendMEBotMessagePreviewResponse.test.dialog
@@ -1,0 +1,52 @@
+{
+    "$schema": "../../../tests.schema",
+    "$kind": "Microsoft.Test.Script",
+    "dialog": {
+        "$kind": "Microsoft.AdaptiveDialog",
+        "id": "planningTest",
+        "triggers": [
+            {
+                "$kind": "Microsoft.OnUnknownIntent",
+                "actions": [
+                    {
+                        "$kind": "Teams.SendMEBotMessagePreviewResponse",
+                        "card": {
+                            "type": "message",
+                            "attachments": [
+                                {
+                                    "contentType": "application/vnd.microsoft.card.thumbnail",
+                                    "content": {
+                                        "title": "card-title"
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        ]
+    },
+    "script": [
+        {
+            "$kind": "Microsoft.Test.UserActivity",
+            "activity": {
+                "type": "message",
+                "text": "hi",
+                "name": "composeExtension/queryLink"
+            }
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReplyActivity",
+          "assertions": [
+            "type == 'invokeResponse'",
+            "conversation.id == 'Action_SendMEBotMessagePreviewResponse'",
+            "value.body.composeExtension.type == 'botMessagePreview'",
+            "value.body.composeExtension.activityPreview.attachmentLayout == 'list'",
+            "value.body.composeExtension.activityPreview.inputHint == 'acceptingInput'",
+            "value.body.composeExtension.activityPreview.type == 'message'",
+            "value.body.composeExtension.activityPreview.attachments[0].contentType == 'application/vnd.microsoft.card.thumbnail'",
+            "value.body.composeExtension.activityPreview.attachments[0].content.title == 'card-title'"
+          ]
+        }
+    ]
+}

--- a/tests/unit/packages/Microsoft.Bot.Components.Teams.Tests/Tests/ActionTests/Action_SendMEBotMessagePreviewResponseError.test.dialog
+++ b/tests/unit/packages/Microsoft.Bot.Components.Teams.Tests/Tests/ActionTests/Action_SendMEBotMessagePreviewResponseError.test.dialog
@@ -1,0 +1,79 @@
+{
+    "$schema": "../../../tests.schema",
+    "$kind": "Microsoft.Test.Script",
+    "dialog": {
+        "$kind": "Microsoft.AdaptiveDialog",
+        "id": "planningTest",
+        "recognizer": {
+            "$kind": "Microsoft.RegexRecognizer",
+            "intents": [
+                {
+                    "intent": "NoCard",
+                    "pattern": "NoCard"
+                },
+                {
+                    "intent": "NoAttachments",
+                    "pattern": "NoAttachments"
+                }
+            ]
+        },
+        "triggers": [
+            {
+                "$kind": "Microsoft.OnIntent",
+                "intent": "NoCard",
+                "actions": [
+                    {
+                        "$kind": "Teams.SendMEBotMessagePreviewResponse"
+                    }
+                ]
+            },
+            {
+                "$kind": "Microsoft.OnIntent",
+                "intent": "NoAttachments",
+                "actions": [
+                    {
+                        "$kind": "Teams.SendMEBotMessagePreviewResponse",
+                        "card": {
+                            "type": "message"
+                        }
+                    }
+                ]
+            },
+            {
+                "$kind": "Microsoft.OnError",
+                "actions": [
+                    {
+                        "$kind": "Microsoft.SendActivity",
+                        "activity": "${turn.dialogEvent.value.message}"
+                    }
+                ]
+            }
+        ]
+    },
+    "script": [
+        {
+            "$kind": "Microsoft.Test.UserActivity",
+            "activity": {
+                "type": "message",
+                "text": "NoCard",
+                "name": "composeExtension/queryLink"
+            }
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "A valid Card is required for Teams.SendMEBotMessagePreviewResponse."
+        },
+        {
+            "$kind": "Microsoft.Test.UserActivity",
+            "activity": {
+                "type": "message",
+                "text": "NoAttachments",
+                "name": "composeExtension/queryLink"
+            }
+        },
+      {
+        "$kind": "Microsoft.Test.AssertReply",
+        "text": "Invalid activity. An attachment is required for Teams.SendMEBotMessagePreviewResponse."
+      }
+    ]
+}

--- a/tests/unit/packages/Microsoft.Bot.Components.Teams.Tests/Tests/ActionTests/Action_SendMEConfigQuerySettingUrlResponse.test.dialog
+++ b/tests/unit/packages/Microsoft.Bot.Components.Teams.Tests/Tests/ActionTests/Action_SendMEConfigQuerySettingUrlResponse.test.dialog
@@ -1,0 +1,39 @@
+{
+    "$schema": "../../../tests.schema",
+    "$kind": "Microsoft.Test.Script",
+    "dialog": {
+        "$kind": "Microsoft.AdaptiveDialog",
+        "id": "planningTest",
+        "triggers": [
+            {
+                "$kind": "Microsoft.OnUnknownIntent",
+                "actions": [
+                    {
+                        "$kind": "Teams.SendMEConfigQuerySettingUrlResponse",
+                        "configUrl": "someBaseUrl.com/somePage.html"
+                    }
+                ]
+            }
+        ]
+    },
+    "script": [
+        {
+            "$kind": "Microsoft.Test.UserActivity",
+            "activity": {
+                "type": "message",
+                "text": "hi",
+                "name": "composeExtension/queryLink"
+            }
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReplyActivity",
+          "assertions": [
+            "type == 'invokeResponse'",
+            "conversation.id == 'Action_SendMEConfigQuerySettingUrlResponse'",
+            "value.body.composeExtension.type == 'config'",
+            "value.body.composeExtension.suggestedActions.actions[0].type == 'openUrl'",
+            "value.body.composeExtension.suggestedActions.actions[0].value == 'someBaseUrl.com/somePage.html'"
+          ]
+        }
+    ]
+}

--- a/tests/unit/packages/Microsoft.Bot.Components.Teams.Tests/Tests/ActionTests/Action_SendMEConfigQuerySettingUrlResponseError.test.dialog
+++ b/tests/unit/packages/Microsoft.Bot.Components.Teams.Tests/Tests/ActionTests/Action_SendMEConfigQuerySettingUrlResponseError.test.dialog
@@ -1,0 +1,32 @@
+{
+    "$schema": "../../../tests.schema",
+    "$kind": "Microsoft.Test.Script",
+    "dialog": {
+        "$kind": "Microsoft.AdaptiveDialog",
+        "id": "planningTest",
+        "triggers": [
+            {
+                "$kind": "Microsoft.OnUnknownIntent",
+                "actions": [
+                    {
+                        "$kind": "Teams.SendMEConfigQuerySettingUrlResponse"
+                    }
+                ]
+            }
+        ]
+    },
+    "script": [
+        {
+            "$kind": "Microsoft.Test.UserActivity",
+            "activity": {
+                "type": "message",
+                "text": "hi",
+                "name": "composeExtension/queryLink"
+            }
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "ConfigUrl is required for Teams.SendMEConfigQuerySettingUrlResponse."
+        }
+    ]
+}

--- a/tests/unit/packages/Microsoft.Bot.Components.Teams.Tests/Tests/ActionTests/Action_SendMEMessageResponse.test.dialog
+++ b/tests/unit/packages/Microsoft.Bot.Components.Teams.Tests/Tests/ActionTests/Action_SendMEMessageResponse.test.dialog
@@ -1,0 +1,38 @@
+{
+    "$schema": "../../../tests.schema",
+    "$kind": "Microsoft.Test.Script",
+    "dialog": {
+        "$kind": "Microsoft.AdaptiveDialog",
+        "id": "planningTest",
+        "triggers": [
+            {
+                "$kind": "Microsoft.OnUnknownIntent",
+                "actions": [
+                    {
+                        "$kind": "Teams.SendMEMessageResponse",
+                        "message": "i want to send this to the user"
+                    }
+                ]
+            }
+        ]
+    },
+    "script": [
+        {
+            "$kind": "Microsoft.Test.UserActivity",
+            "activity": {
+                "type": "message",
+                "text": "hi",
+                "name": "composeExtension/queryLink"
+            }
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReplyActivity",
+          "assertions": [
+            "type == 'invokeResponse'",
+            "conversation.id == 'Action_SendMEMessageResponse'",
+            "value.body.composeExtension.type == 'message'",
+            "value.body.composeExtension.text == 'i want to send this to the user'"
+          ]
+        }
+    ]
+}

--- a/tests/unit/packages/Microsoft.Bot.Components.Teams.Tests/Tests/ActionTests/Action_SendMEMessageResponseError.test.dialog
+++ b/tests/unit/packages/Microsoft.Bot.Components.Teams.Tests/Tests/ActionTests/Action_SendMEMessageResponseError.test.dialog
@@ -1,0 +1,32 @@
+{
+    "$schema": "../../../tests.schema",
+    "$kind": "Microsoft.Test.Script",
+    "dialog": {
+        "$kind": "Microsoft.AdaptiveDialog",
+        "id": "planningTest",
+        "triggers": [
+            {
+                "$kind": "Microsoft.OnUnknownIntent",
+                "actions": [
+                    {
+                        "$kind": "Teams.SendMEMessageResponse"
+                    }
+                ]
+            }
+        ]
+    },
+    "script": [
+        {
+            "$kind": "Microsoft.Test.UserActivity",
+            "activity": {
+                "type": "message",
+                "text": "hi",
+                "name": "composeExtension/queryLink"
+            }
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "A Message is required for Teams.SendMEMessageResponse."
+        }
+    ]
+}

--- a/tests/unit/packages/Microsoft.Bot.Components.Teams.Tests/Tests/ActionTests/Action_SendMESelectItemResponse.test.dialog
+++ b/tests/unit/packages/Microsoft.Bot.Components.Teams.Tests/Tests/ActionTests/Action_SendMESelectItemResponse.test.dialog
@@ -1,0 +1,50 @@
+{
+    "$schema": "../../../tests.schema",
+    "$kind": "Microsoft.Test.Script",
+    "dialog": {
+        "$kind": "Microsoft.AdaptiveDialog",
+        "id": "planningTest",
+        "triggers": [
+            {
+                "$kind": "Microsoft.OnUnknownIntent",
+                "actions": [
+                    {
+                        "$kind": "Teams.SendMESelectItemResponse",
+                        "card": {
+                            "type": "message",
+                            "attachments": [
+                                {
+                                    "contentType": "application/vnd.microsoft.card.thumbnail",
+                                    "content": {
+                                        "title": "card-title"
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        ]
+    },
+    "script": [
+        {
+            "$kind": "Microsoft.Test.UserActivity",
+            "activity": {
+                "type": "message",
+                "text": "hi",
+                "name": "composeExtension/queryLink"
+            }
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReplyActivity",
+          "assertions": [
+            "type == 'invokeResponse'",
+            "conversation.id == 'Action_SendMESelectItemResponse'",
+            "value.body.composeExtension.type == 'result'",
+            "value.body.composeExtension.attachmentLayout == 'list'",
+            "value.body.composeExtension.attachments[0].contentType == 'application/vnd.microsoft.card.thumbnail'",
+            "value.body.composeExtension.attachments[0].content.title == 'card-title'"
+          ]
+        }
+    ]
+}

--- a/tests/unit/packages/Microsoft.Bot.Components.Teams.Tests/Tests/ActionTests/Action_SendMESelectItemResponseError.test.dialog
+++ b/tests/unit/packages/Microsoft.Bot.Components.Teams.Tests/Tests/ActionTests/Action_SendMESelectItemResponseError.test.dialog
@@ -1,0 +1,79 @@
+{
+    "$schema": "../../../tests.schema",
+    "$kind": "Microsoft.Test.Script",
+    "dialog": {
+        "$kind": "Microsoft.AdaptiveDialog",
+        "id": "planningTest",
+        "recognizer": {
+            "$kind": "Microsoft.RegexRecognizer",
+            "intents": [
+                {
+                    "intent": "NoCard",
+                    "pattern": "NoCard"
+                },
+                {
+                    "intent": "NoAttachments",
+                    "pattern": "NoAttachments"
+                }
+            ]
+        },
+        "triggers": [
+            {
+                "$kind": "Microsoft.OnIntent",
+                "intent": "NoCard",
+                "actions": [
+                    {
+                        "$kind": "Teams.SendMESelectItemResponse"
+                    }
+                ]
+            },
+            {
+                "$kind": "Microsoft.OnIntent",
+                "intent": "NoAttachments",
+                "actions": [
+                    {
+                        "$kind": "Teams.SendMESelectItemResponse",
+                        "card": {
+                            "type": "message"
+                        }
+                    }
+                ]
+            },
+            {
+                "$kind": "Microsoft.OnError",
+                "actions": [
+                    {
+                        "$kind": "Microsoft.SendActivity",
+                        "activity": "${turn.dialogEvent.value.message}"
+                    }
+                ]
+            }
+        ]
+    },
+    "script": [
+        {
+            "$kind": "Microsoft.Test.UserActivity",
+            "activity": {
+                "type": "message",
+                "text": "NoCard",
+                "name": "composeExtension/queryLink"
+            }
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "A valid card is required for Teams.SendMESelectItemResponse."
+        },
+        {
+            "$kind": "Microsoft.Test.UserActivity",
+            "activity": {
+                "type": "message",
+                "text": "NoAttachments",
+                "name": "composeExtension/queryLink"
+            }
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "Invalid activity. An attachment is required for Teams.SendMESelectItemResponse."
+        }
+    ]
+}

--- a/tests/unit/packages/Microsoft.Bot.Components.Teams.Tests/Tests/ActionTests/Action_SendMessageToTeamsChannel.test.dialog
+++ b/tests/unit/packages/Microsoft.Bot.Components.Teams.Tests/Tests/ActionTests/Action_SendMessageToTeamsChannel.test.dialog
@@ -1,0 +1,63 @@
+{
+    "$schema": "../../../tests.schema",
+    "$kind": "Microsoft.Test.Script",
+    "dialog": {
+        "$kind": "Microsoft.AdaptiveDialog",
+        "id": "planningTest",
+        "triggers": [
+            {
+                "$kind": "Microsoft.OnUnknownIntent",
+                "actions": [
+                    {
+                        "$kind": "Teams.SendMessageToTeamsChannel",
+                        "conversationReferenceProperty": "conversation.result",
+                        "activity": {
+                            "type": "message",
+                            "text": "This is a message to a Teams Channel"
+                        }
+                    },
+                    {
+                        "$kind": "Teams.SendMessageToTeamsChannel",
+                        "conversationReferenceProperty": "conversation.resultWithCustomProperties",
+                        "activity": {
+                            "type": "message",
+                            "text": "This is a message to a Teams Channel with custom properties"
+                        },
+                        "teamsChannelId": "customTeamsChannel"
+                    }
+                ]
+            }
+        ]
+    },
+    "script": [
+        {
+            "$kind": "Microsoft.Test.UserActivity",
+            "activity": {
+                "type": "message",
+                "text": "hi",
+                "channelData": {
+                    "channel": {
+                        "id": "fakeTeamsChannelToSendTo"
+                    }
+                }
+            }
+        },
+        {
+            "$kind": "Microsoft.Test.MemoryAssertions",
+            "assertions": [
+                "conversation.result.activityId == '0'",
+                "conversation.result.channelId == 'msteams'",
+                "conversation.result.conversation.conversationType == 'groupChat'",
+                "conversation.result.conversation.isGroup == true",
+                "conversation.result.conversation.name == 'group'",
+                "conversation.result.conversation.tenantId == 'tenantId-Guid'",
+                "conversation.resultWithCustomProperties.activityId == '0'",
+                "conversation.resultWithCustomProperties.channelId == 'msteams'",
+                "conversation.resultWithCustomProperties.conversation.conversationType == 'groupChat'",
+                "conversation.resultWithCustomProperties.conversation.isGroup == true",
+                "conversation.resultWithCustomProperties.conversation.name == 'group'",
+                "conversation.resultWithCustomProperties.conversation.tenantId == 'tenantId-Guid'"
+            ]
+        }
+    ]
+}

--- a/tests/unit/packages/Microsoft.Bot.Components.Teams.Tests/Tests/ActionTests/Action_SendMessageToTeamsChannelError.test.dialog
+++ b/tests/unit/packages/Microsoft.Bot.Components.Teams.Tests/Tests/ActionTests/Action_SendMessageToTeamsChannelError.test.dialog
@@ -1,0 +1,37 @@
+{
+    "$schema": "../../../tests.schema",
+    "$kind": "Microsoft.Test.Script",
+    "dialog": {
+        "$kind": "Microsoft.AdaptiveDialog",
+        "id": "planningTest",
+        "triggers": [
+            {
+                "$kind": "Microsoft.OnUnknownIntent",
+                "actions": [
+                    {
+                        "$kind": "Teams.SendMessageToTeamsChannel"
+                    }
+                ]
+            },
+            {
+                "$kind": "Microsoft.OnError",
+                "actions": [
+                    {
+                        "$kind": "Microsoft.SendActivity",
+                        "activity": "${turn.dialogEvent.value.message}"
+                    }
+                ]
+            }
+        ]
+    },
+    "script": [
+        {
+            "$kind": "Microsoft.Test.UserSays",
+            "text": "hi"
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "Teams.SendMessageToTeamsChannel works only on the Teams channel."
+        }
+    ]
+}

--- a/tests/unit/packages/Microsoft.Bot.Components.Teams.Tests/Tests/ActionTests/Action_SendTabAuthResponseError.test.dialog
+++ b/tests/unit/packages/Microsoft.Bot.Components.Teams.Tests/Tests/ActionTests/Action_SendTabAuthResponseError.test.dialog
@@ -1,0 +1,43 @@
+{
+    "$schema": "../../../tests.schema",
+    "$kind": "Microsoft.Test.Script",
+    "dialog": {
+        "$kind": "Microsoft.AdaptiveDialog",
+        "id": "planningTest",
+        "triggers": [
+            {
+                "$kind": "Microsoft.OnUnknownIntent",
+                "actions": [
+                    {
+                        "$kind": "Teams.SendTabAuthResponse",
+                        "connectionName": "someConnection",
+                        "title": "someTitle"
+                    }
+                ]
+            },
+            {
+                "$kind": "Microsoft.OnError",
+                "actions": [
+                    {
+                        "$kind": "Microsoft.SendActivity",
+                        "activity": "${turn.dialogEvent.value.message}"
+                    }
+                ]
+            }
+        ]
+    },
+    "script": [
+        {
+            "$kind": "Microsoft.Test.UserActivity",
+            "activity": {
+                "type": "message",
+                "text": "NoConnectionName",
+                "name": "composeExtension/queryLink"
+            }
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "Teams.SendTabAuthResponse: not supported by the current adapter."
+        }
+    ]
+}

--- a/tests/unit/packages/Microsoft.Bot.Components.Teams.Tests/Tests/ActionTests/Action_SendTabAuthResponseErrorWithAdapter.test.dialog
+++ b/tests/unit/packages/Microsoft.Bot.Components.Teams.Tests/Tests/ActionTests/Action_SendTabAuthResponseErrorWithAdapter.test.dialog
@@ -1,0 +1,88 @@
+{
+    "$schema": "../../../tests.schema",
+    "$kind": "Microsoft.Test.Script",
+    "dialog": {
+        "$kind": "Microsoft.AdaptiveDialog",
+        "id": "planningTest",
+        "recognizer": {
+            "$kind": "Microsoft.RegexRecognizer",
+            "intents": [
+                {
+                    "intent": "NoConnectionName",
+                    "pattern": "NoConnectionName"
+                },
+                {
+                    "intent": "NoTitle",
+                    "pattern": "NoTitle"
+                }
+            ]
+        },
+        "triggers": [
+            {
+                "$kind": "Microsoft.OnIntent",
+                "intent": "NoConnectionName",
+                "actions": [
+                    {
+                        "$kind": "Teams.SendTabAuthResponse",
+                        "connectionName": "=turn.channelData.DoesNotExist"
+                    }
+                ]
+            },
+            {
+                "$kind": "Microsoft.OnIntent",
+                "intent": "NoTitle",
+                "actions": [
+                    {
+                        "$kind": "Teams.SendTabAuthResponse",
+                        "connectionName": "testConnection",
+                        "title": "=turn.channelData.doesNotExist"
+                    }
+                ]
+            },
+            {
+                "$kind": "Microsoft.OnIntent",
+                "intent": "NoAttachments",
+                "actions": [
+                    {
+                        "$kind": "Teams.SendTabAuthResponse"
+                    }
+                ]
+            },
+            {
+                "$kind": "Microsoft.OnError",
+                "actions": [
+                    {
+                        "$kind": "Microsoft.SendActivity",
+                        "activity": "${turn.dialogEvent.value.message}"
+                    }
+                ]
+            }
+        ]
+    },
+    "script": [
+        {
+            "$kind": "Microsoft.Test.UserActivity",
+            "activity": {
+                "type": "message",
+                "text": "NoConnectionName",
+                "name": "tab/fetch"
+            }
+        },
+        {
+          "$kind": "Microsoft.Test.AssertReply",
+          "text": "A valid ConnectionName is required for auth responses."
+        },
+        {
+            "$kind": "Microsoft.Test.UserActivity",
+            "activity": {
+                "type": "message",
+                "text": "NoTitle",
+                "name": "tab/fetch"
+            }
+        },
+        {
+          "$kind": "Microsoft.Test.AssertReply",
+          "text": "A valid Title is required for auth responses."
+        }
+    ]
+}

--- a/tests/unit/packages/Microsoft.Bot.Components.Teams.Tests/Tests/ActionTests/Action_SendTabCardResponse.test.dialog
+++ b/tests/unit/packages/Microsoft.Bot.Components.Teams.Tests/Tests/ActionTests/Action_SendTabCardResponse.test.dialog
@@ -1,0 +1,66 @@
+{
+    "$schema": "../../../tests.schema",
+    "$kind": "Microsoft.Test.Script",
+    "dialog": {
+        "$kind": "Microsoft.AdaptiveDialog",
+        "id": "planningTest",
+        "triggers": [
+            {
+                "$kind": "Microsoft.OnUnknownIntent",
+                "actions": [
+                    {
+                        "$kind": "Teams.SendTabCardResponse",
+                        "cards": {
+                            "type": "message",
+                            "attachments": [
+                                {
+                                    "contentType": "application/vnd.microsoft.card.adaptive",
+                                    "content": {
+                                      "type": "AdaptiveCard",
+                                      "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+                                      "version": "1.2",
+                                      "body": [
+                                        {
+                                          "type": "Container",
+                                          "items": [
+                                            {
+                                              "type": "RichTextBlock",
+                                              "inlines": [
+                                                {
+                                                  "type": "TextRun",
+                                                  "text": "Success!"
+                                                }
+                                              ]
+                                            }
+                                          ]
+                                        }
+                                      ]
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        ]
+    },
+    "script": [
+        {
+            "$kind": "Microsoft.Test.UserActivity",
+            "activity": {
+                "type": "message",
+                "text": "hi",
+                "name": "tab/fetch"
+            }
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReplyActivity",
+          "assertions": [
+            "type == 'invokeResponse'",
+            "conversation.id == 'Action_SendTabCardResponse'",
+            "value.body.tab.type == 'continue'",
+            "value.body.tab.value.cards[0].card.body[0].items[0].inlines[0].text == 'Success!'"
+          ]
+        }
+    ]
+}

--- a/tests/unit/packages/Microsoft.Bot.Components.Teams.Tests/Tests/ActionTests/Action_SendTabCardResponseError.test.dialog
+++ b/tests/unit/packages/Microsoft.Bot.Components.Teams.Tests/Tests/ActionTests/Action_SendTabCardResponseError.test.dialog
@@ -1,0 +1,79 @@
+{
+    "$schema": "../../../tests.schema",
+    "$kind": "Microsoft.Test.Script",
+    "dialog": {
+        "$kind": "Microsoft.AdaptiveDialog",
+        "id": "planningTest",
+        "recognizer": {
+            "$kind": "Microsoft.RegexRecognizer",
+            "intents": [
+                {
+                    "intent": "NoCard",
+                    "pattern": "NoCard"
+                },
+                {
+                    "intent": "NoAttachments",
+                    "pattern": "NoAttachments"
+                }
+            ]
+        },
+        "triggers": [
+            {
+                "$kind": "Microsoft.OnIntent",
+                "intent": "NoCard",
+                "actions": [
+                    {
+                        "$kind": "Teams.SendTabCardResponse"
+                    }
+                ]
+            },
+            {
+                "$kind": "Microsoft.OnIntent",
+                "intent": "NoAttachments",
+                "actions": [
+                    {
+                        "$kind": "Teams.SendTabCardResponse",
+                        "cards": {
+                            
+                        }
+                    }
+                ]
+            },
+            {
+                "$kind": "Microsoft.OnError",
+                "actions": [
+                    {
+                        "$kind": "Microsoft.SendActivity",
+                        "activity": "${turn.dialogEvent.value.message}"
+                    }
+                ]
+            }
+        ]
+    },
+    "script": [
+        {
+            "$kind": "Microsoft.Test.UserActivity",
+            "activity": {
+                "type": "message",
+                "text": "NoCard",
+                "name": "tab/fetch"
+            }
+        },
+        {
+          "$kind": "Microsoft.Test.AssertReply",
+          "text": "Valid Cards are required for Teams.SendTabCardResponse."
+        },
+        {
+            "$kind": "Microsoft.Test.UserActivity",
+            "activity": {
+                "type": "message",
+                "text": "NoAttachments",
+                "name": "tab/fetch"
+            }
+        },
+        {
+          "$kind": "Microsoft.Test.AssertReply",
+          "text": "Invalid activity. Attachment(s) are required for Teams.SendTabCardResponse."
+        }
+    ]
+}

--- a/tests/unit/packages/Microsoft.Bot.Components.Teams.Tests/Tests/ActionTests/Action_SendTaskModuleCardResponse.test.dialog
+++ b/tests/unit/packages/Microsoft.Bot.Components.Teams.Tests/Tests/ActionTests/Action_SendTaskModuleCardResponse.test.dialog
@@ -1,0 +1,56 @@
+{
+    "$schema": "../../../tests.schema",
+    "$kind": "Microsoft.Test.Script",
+    "dialog": {
+        "$kind": "Microsoft.AdaptiveDialog",
+        "id": "planningTest",
+        "triggers": [
+            {
+                "$kind": "Microsoft.OnUnknownIntent",
+                "actions": [
+                    {
+                        "$kind": "Teams.SendTaskModuleCardResponse",
+                        "title": "some title",
+                        "height": 1,
+                        "width": 2,
+                        "completionBotId": "someBotId",
+                        "card": {
+                            "type": "message",
+                            "attachments": [
+                                {
+                                    "contentType": "application/vnd.microsoft.card.thumbnail",
+                                    "content": {
+                                        "title": "card-title"
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                ]
+            }
+        ]
+    },
+    "script": [
+        {
+            "$kind": "Microsoft.Test.UserActivity",
+            "activity": {
+                "type": "message",
+                "text": "hi",
+                "name": "composeExtension/queryLink"
+            }
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReplyActivity",
+          "assertions": [
+            "type == 'invokeResponse'",
+            "conversation.id == 'Action_SendTaskModuleCardResponse'",
+            "value.body.task.value.completionBotId == 'someBotId'",
+            "value.body.task.value.height == 1",
+            "value.body.task.value.title == 'some title'",
+            "value.body.task.value.width == 2",
+            "value.body.task.value.card.contentType == 'application/vnd.microsoft.card.thumbnail'",
+            "value.body.task.value.card.content.title == 'card-title'"
+          ]
+        }
+    ]
+}

--- a/tests/unit/packages/Microsoft.Bot.Components.Teams.Tests/Tests/ActionTests/Action_SendTaskModuleCardResponseError.test.dialog
+++ b/tests/unit/packages/Microsoft.Bot.Components.Teams.Tests/Tests/ActionTests/Action_SendTaskModuleCardResponseError.test.dialog
@@ -1,0 +1,79 @@
+{
+    "$schema": "../../../tests.schema",
+    "$kind": "Microsoft.Test.Script",
+    "dialog": {
+        "$kind": "Microsoft.AdaptiveDialog",
+        "id": "planningTest",
+        "recognizer": {
+            "$kind": "Microsoft.RegexRecognizer",
+            "intents": [
+                {
+                    "intent": "NoCard",
+                    "pattern": "NoCard"
+                },
+                {
+                    "intent": "NoAttachments",
+                    "pattern": "NoAttachments"
+                }
+            ]
+        },
+        "triggers": [
+            {
+                "$kind": "Microsoft.OnIntent",
+                "intent": "NoCard",
+                "actions": [
+                    {
+                        "$kind": "Teams.SendTaskModuleCardResponse"
+                    }
+                ]
+            },
+            {
+                "$kind": "Microsoft.OnIntent",
+                "intent": "NoAttachments",
+                "actions": [
+                    {
+                        "$kind": "Teams.SendTaskModuleCardResponse",
+                        "card": {
+                            "type": "message"
+                        }
+                    }
+                ]
+            },
+            {
+                "$kind": "Microsoft.OnError",
+                "actions": [
+                    {
+                        "$kind": "Microsoft.SendActivity",
+                        "activity": "${turn.dialogEvent.value.message}"
+                    }
+                ]
+            }
+        ]
+    },
+    "script": [
+        {
+            "$kind": "Microsoft.Test.UserActivity",
+            "activity": {
+                "type": "message",
+                "text": "NoCard",
+                "name": "composeExtension/queryLink"
+            }
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "A valid Card is required for Teams.SendTaskModuleCardResponse."
+        },
+        {
+            "$kind": "Microsoft.Test.UserActivity",
+            "activity": {
+                "type": "message",
+                "text": "NoAttachments",
+                "name": "composeExtension/queryLink"
+            }
+        },
+        {
+          "$kind": "Microsoft.Test.AssertReply",
+          "text": "Invalid activity. An attachment is required for Teams.SendTaskModuleCardResponse."
+        }
+    ]
+}

--- a/tests/unit/packages/Microsoft.Bot.Components.Teams.Tests/Tests/ActionTests/Action_SendTaskModuleMessageResponse.test.dialog
+++ b/tests/unit/packages/Microsoft.Bot.Components.Teams.Tests/Tests/ActionTests/Action_SendTaskModuleMessageResponse.test.dialog
@@ -1,0 +1,37 @@
+{
+    "$schema": "../../../tests.schema",
+    "$kind": "Microsoft.Test.Script",
+    "dialog": {
+        "$kind": "Microsoft.AdaptiveDialog",
+        "id": "planningTest",
+        "triggers": [
+            {
+                "$kind": "Microsoft.OnUnknownIntent",
+                "actions": [
+                    {
+                        "$kind": "Teams.SendTaskModuleMessageResponse",
+                        "message": "i want to send this to the user"
+                    }
+                ]
+            }
+        ]
+    },
+    "script": [
+        {
+            "$kind": "Microsoft.Test.UserActivity",
+            "activity": {
+                "type": "message",
+                "text": "hi",
+                "name": "composeExtension/queryLink"
+            }
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReplyActivity",
+            "assertions": [
+                "type == 'invokeResponse'",
+                "conversation.id == 'Action_SendTaskModuleMessageResponse'",
+                "value.body.task.value == 'i want to send this to the user'"
+            ]
+        }
+    ]
+}

--- a/tests/unit/packages/Microsoft.Bot.Components.Teams.Tests/Tests/ActionTests/Action_SendTaskModuleUrlResponse.test.dialog
+++ b/tests/unit/packages/Microsoft.Bot.Components.Teams.Tests/Tests/ActionTests/Action_SendTaskModuleUrlResponse.test.dialog
@@ -1,0 +1,47 @@
+{
+    "$schema": "../../../tests.schema",
+    "$kind": "Microsoft.Test.Script",
+    "dialog": {
+        "$kind": "Microsoft.AdaptiveDialog",
+        "id": "planningTest",
+        "triggers": [
+            {
+                "$kind": "Microsoft.OnUnknownIntent",
+                "actions": [
+                    {
+                        "$kind": "Teams.SendTaskModuleUrlResponse",
+                        "title": "some title",
+                        "height": 1,
+                        "width": 2,
+                        "completionBotId": "someBotId",
+                        "url": "http://thisIsTheMainUrl.com",
+                        "fallbackUrl": "http://thisIsTheFallbackUrl.net/okay/falling/back_now"
+                    }
+                ]
+            }
+        ]
+    },
+    "script": [
+        {
+            "$kind": "Microsoft.Test.UserActivity",
+            "activity": {
+                "type": "message",
+                "text": "hi",
+                "name": "composeExtension/queryLink"
+            }
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReplyActivity",
+            "assertions": [
+                "type == 'invokeResponse'",
+                "conversation.id == 'Action_SendTaskModuleUrlResponse'",
+                "value.body.task.value.completionBotId == 'someBotId'",
+                "value.body.task.value.height == 1",
+                "value.body.task.value.title == 'some title'",
+                "value.body.task.value.width == 2",
+                "value.body.task.value.url == 'http://thisIsTheMainUrl.com'",
+                "value.body.task.value.fallbackUrl == 'http://thisIsTheFallbackUrl.net/okay/falling/back_now'"
+            ]
+        }
+    ]
+}

--- a/tests/unit/packages/Microsoft.Bot.Components.Teams.Tests/Tests/ActionTests/Action_SendTaskModuleUrlResponseError.test.dialog
+++ b/tests/unit/packages/Microsoft.Bot.Components.Teams.Tests/Tests/ActionTests/Action_SendTaskModuleUrlResponseError.test.dialog
@@ -1,0 +1,42 @@
+{
+    "$schema": "../../../tests.schema",
+    "$kind": "Microsoft.Test.Script",
+    "dialog": {
+        "$kind": "Microsoft.AdaptiveDialog",
+        "id": "planningTest",
+        "triggers": [
+            {
+                "$kind": "Microsoft.OnUnknownIntent",
+                "actions": [
+                    {
+                        "$kind": "Teams.SendTaskModuleUrlResponse",
+                        "url": "=turn.channelData.doesNotExist"
+                    }
+                ]
+            },
+            {
+                "$kind": "Microsoft.OnError",
+                "actions": [
+                    {
+                        "$kind": "Microsoft.SendActivity",
+                        "activity": "${turn.dialogEvent.value.message}"
+                    }
+                ]
+            }
+        ]
+    },
+    "script": [
+        {
+            "$kind": "Microsoft.Test.UserActivity",
+            "activity": {
+                "type": "message",
+                "text": "hi",
+                "name": "composeExtension/queryLink"
+            }
+        },
+        {
+            "$kind": "Microsoft.Test.AssertReply",
+            "text": "Missing Url for Teams.SendTaskModuleUrlResponse."
+        }
+    ]
+}

--- a/tests/unit/packages/Microsoft.Bot.Components.Teams.Tests/Tests/ConditionalTests/ConditionalsTests_OnTeamsActivityTypes.test.dialog
+++ b/tests/unit/packages/Microsoft.Bot.Components.Teams.Tests/Tests/ConditionalTests/ConditionalsTests_OnTeamsActivityTypes.test.dialog
@@ -1,0 +1,616 @@
+{
+  "$schema": "../../../tests.schema",
+  "$kind": "Microsoft.Test.Script",
+  "dialog": {
+    "$kind": "Microsoft.AdaptiveDialog",
+    "id": "planningTest",
+    "triggers": [
+      {
+        "$kind": "Microsoft.OnInvokeActivity",
+        "actions": [
+          {
+            "$kind": "Microsoft.SendActivity",
+            "activity": "${turn.activity.text}"
+          }
+        ]
+      },
+      {
+        "$kind": "Microsoft.OnConversationUpdateActivity",
+        "actions": [
+          {
+            "$kind": "Microsoft.SendActivity",
+            "activity": "${turn.activity.text}"
+          }
+        ]
+      },
+      {
+        "$kind": "Teams.OnAppBasedLinkQuery",
+        "condition": "turn.activity.text == 'OnAppBasedLinkQuery'",
+        "actions": [
+          {
+            "$kind": "Microsoft.SendActivity",
+            "activity": "OnAppBasedLinkQuery"
+          }
+        ]
+      },
+      {
+        "$kind": "Teams.OnCardAction",
+        "condition": "turn.activity.text == 'OnCardAction'",
+        "actions": [
+          {
+            "$kind": "Microsoft.SendActivity",
+            "activity": "OnCardAction"
+          }
+        ]
+      },
+      {
+        "$kind": "Teams.OnChannelCreated",
+        "condition": "turn.activity.text == 'OnChannelCreated'",
+        "actions": [
+          {
+            "$kind": "Microsoft.SendActivity",
+            "activity": "OnChannelCreated"
+          }
+        ]
+      },
+      {
+        "$kind": "Teams.OnChannelDeleted",
+        "condition": "turn.activity.text == 'OnChannelDeleted'",
+        "actions": [
+          {
+            "$kind": "Microsoft.SendActivity",
+            "activity": "OnChannelDeleted"
+          }
+        ]
+      },
+      {
+        "$kind": "Teams.OnChannelRenamed",
+        "condition": "turn.activity.text == 'OnChannelRenamed'",
+        "actions": [
+          {
+            "$kind": "Microsoft.SendActivity",
+            "activity": "OnChannelRenamed"
+          }
+        ]
+      },
+      {
+        "$kind": "Teams.OnChannelRestored",
+        "condition": "turn.activity.text == 'OnChannelRestored'",
+        "actions": [
+          {
+            "$kind": "Microsoft.SendActivity",
+            "activity": "OnChannelRestored"
+          }
+        ]
+      },
+      {
+        "$kind": "Teams.OnFileConsent",
+        "condition": "turn.activity.text == 'OnFileConsent'",
+        "actions": [
+          {
+            "$kind": "Microsoft.SendActivity",
+            "activity": "OnFileConsent"
+          }
+        ]
+      },
+      {
+        "$kind": "Teams.OnMECardButtonClicked",
+        "condition": "turn.activity.text == 'OnCardButtonClicked'",
+        "actions": [
+          {
+            "$kind": "Microsoft.SendActivity",
+            "activity": "OnCardButtonClicked"
+          }
+        ]
+      },
+      {
+        "$kind": "Teams.OnMEConfigQuerySettingUrl",
+        "condition": "turn.activity.text == 'OnConfigurationQuerySettingUrl'",
+        "actions": [
+          {
+            "$kind": "Microsoft.SendActivity",
+            "activity": "OnConfigurationQuerySettingUrl"
+          }
+        ]
+      },
+      {
+        "$kind": "Teams.OnMEConfigSetting",
+        "condition": "turn.activity.text == 'OnConfigurationSetting'",
+        "actions": [
+          {
+            "$kind": "Microsoft.SendActivity",
+            "activity": "OnConfigurationSetting"
+          }
+        ]
+      },
+      {
+        "$kind": "Teams.OnMEFetchTask",
+        "condition": "turn.activity.text == 'OnFetchTask'",
+        "actions": [
+          {
+            "$kind": "Microsoft.SendActivity",
+            "activity": "OnFetchTask"
+          }
+        ]
+      },
+      {
+        "$kind": "Teams.OnMEQuery",
+        "condition": "turn.activity.text == 'OnQuery'",
+        "actions": [
+          {
+            "$kind": "Microsoft.SendActivity",
+            "activity": "OnQuery"
+          }
+        ]
+      },
+      {
+        "$kind": "Teams.OnMESelectItem",
+        "condition": "turn.activity.text == 'OnSelectItem'",
+        "actions": [
+          {
+            "$kind": "Microsoft.SendActivity",
+            "activity": "OnSelectItem"
+          }
+        ]
+      },
+      {
+        "$kind": "Teams.OnMESubmitAction",
+        "condition": "turn.activity.text == 'OnSubmitAction'",
+        "actions": [
+          {
+            "$kind": "Microsoft.SendActivity",
+            "activity": "OnSubmitAction"
+          }
+        ]
+      },
+      {
+        "$kind": "Teams.OnO365ConnectorCardAction",
+        "condition": "turn.activity.text == 'OnO365ConnectorCardAction'",
+        "actions": [
+          {
+            "$kind": "Microsoft.SendActivity",
+            "activity": "OnO365ConnectorCardAction"
+          }
+        ]
+      },
+      {
+        "$kind": "Teams.OnTaskModuleFetch",
+        "condition": "turn.activity.text == 'OnTaskModuleFetch'",
+        "actions": [
+          {
+            "$kind": "Microsoft.SendActivity",
+            "activity": "OnTaskModuleFetch"
+          }
+        ]
+      },
+      {
+        "$kind": "Teams.OnTabFetch",
+        "condition": "turn.activity.text == 'OnTabFetch'",
+        "actions": [
+          {
+            "$kind": "Microsoft.SendActivity",
+            "activity": "OnTabFetch"
+          }
+        ]
+      },
+      {
+        "$kind": "Teams.OnTaskModuleSubmit",
+        "condition": "turn.activity.text == 'OnTaskModuleSubmit'",
+        "actions": [
+          {
+            "$kind": "Microsoft.SendActivity",
+            "activity": "OnTaskModuleSubmit"
+          }
+        ]
+      },
+      {
+        "$kind": "Teams.OnTabSubmit",
+        "condition": "turn.activity.text == 'OnTabSubmit'",
+        "actions": [
+          {
+            "$kind": "Microsoft.SendActivity",
+            "activity": "OnTabSubmit"
+          }
+        ]
+      },
+      {
+        "$kind": "Teams.OnTeamArchived",
+        "condition": "turn.activity.text == 'OnTeamArchived'",
+        "actions": [
+          {
+            "$kind": "Microsoft.SendActivity",
+            "activity": "OnTeamArchived"
+          }
+        ]
+      },
+      {
+        "$kind": "Teams.OnTeamDeleted",
+        "condition": "turn.activity.text == 'OnTeamDeleted'",
+        "actions": [
+          {
+            "$kind": "Microsoft.SendActivity",
+            "activity": "OnTeamDeleted"
+          }
+        ]
+      },
+      {
+        "$kind": "Teams.OnTeamHardDeleted",
+        "condition": "turn.activity.text == 'OnTeamHardDeleted'",
+        "actions": [
+          {
+            "$kind": "Microsoft.SendActivity",
+            "activity": "OnTeamHardDeleted"
+          }
+        ]
+      },
+      {
+        "$kind": "Teams.OnTeamRenamed",
+        "condition": "turn.activity.text == 'OnTeamRenamed'",
+        "actions": [
+          {
+            "$kind": "Microsoft.SendActivity",
+            "activity": "OnTeamRenamed"
+          }
+        ]
+      },
+      {
+        "$kind": "Teams.OnTeamRestored",
+        "condition": "turn.activity.text == 'OnTeamRestored'",
+        "actions": [
+          {
+            "$kind": "Microsoft.SendActivity",
+            "activity": "OnTeamRestored"
+          }
+        ]
+      },
+      {
+        "$kind": "Teams.OnTeamUnarchived",
+        "condition": "turn.activity.text == 'OnTeamUnarchived'",
+        "actions": [
+          {
+            "$kind": "Microsoft.SendActivity",
+            "activity": "OnTeamUnarchived"
+          }
+        ]
+      }
+    ],
+    "autoEndDialog": false,
+    "defaultResultProperty": "dialog.result"
+  },
+  "script": [
+    {
+      "$kind": "Microsoft.Test.UserActivity",
+      "activity": {
+        "type": "invoke",
+        "text": "OnAppBasedLinkQuery",
+        "value": {},
+        "name": "composeExtension/queryLink"
+      }
+    },
+    {
+      "$kind": "Microsoft.Test.AssertReply",
+      "text": "OnAppBasedLinkQuery"
+    },
+    {
+      "$kind": "Microsoft.Test.UserActivity",
+      "activity": {
+        "type": "invoke",
+        "text": "OnCardAction",
+        "value": {}
+      }
+    },
+    {
+      "$kind": "Microsoft.Test.AssertReply",
+      "text": "OnCardAction"
+    },
+    {
+      "$kind": "Microsoft.Test.UserActivity",
+      "activity": {
+        "type": "conversationUpdate",
+        "text": "OnChannelCreated",
+        "channelData": {
+          "eventType": "channelCreated"
+        }
+      }
+    },
+    {
+      "$kind": "Microsoft.Test.AssertReply",
+      "text": "OnChannelCreated"
+    },
+    {
+      "$kind": "Microsoft.Test.UserActivity",
+      "activity": {
+        "type": "conversationUpdate",
+        "text": "OnChannelDeleted",
+        "channelData": {
+          "eventType": "channelDeleted"
+        }
+      }
+    },
+    {
+      "$kind": "Microsoft.Test.AssertReply",
+      "text": "OnChannelDeleted"
+    },
+    {
+      "$kind": "Microsoft.Test.UserActivity",
+      "activity": {
+        "type": "conversationUpdate",
+        "text": "OnChannelRenamed",
+        "channelData": {
+          "eventType": "channelRenamed"
+        }
+      }
+    },
+    {
+      "$kind": "Microsoft.Test.AssertReply",
+      "text": "OnChannelRenamed"
+    },
+    {
+      "$kind": "Microsoft.Test.UserActivity",
+      "activity": {
+        "type": "conversationUpdate",
+        "text": "OnChannelRestored",
+        "channelData": {
+          "eventType": "channelRestored"
+        }
+      }
+    },
+    {
+      "$kind": "Microsoft.Test.AssertReply",
+      "text": "OnChannelRestored"
+    },
+    {
+      "$kind": "Microsoft.Test.UserActivity",
+      "activity": {
+        "type": "invoke",
+        "text": "OnFileConsent",
+        "value": {},
+        "name": "fileConsent/invoke"
+      }
+    },
+    {
+      "$kind": "Microsoft.Test.AssertReply",
+      "text": "OnFileConsent"
+    },
+    {
+      "$kind": "Microsoft.Test.UserActivity",
+      "activity": {
+        "type": "invoke",
+        "text": "OnCardButtonClicked",
+        "value": {},
+        "name": "composeExtension/onCardButtonClicked"
+      }
+    },
+    {
+      "$kind": "Microsoft.Test.AssertReply",
+      "text": "OnCardButtonClicked"
+    },
+    {
+      "$kind": "Microsoft.Test.UserActivity",
+      "activity": {
+        "type": "invoke",
+        "text": "OnConfigurationQuerySettingUrl",
+        "value": {},
+        "name": "composeExtension/querySettingUrl"
+      }
+    },
+    {
+      "$kind": "Microsoft.Test.AssertReply",
+      "text": "OnConfigurationQuerySettingUrl"
+    },
+    {
+      "$kind": "Microsoft.Test.UserActivity",
+      "activity": {
+        "type": "invoke",
+        "text": "OnConfigurationSetting",
+        "value": {},
+        "name": "composeExtension/setting"
+      }
+    },
+    {
+      "$kind": "Microsoft.Test.AssertReply",
+      "text": "OnConfigurationSetting"
+    },
+    {
+      "$kind": "Microsoft.Test.UserActivity",
+      "activity": {
+        "type": "invoke",
+        "text": "OnFetchTask",
+        "value": {},
+        "name": "composeExtension/fetchTask"
+      }
+    },
+    {
+      "$kind": "Microsoft.Test.AssertReply",
+      "text": "OnFetchTask"
+    },
+    {
+      "$kind": "Microsoft.Test.UserActivity",
+      "activity": {
+        "type": "invoke",
+        "text": "OnQuery",
+        "value": {},
+        "name": "composeExtension/query"
+      }
+    },
+    {
+      "$kind": "Microsoft.Test.AssertReply",
+      "text": "OnQuery"
+    },
+    {
+      "$kind": "Microsoft.Test.UserActivity",
+      "activity": {
+        "type": "invoke",
+        "text": "OnSelectItem",
+        "value": {},
+        "name": "composeExtension/selectItem"
+      }
+    },
+    {
+      "$kind": "Microsoft.Test.AssertReply",
+      "text": "OnSelectItem"
+    },
+    {
+      "$kind": "Microsoft.Test.UserActivity",
+      "activity": {
+        "type": "invoke",
+        "text": "OnSubmitAction",
+        "value": {},
+        "name": "composeExtension/submitAction"
+      }
+    },
+    {
+      "$kind": "Microsoft.Test.AssertReply",
+      "text": "OnSubmitAction"
+    },
+    {
+      "$kind": "Microsoft.Test.UserActivity",
+      "activity": {
+        "type": "invoke",
+        "text": "OnO365ConnectorCardAction",
+        "value": {},
+        "name": "actionableMessage/executeAction"
+      }
+    },
+    {
+      "$kind": "Microsoft.Test.AssertReply",
+      "text": "OnO365ConnectorCardAction"
+    },
+    {
+      "$kind": "Microsoft.Test.UserActivity",
+      "activity": {
+        "type": "invoke",
+        "text": "OnTabFetch",
+        "value": {},
+        "name": "tab/fetch"
+      }
+    },
+    {
+      "$kind": "Microsoft.Test.AssertReply",
+      "text": "OnTabFetch"
+    },
+    {
+      "$kind": "Microsoft.Test.UserActivity",
+      "activity": {
+        "type": "invoke",
+        "text": "OnTaskModuleFetch",
+        "value": {},
+        "name": "task/fetch"
+      }
+    },
+    {
+      "$kind": "Microsoft.Test.AssertReply",
+      "text": "OnTaskModuleFetch"
+    },
+    {
+      "$kind": "Microsoft.Test.UserActivity",
+      "activity": {
+        "type": "invoke",
+        "text": "OnTabSubmit",
+        "value": {},
+        "name": "tab/submit"
+      }
+    },
+    {
+      "$kind": "Microsoft.Test.AssertReply",
+      "text": "OnTabSubmit"
+    },
+    {
+      "$kind": "Microsoft.Test.UserActivity",
+      "activity": {
+        "type": "invoke",
+        "text": "OnTaskModuleSubmit",
+        "value": {},
+        "name": "task/submit"
+      }
+    },
+    {
+      "$kind": "Microsoft.Test.AssertReply",
+      "text": "OnTaskModuleSubmit"
+    },
+    {
+      "$kind": "Microsoft.Test.UserActivity",
+      "activity": {
+        "type": "conversationUpdate",
+        "text": "OnTeamArchived",
+        "channelData": {
+          "eventType": "teamArchived"
+        }
+      }
+    },
+    {
+      "$kind": "Microsoft.Test.AssertReply",
+      "text": "OnTeamArchived"
+    },
+    {
+      "$kind": "Microsoft.Test.UserActivity",
+      "activity": {
+        "type": "conversationUpdate",
+        "text": "OnTeamDeleted",
+        "channelData": {
+          "eventType": "teamDeleted"
+        }
+      }
+    },
+    {
+      "$kind": "Microsoft.Test.AssertReply",
+      "text": "OnTeamDeleted"
+    },
+    {
+      "$kind": "Microsoft.Test.UserActivity",
+      "activity": {
+        "type": "conversationUpdate",
+        "text": "OnTeamHardDeleted",
+        "channelData": {
+          "eventType": "teamHardDeleted"
+        }
+      }
+    },
+    {
+      "$kind": "Microsoft.Test.AssertReply",
+      "text": "OnTeamHardDeleted"
+    },
+    {
+      "$kind": "Microsoft.Test.UserActivity",
+      "activity": {
+        "type": "conversationUpdate",
+        "text": "OnTeamRenamed",
+        "channelData": {
+          "eventType": "teamRenamed"
+        }
+      }
+    },
+    {
+      "$kind": "Microsoft.Test.AssertReply",
+      "text": "OnTeamRenamed"
+    },
+    {
+      "$kind": "Microsoft.Test.UserActivity",
+      "activity": {
+        "type": "conversationUpdate",
+        "text": "OnTeamRestored",
+        "channelData": {
+          "eventType": "teamRestored"
+        }
+      }
+    },
+    {
+      "$kind": "Microsoft.Test.AssertReply",
+      "text": "OnTeamRestored"
+    },
+    {
+      "$kind": "Microsoft.Test.UserActivity",
+      "activity": {
+        "type": "conversationUpdate",
+        "text": "OnTeamUnarchived",
+        "channelData": {
+          "eventType": "teamUnarchived"
+        }
+      }
+    },
+    {
+      "$kind": "Microsoft.Test.AssertReply",
+      "text": "OnTeamUnarchived"
+    }
+  ]
+}


### PR DESCRIPTION
<!-- This repository only accepts pull requests related to open issues, please link the open issue in description below. -->
<!-- See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. -->
<!-- For example - Close #123: Description goes here. -->

### Purpose
<!--What is the context of this pull request? Why is it being done? -->
Revert the Teams package unit tests that were accidentally removed in #1144
