### PR TITLE
feat: functional tests generate empty bots in js

### DIFF
--- a/tests/functional/build/yaml/deployBotResources/deployBotResources.yml
+++ b/tests/functional/build/yaml/deployBotResources/deployBotResources.yml
@@ -153,7 +153,10 @@ stages:
           appId: $(BFCFNEMPTYBOTJSWEBAPPID)
           appSecret: $(BFCFNEMPTYBOTJSWEBAPPSECRET)
           project:
-            directory: 'Tests/Functional/Bots/JavaScript/Consumers/CodeFirst/SimpleHostBot'
+            generator: "generators/generator-bot-empty"
+            integration: "webapp"
+            name: "EmptyBotJSWebApp"
+            platform: "js"
           dependency:
             registry: ${{ parameters.dependenciesRegistryJSHosts }}
             version: ${{ parameters.dependenciesVersionJSHosts }}
@@ -164,7 +167,10 @@ stages:
           appId: $(BFCFNEMPTYBOTJSFUNCTIONSID)
           appSecret: $(BFCFNEMPTYBOTJSFUNCTIONSSECRET)
           project:
-            directory: 'Tests/Functional/Bots/JavaScript/Consumers/CodeFirst/SimpleHostBot'
+            generator: "generators/generator-bot-empty"
+            integration: "functions"
+            name: "EmptyBotJSFunctions"
+            platform: "js"
           dependency:
             registry: ${{ parameters.dependenciesRegistryJSHosts }}
             version: ${{ parameters.dependenciesVersionJSHosts }}

--- a/tests/functional/build/yaml/deployBotResources/dotnet/deploy.yml
+++ b/tests/functional/build/yaml/deployBotResources/dotnet/deploy.yml
@@ -55,7 +55,7 @@ stages:
     jobs:
       - job: "Deploy"
         variables:
-          SolutionDir: "$(BUILD.SOURCESDIRECTORY)/bots/"
+          SolutionDir: "$(BUILD.SOURCESDIRECTORY)/workspace/"
         displayName: "Deploy steps"
         steps:
           # Delete Bot Resources

--- a/tests/functional/build/yaml/deployBotResources/dotnet/evaluateDependenciesVariables.yml
+++ b/tests/functional/build/yaml/deployBotResources/dotnet/evaluateDependenciesVariables.yml
@@ -19,20 +19,17 @@ steps:
       failOnStderr: true
       script: |
         # Get Source
-        $sourceDotNetv3MyGet = "https://botbuilder.myget.org/F/botbuilder-v3-dotnet-daily/api/v3/index.json" 
         $sourceDotNetArtifacts = "https://pkgs.dev.azure.com/ConversationalAI/BotFramework/_packaging/SDK/nuget/v3/index.json" 
         $sourceDotNetMyGet = "https://botbuilder.myget.org/F/botbuilder-v4-dotnet-daily/api/v3/index.json"
         switch -regex ("${{ parameters.registry }}") {
           "^($null|)$" {
             switch ("${{ parameters.botType }}") {
-              "SkillV3" { $source = $sourceDotNetv3MyGet } 
               default { $source = $sourceDotNetArtifacts }
             }
           }
           "Artifacts" { $source = $sourceDotNetArtifacts }
           "MyGet" { 
             switch ("${{ parameters.botType }}") {
-              "SkillV3" { $source = $sourceDotNetv3MyGet } 
               default { $source = $sourceDotNetMyGet }
             }
           }
@@ -53,8 +50,6 @@ steps:
             if ("${{ parameters.botType }}" -in "Host", "Skill") {
               $PackageList = nuget list Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime -Source "$source" -PreRelease
               $versionNumber = $PackageList.Split(" ")[-1]
-            } elseif ("${{ parameters.botType }}" -in "SkillV3") {
-              $versionNumber = ""
             }
           }
           STABLE { $versionNumber = "" }

--- a/tests/functional/build/yaml/deployBotResources/generator/deploy.yml
+++ b/tests/functional/build/yaml/deployBotResources/generator/deploy.yml
@@ -8,7 +8,7 @@ parameters:
     type: string  
 
 steps:
-  # Create /workspace directory
+  # Create /workspace
   - script: |
       mkdir workspace
     displayName: 'Create workspace directory'

--- a/tests/functional/build/yaml/deployBotResources/generator/deploy.yml
+++ b/tests/functional/build/yaml/deployBotResources/generator/deploy.yml
@@ -8,10 +8,10 @@ parameters:
     type: string  
 
 steps:
-  # Create /bots directory
+  # Create /workspace directory
   - script: |
-      mkdir bots
-    displayName: 'Create bots directory'
+      mkdir workspace
+    displayName: 'Create workspace directory'
 
   # Install yarn workspace
   - script: |

