### PR TITLE
fix: Allow previews to generate suffix version as well

### DIFF
--- a/build/yaml/templates/npm-versioning-steps.yml
+++ b/build/yaml/templates/npm-versioning-steps.yml
@@ -13,7 +13,7 @@ steps:
       $deploymentRing = $deploymentRingOverride;
     }
 
-    if ($deploymentRing.ToLowerInvariant() -eq "rc") {
+    if (($deploymentRing.ToLowerInvariant() -eq "rc") -or ($deploymentRing.ToLowerInvariant() -eq "preview")) {
       $releaseCandidateNumber = "$env:RELEASECANDIDATENUMBER";
       "Release Candidate Number = $releaseCandidateNumber";
 


### PR DESCRIPTION
<!-- This repository only accepts pull requests related to open issues, please link the open issue in description below. -->
<!-- See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. -->
<!-- For example - Close #123: Description goes here. -->

### Purpose

Right now only RC gets to name versions RC.0, RC.1, etc. However there is a need for preview package to do it too. Furthermore, there is interdependency in the package such that a dynamically generated version of the package won't work well (because you'd need to check back in the new version number). Need more thoughts but this should help us unblock R14.

### Changes

<!-- Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.) -->

### Tests

<!-- Is this covered by existing tests or new ones? If no, why not? -->

### Feature Plan

<!-- Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues. -->

