### PR TITLE
chore: update deprecated nuget package licenseurl properties

### DIFF
--- a/packages/Directory.Build.props
+++ b/packages/Directory.Build.props
@@ -13,17 +13,12 @@
   <PropertyGroup>
     <!-- Rules found at: https://aka.ms/Microsoft-NuGet-Compliance -->
     <PackageIconUrl>https://raw.githubusercontent.com/microsoft/botframework-sdk/master/icon.png</PackageIconUrl>
-    <PackageLicenseUrl>https://github.com/Microsoft/BotBuilder/blob/master/LICENSE</PackageLicenseUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <LicenseUrl>https://github.com/Microsoft/BotBuilder-dotnet/blob/master/LICENSE</LicenseUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryType />
     <NeutralLanguage>en-US</NeutralLanguage>
     <RepositoryUrl>https://github.com/Microsoft/botframework-components</RepositoryUrl>
-    <!--
-      Suppress a warning about upcoming deprecation of PackageLicenseUrl. When embedding licenses are supported,
-      replace PackageLicenseUrl with PackageLicenseExpression.
-    -->
-    <NoWarn>$(NoWarn);NU5125</NoWarn>
+    <NoWarn>$(NoWarn);</NoWarn>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>

--- a/packages/Directory.Build.props
+++ b/packages/Directory.Build.props
@@ -18,7 +18,7 @@
     <RepositoryType />
     <NeutralLanguage>en-US</NeutralLanguage>
     <RepositoryUrl>https://github.com/Microsoft/botframework-components</RepositoryUrl>
-    <NoWarn>$(NoWarn);</NoWarn>
+    <NoWarn>$(NoWarn);NU5048</NoWarn>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>

--- a/packages/Directory.Build.props
+++ b/packages/Directory.Build.props
@@ -12,7 +12,7 @@
 
   <PropertyGroup>
     <!-- Rules found at: https://aka.ms/Microsoft-NuGet-Compliance -->
-    <PackageIconUrl>https://raw.githubusercontent.com/microsoft/botframework-sdk/master/icon.png</PackageIconUrl>
+    <PackageIconUrl>https://raw.githubusercontent.com/microsoft/botframework-sdk/main/icon.png</PackageIconUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryType />

--- a/packages/HelpAndCancel/Microsoft.Bot.Components.HelpAndCancel.nuspec
+++ b/packages/HelpAndCancel/Microsoft.Bot.Components.HelpAndCancel.nuspec
@@ -6,7 +6,7 @@
         <authors>Microsoft</authors>
         <owners>Microsoft</owners>
         <copyright>© Microsoft Corporation. All rights reserved.</copyright>
-        <license>https://github.com/Microsoft/BotBuilder/blob/master/LICENSE</license>
+        <license type="expression">MIT</license>
         <requireLicenseAcceptance>true</requireLicenseAcceptance>
         <projectUrl>https://github.com/Microsoft/botframework-components/tree/main/packages/HelpAndCancel</projectUrl>
         <releaseNotes>First version of HelpAndCancel package</releaseNotes>

--- a/packages/HelpAndCancel/Microsoft.Bot.Components.HelpAndCancel.nuspec
+++ b/packages/HelpAndCancel/Microsoft.Bot.Components.HelpAndCancel.nuspec
@@ -6,7 +6,7 @@
         <authors>Microsoft</authors>
         <owners>Microsoft</owners>
         <copyright>© Microsoft Corporation. All rights reserved.</copyright>
-        <licenseUrl>https://github.com/Microsoft/BotBuilder/blob/master/LICENSE</licenseUrl>
+        <license>https://github.com/Microsoft/BotBuilder/blob/master/LICENSE</license>
         <requireLicenseAcceptance>true</requireLicenseAcceptance>
         <projectUrl>https://github.com/Microsoft/botframework-components/tree/main/packages/HelpAndCancel</projectUrl>
         <releaseNotes>First version of HelpAndCancel package</releaseNotes>

--- a/packages/Welcome/Microsoft.Bot.Components.Welcome.nuspec
+++ b/packages/Welcome/Microsoft.Bot.Components.Welcome.nuspec
@@ -6,7 +6,7 @@
         <authors>Microsoft</authors>
         <owners>Microsoft</owners>
         <copyright>© Microsoft Corporation. All rights reserved.</copyright>
-        <license>https://github.com/Microsoft/BotBuilder/blob/master/LICENSE</license>
+        <license type="expression">MIT</license>
         <requireLicenseAcceptance>true</requireLicenseAcceptance>
         <projectUrl>https://github.com/Microsoft/botframework-components/tree/main/packages/Welcome</projectUrl>
         <releaseNotes>First version of welcome package</releaseNotes>

--- a/packages/Welcome/Microsoft.Bot.Components.Welcome.nuspec
+++ b/packages/Welcome/Microsoft.Bot.Components.Welcome.nuspec
@@ -6,7 +6,7 @@
         <authors>Microsoft</authors>
         <owners>Microsoft</owners>
         <copyright>© Microsoft Corporation. All rights reserved.</copyright>
-        <licenseUrl>https://github.com/Microsoft/BotBuilder/blob/master/LICENSE</licenseUrl>
+        <license>https://github.com/Microsoft/BotBuilder/blob/master/LICENSE</license>
         <requireLicenseAcceptance>true</requireLicenseAcceptance>
         <projectUrl>https://github.com/Microsoft/botframework-components/tree/main/packages/Welcome</projectUrl>
         <releaseNotes>First version of welcome package</releaseNotes>

--- a/skills/csharp/Directory.Build.props
+++ b/skills/csharp/Directory.Build.props
@@ -24,7 +24,7 @@
 
   <PropertyGroup>
     <RepositoryUrl>https://github.com/microsoft/botframework-skills</RepositoryUrl>
-    <LicenseUrl>https://github.com/microsoft/botframework-skills/blob/master/LICENSE</LicenseUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryType />
     <NeutralLanguage>en-US</NeutralLanguage>
     <NoWarn>$(NoWarn);NU5125;NU1701;8002</NoWarn>

--- a/tests/functional/Directory.Build.props
+++ b/tests/functional/Directory.Build.props
@@ -25,7 +25,7 @@
 
   <PropertyGroup>    
     <RepositoryUrl>https://github.com/microsoft/BotFramework-FunctionalTests</RepositoryUrl>
-    <LicenseUrl>https://github.com/microsoft/BotFramework-FunctionalTests/blob/main/LICENSE</LicenseUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryType />
     <NeutralLanguage>en-US</NeutralLanguage>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>


### PR DESCRIPTION
<!-- This repository only accepts pull requests related to open issues, please link the open issue in description below. -->
<!-- See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. -->
<!-- For example - Close #123: Description goes here. -->

### Purpose
- In Directory.Build.props (for .csproj packages), replace deprecated `LicenseUrl` property with `PackageLicenseExpression`.
- In .nuspec files, replace deprecated `licenseUrl` property with `license type='expression'`
- Add NU5048 to NoWarn for PackageIconUrl/iconUrl as we will continue to use it to reference the icon.png on botframework-sdk repo (and fix reference to point to main branch)

#minor