--- a/tests/functional/build/yaml/deployBotResources/js/deploy.yml
+++ b/tests/functional/build/yaml/deployBotResources/js/deploy.yml
@@ -134,15 +134,16 @@ stages:
               customRegistries: 'useNpmrc'
               verbose: true
 
-          # Remove web.config generated from template to be able to run "az bot prepare-deploy"
-          - task: PowerShell@2
-            displayName: 'Remove web.config'
-            inputs:
-              targetType: inline
-              workingDirectory: '$(SOLUTIONDIR)/${{ bot.project.name }}'
-              failOnStderr: true
-              script: |
-                Remove-Item .\web.config
+          # Remove web.config generated from webapp template to be able to run "az bot prepare-deploy"
+          - ${{ if eq(bot.project.integration, 'webapp') }}:
+            - task: PowerShell@2
+              displayName: 'Remove web.config'
+              inputs:
+                targetType: inline
+                workingDirectory: '$(SOLUTIONDIR)/${{ bot.project.name }}'
+                failOnStderr: true
+                script: |
+                  Remove-Item .\web.config
 
           # Prepare bot
           - task: AzureCLI@2

--- a/tests/functional/build/yaml/deployBotResources/js/deploy.yml
+++ b/tests/functional/build/yaml/deployBotResources/js/deploy.yml
@@ -54,7 +54,7 @@ stages:
     jobs:
       - job: "Deploy"
         variables:
-          SolutionDir: "$(BUILD.SOURCESDIRECTORY)/bots/"
+          SolutionDir: "$(BUILD.SOURCESDIRECTORY)/workspace/"
         displayName: "Deploy steps"
         steps:
           # Delete Bot Resources

--- a/tests/functional/build/yaml/deployBotResources/js/deploy.yml
+++ b/tests/functional/build/yaml/deployBotResources/js/deploy.yml
@@ -134,7 +134,17 @@ stages:
               customRegistries: 'useNpmrc'
               verbose: true
 
-          # Prepate bot
+          # Remove web.config generated from template to be able to run "az bot prepare-deploy"
+          - task: PowerShell@2
+            displayName: 'Remove web.config'
+            inputs:
+              targetType: inline
+              workingDirectory: '$(SOLUTIONDIR)/${{ bot.project.name }}'
+              failOnStderr: true
+              script: |
+                Remove-Item .\web.config
+
+          # Prepare bot
           - task: AzureCLI@2
             displayName: 'Prepare Bot'
             inputs:

--- a/tests/functional/build/yaml/deployBotResources/js/deploy.yml
+++ b/tests/functional/build/yaml/deployBotResources/js/deploy.yml
@@ -53,6 +53,8 @@ stages:
     dependsOn: "${{ parameters.dependsOn }}"
     jobs:
       - job: "Deploy"
+        variables:
+          SolutionDir: "$(BUILD.SOURCESDIRECTORY)/bots/"
         displayName: "Deploy steps"
         steps:
           # Delete Bot Resources
@@ -72,30 +74,18 @@ stages:
               botName: "${{ bot.name }}"
               keyVault: "${{ parameters.keyVault }}"
 
-          # Prepare .env file, deleting all the declared skills, so it uses only the settings define in Azure
-          - ${{ if eq(bot.type, 'Host') }}:
-            - task: PowerShell@2
-              displayName: 'Prepare .env file'
-              inputs:
-                targetType: inline
-                workingDirectory: '$(SYSTEM.DEFAULTWORKINGDIRECTORY)/${{ bot.project.directory }}'
-                failOnStderr: true
-                script: |
-                  $file = "./.env"
-                  $content = Get-Content $file
-                  $content | ForEach-Object {
-                    $line = $_
-                    if ($line.Trim().Length -gt 0 -and -not $line.Trim().ToLower().StartsWith('skill_')) {
-                      $line
-                    }
-                  } | Set-Content $file;
-
           # Evaluate dependencies source and version
           - template: evaluateDependenciesVariables.yml
             parameters:
               botType: "${{ bot.type }}"
               registry: "${{ bot.dependency.registry }}"
               version: "${{ bot.dependency.version }}"
+
+          # Generate bot template
+          - template: ../generator/deploy.yml
+            parameters:
+              project: "${{ bot.project }}"
+              solutiondir: "$(SOLUTIONDIR)"     
 
           # Tag BotBuilder version
           - template: ../common/tagBotBuilderVersion.yml

--- a/tests/functional/build/yaml/deployBotResources/js/deploy.yml
+++ b/tests/functional/build/yaml/deployBotResources/js/deploy.yml
@@ -101,7 +101,7 @@ stages:
             displayName: 'Set BotBuilder source and version'
             inputs:
               targetType: inline
