### PR TITLE
chore: fix response for missing text scripts in npm packages

### DIFF
--- a/packages/HelpAndCancel/package.json
+++ b/packages/HelpAndCancel/package.json
@@ -21,6 +21,6 @@
     "url": "https://github.com/Microsoft/botframework-components.git"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"No test specified for package \\\"@microsoft/bot-components-helpandcancel\\\", skipping.\""
   }
 }

--- a/packages/Welcome/package.json
+++ b/packages/Welcome/package.json
@@ -21,6 +21,6 @@
     "url": "https://github.com/Microsoft/botframework-components.git"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"No test specified for package \\\"@microsoft/bot-components-welcome\\\", skipping.\""
   }
 }


### PR DESCRIPTION
<!-- This repository only accepts pull requests related to open issues, please link the open issue in description below. -->
<!-- See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. -->
<!-- For example - Close #123: Description goes here. -->

### Purpose
The npm pipelines with declarative assets do not have any tests associated with them, but due to limitations in yarn we are unable to have a pipeline appropriately discern if they are available. 

Some background via comment in the yaml file:
> You are probably wondering "Why not just run 'yarn exec npm run --if-present test'?".
> On Azure Pipelines, yarn install by default restores modules to a global node_modules cache
> instead of a local package cache. When running the npm CLI, it is unable to resolve required
> dependencies as a result, whereas yarn run <script> can do so successfully. However,
> yarn does not yet have an --if-present condition - the immediate step below simulates this
> by manually reading the package.json and checking for the presence of $.scripts.test in the JSON.

Both HelpAndCancel/Welcome packages do not have any associated tests, but it is good to keep our packages.json files standardized and maintain that property throughout. The issue with their current setup is that the test command raises an error. This is handled by the pipelines as a warning so it may continue, but will continue to have a confusing status as we don't anticipate tests for these asset packages.

![image](https://user-images.githubusercontent.com/43043272/124842057-8f01e100-df43-11eb-93c0-1eedb19ca436.png)
![image](https://user-images.githubusercontent.com/43043272/124842068-93c69500-df43-11eb-8f10-e46823ac7389.png)
![image](https://user-images.githubusercontent.com/43043272/124842257-ff106700-df43-11eb-9f81-b231c7a89bdb.png)

I have updated the test script to remove `exit 1` and provide a more descriptive output to aid debugging. Now the pipelines pass as expected.

![image](https://user-images.githubusercontent.com/43043272/124842224-f029b480-df43-11eb-8d8c-22d4def459ac.png)
![image](https://user-images.githubusercontent.com/43043272/124842242-f6b82c00-df43-11eb-8cf6-0a9c991d8308.png)

#minor
