### PR TITLE
fix: nuget package version override to allow "preview" ring

### DIFF
--- a/build/yaml/templates/nuget-versioning-steps.yml
+++ b/build/yaml/templates/nuget-versioning-steps.yml
@@ -13,7 +13,7 @@ steps:
       $deploymentRing = $deploymentRingOverride;
     }
 
-    if ($deploymentRing.ToLowerInvariant() -eq "rc") {
+    if (($deploymentRing.ToLowerInvariant() -eq "rc") -or ($deploymentRing.ToLowerInvariant() -eq "preview")) {
       $releaseCandidateNumber = "$env:RELEASECANDIDATENUMBER";
       "Release Candidate Number = $releaseCandidateNumber";
 

--- a/tests/unit/packages/Microsoft.Bot.Components.Teams.Tests/Microsoft.Bot.Components.Teams.Tests.csproj
+++ b/tests/unit/packages/Microsoft.Bot.Components.Teams.Tests/Microsoft.Bot.Components.Teams.Tests.csproj
@@ -10,7 +10,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive.Testing" Version="4.14.0.preview" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive.Testing" Version="4.14.0-preview" />
     <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Declarative" Version="4.14.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.1.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.1.0" />

--- a/tests/unit/packages/Microsoft.Bot.Components.Teams.Tests/Microsoft.Bot.Components.Teams.Tests.csproj
+++ b/tests/unit/packages/Microsoft.Bot.Components.Teams.Tests/Microsoft.Bot.Components.Teams.Tests.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive.Testing" Version="4.13.2-preview" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Declarative" Version="4.13.2" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive.Testing" Version="4.14.0.preview" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Declarative" Version="4.14.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.1.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.1.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />

--- a/tests/unit/skills/calendar/Microsoft.Bot.Dialogs.Tests.Skills.Calendar.csproj
+++ b/tests/unit/skills/calendar/Microsoft.Bot.Dialogs.Tests.Skills.Calendar.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.14.0" />
     <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive" Version="4.14.0" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive.Testing" Version="4.14.0.preview" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive.Testing" Version="4.14.0-preview" />
     <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Declarative" Version="4.14.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.3" />

--- a/tests/unit/skills/common/Microsoft.Bot.Dialogs.Tests.Common.csproj
+++ b/tests/unit/skills/common/Microsoft.Bot.Dialogs.Tests.Common.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.14.0" />
     <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive" Version="4.14.0" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive.Testing" Version="4.14.0.preview" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive.Testing" Version="4.14.0-preview" />
     <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Declarative" Version="4.14.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.3" />

--- a/tests/unit/skills/people/Microsoft.Bot.Dialogs.Tests.Skills.People.csproj
+++ b/tests/unit/skills/people/Microsoft.Bot.Dialogs.Tests.Skills.People.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.14.0" />
     <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive" Version="4.14.0" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive.Testing" Version="4.14.0.preview" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive.Testing" Version="4.14.0-preview" />
     <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Declarative" Version="4.14.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.3" />


### PR DESCRIPTION
<!-- This repository only accepts pull requests related to open issues, please link the open issue in description below. -->
<!-- See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. -->
<!-- For example - Close #123: Description goes here. -->

### Purpose

Allow preview ring to also specify a version override

### Changes

<!-- Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.) -->

### Tests

<!-- Is this covered by existing tests or new ones? If no, why not? -->

### Feature Plan

<!-- Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues. -->