-              workingDirectory: '$(SYSTEM.DEFAULTWORKINGDIRECTORY)/${{ bot.project.directory }}'
+              workingDirectory: '$(SOLUTIONDIR)/${{ bot.project.name }}'
               failOnStderr: true
               script: |
                 $registry = "$(DEPENDENCIESSOURCE)";
@@ -130,7 +130,7 @@ stages:
             displayName: 'Install dependencies'
             inputs:
               command: 'install'
-              workingDir: '$(SYSTEM.DEFAULTWORKINGDIRECTORY)/${{ bot.project.directory }}'
+              workingDir: '$(SOLUTIONDIR)/${{ bot.project.name }}'
               customRegistries: 'useNpmrc'
               verbose: true
 
@@ -141,13 +141,13 @@ stages:
               azureSubscription: "${{ parameters.azureSubscription }}"
               scriptType: pscore
               scriptLocation: inlineScript
-              inlineScript: 'az bot prepare-deploy --code-dir "${{ bot.project.directory }}" --lang Javascript'
+              inlineScript: 'az bot prepare-deploy --code-dir "$(SOLUTIONDIR)/${{ bot.project.name }}" --lang Javascript'
 
           # Zip bot
           - task: ArchiveFiles@2
             displayName: 'Zip bot'
             inputs:
-              rootFolderOrFile: '$(SYSTEM.DEFAULTWORKINGDIRECTORY)/${{ bot.project.directory }}'
+              rootFolderOrFile: '$(SOLUTIONDIR)/${{ bot.project.name }}'
               includeRootFolder: false
               archiveType: 'zip'
               archiveFile: '$(SYSTEM.DEFAULTWORKINGDIRECTORY)/build/${{ bot.name }}.zip'

--- a/tests/functional/build/yaml/deployBotResources/js/deploy.yml
+++ b/tests/functional/build/yaml/deployBotResources/js/deploy.yml
@@ -206,3 +206,11 @@ stages:
                 botGroup: "${{ parameters.resourceGroup }}"
                 botName: "${{ bot.name }}"
                 resourceSuffix: "${{ parameters.resourceSuffix }}"
+
+          # Debugging output for the workspace
+          - script: |
+              cd ..
+              dir *.* /s
+            displayName: 'Dir workspace'
+            continueOnError: true
+            condition: succeededOrFailed()

--- a/tests/functional/build/yaml/deployBotResources/js/evaluateDependenciesVariables.yml
+++ b/tests/functional/build/yaml/deployBotResources/js/evaluateDependenciesVariables.yml
@@ -20,12 +20,10 @@ steps:
       script: |
         # Get Source
         $sourceJSMyGet = "https://botbuilder.myget.org/F/botbuilder-v4-js-daily/npm/"
-        $sourceJSv3MyGet = "https://botbuilder.myget.org/F/botbuilder-v3-js-daily/npm/"
         $sourceJSNpm = "https://registry.npmjs.com/" 
         switch -regex ("${{ parameters.registry }}") {
           "^($null|MyGet)$" {
             switch ("${{ parameters.botType }}") {
-              "SkillV3" { $source = $sourceJSv3MyGet } 
               default { $source = $sourceJSMyGet }
             }
           }
@@ -54,9 +52,6 @@ steps:
           STABLE { 
             if ("${{ parameters.botType }}" -in "Host", "Skill") {
               $PackageList = npm show botbuilder@* version | Out-String;
-            }
-            elseif ("${{ parameters.botType }}" -in "SkillV3") {
-              $PackageList = npm show botbuilder@3.* version | Out-String;
             }
             $versionNumber = ($PackageList.Split(" ")[-1]).Trim().TrimStart("'").TrimEnd("'");
           }


### PR DESCRIPTION
#1069 #minor
### Purpose
This pull request refactors the skills functional tests to create an Empty Bot from the local genreator-bot-empty in javascript, for both web app and functions integrations.

### Changes
- Updated /deployBotResources.yml
  - Pass parameters used with bot project generators: local generator, name, platform, and integration
- Updated /js/deploy
  - Remove unused steps copied over from skills tests
  - Add steps to deploy a template with the generator
  - Add debugging step 
- Remove additional references to SkillV3 bots (unused) in the JS deploy steps
- Rename the working directory to /workspace to better differentiate when viewing debug output
- 
### Screenshots
**Pipeline passing for all combinations**
![image](https://user-images.githubusercontent.com/43043272/124167423-da565400-da58-11eb-98cc-d2b99a6db3ea.png)

**Web App in Azure greets as expected**
![image](https://user-images.githubusercontent.com/43043272/124168509-19d17000-da5a-11eb-98c6-7eeb8013edaf.png)

### Tests
These are test resources.

### Feature Plan
Follow up with a PR to deploy an Azure Functions App resource, then the Direct Line tests.

