### PR TITLE
build: add functions app deployment/testing to functional tests

### DIFF
--- a/build/templates/template-function-bot-resources.json
+++ b/build/templates/template-function-bot-resources.json
@@ -54,8 +54,7 @@
         "name": "[parameters('botName')]",
         "kind": "functionapp",
         "httpsOnly": true,
-        "alwaysOn": true,
-        "serverFarmId": "[concat('/subscriptions/', subscription().id,'/resourcegroups/', parameters('appServicePlanResourceGroup'), '/providers/Microsoft.Web/serverfarms/', parameters('appServicePlanName'))]"
+        "alwaysOn": true
       },
       "resources": [
         {

--- a/build/templates/template-function-bot-resources.json
+++ b/build/templates/template-function-bot-resources.json
@@ -54,7 +54,8 @@
         "name": "[parameters('botName')]",
         "kind": "functionapp",
         "httpsOnly": true,
-        "alwaysOn": true
+        "alwaysOn": true,
+        "serverFarmId": "[concat('/subscriptions/', subscription().id,'/resourcegroups/', parameters('appServicePlanResourceGroup'), '/providers/Microsoft.Web/serverfarms/', parameters('appServicePlanName'))]"
       },
       "resources": [
         {

--- a/build/templates/template-function-bot-resources.json
+++ b/build/templates/template-function-bot-resources.json
@@ -46,129 +46,33 @@
   "resources": [
     {
       "type": "Microsoft.Web/sites",
-      "apiVersion": "2020-09-01",
-      "name": "[parameters('botName')]",
+      "apiVersion": "2015-08-01",
       "location": "[parameters('botLocation')]",
-      "kind": "app",
+      "kind": "functionapp",
+      "name": "[parameters('botName')]",
       "properties": {
-        "enabled": true,
-        "hostNameSslStates": [
-          {
-            "name": "[concat(parameters('botName'), '.azurewebsites.net')]",
-            "sslState": "Disabled",
-            "hostType": "Standard"
-          },
-          {
-            "name": "[concat(parameters('botName'), '.scm.azurewebsites.net')]",
-            "sslState": "Disabled",
-            "hostType": "Repository"
+        "name": "[parameters('botName')]",
+        "kind": "functionapp",
+        "httpsOnly": true,
+        "alwaysOn": true
+      },
+      "resources": [
+        {
+          "name": "appsettings",
+          "type": "config",
+          "apiVersion": "2015-08-01",
+          "dependsOn": [
+            "[concat('Microsoft.Web/Sites/', parameters('botName'))]"
+          ],
+          "properties": {
+            "FUNCTIONS_EXTENSION_VERSION": "~3",
+            "FUNCTIONS_WORKER_RUNTIME": "dotnet",
+            "APPINSIGHTS_INSTRUMENTATIONKEY": "[if(empty(parameters('appInsightsName')), '', reference(resourceId(parameters('appServicePlanResourceGroup'),'Microsoft.Insights/components', parameters('appInsightsName')), '2015-05-01', 'Full').properties.InstrumentationKey)]",
+            "MicrosoftAppId": "[parameters('appId')]",
+            "MicrosoftAppPassword": "[parameters('appSecret')]"
           }
-        ],
-        "serverFarmId": "[concat('/subscriptions/', subscription().id,'/resourcegroups/', parameters('appServicePlanResourceGroup'), '/providers/Microsoft.Web/serverfarms/', parameters('appServicePlanName'))]",
-        "reserved": true,
-        "hyperV": false,
-        "siteConfig": {
-          "appSettings": [
-            {
-              "name": "WEBSITE_NODE_DEFAULT_VERSION",
-              "value": "10.14.1"
-            },
-            {
-              "name": "MicrosoftAppId",
-              "value": "[parameters('appId')]"
-            },
-            {
-              "name": "MicrosoftAppPassword",
-              "value": "[parameters('appSecret')]"
-            },
-            {
-              "name": "APPINSIGHTS_INSTRUMENTATIONKEY",
-              "value": "[if(empty(parameters('appInsightsName')), '', reference(resourceId(parameters('appServicePlanResourceGroup'),'Microsoft.Insights/components', parameters('appInsightsName')), '2015-05-01', 'Full').properties.InstrumentationKey)]"
-            },
-            {
-              "name": "APPLICATIONINSIGHTS_CONNECTION_STRING",
-              "value": "[if(empty(parameters('appInsightsName')), '', reference(resourceId(parameters('appServicePlanResourceGroup'),'Microsoft.Insights/components', parameters('appInsightsName')), '2015-05-01', 'Full').properties.ConnectionString)]"
-            },
-            {
-              "name": "ApplicationInsightsAgent_EXTENSION_VERSION",
-              "value": "~2"
-            }
-          ],
-          "webSocketsEnabled": true,
-          "scmType": "None",
-          "use32BitWorkerProcess": true,
-          "alwaysOn": true,
-          "managedPipelineMode": "Integrated",
-          "virtualApplications": [
-            {
-              "virtualPath": "/",
-              "physicalPath": "site\\wwwroot",
-              "preloadEnabled": true
-            }
-          ],
-          "loadBalancing": "LeastRequests",
-          "experiments": {
-            "rampUpRules": []
-          },
-          "autoHealEnabled": false,
-          "cors": {
-            "allowedOrigins": [
-              "https://botservice.hosting.portal.azure.net",
-              "https://hosting.onecloud.azure-test.net/"
-            ],
-            "supportCredentials": false
-          },
-          "localMySqlEnabled": false,
-          "ipSecurityRestrictions": [
-            {
-              "ipAddress": "Any",
-              "action": "Allow",
-              "priority": 1,
-              "name": "Allow all",
-              "description": "Allow all access"
-            }
-          ],
-          "scmIpSecurityRestrictions": [
-            {
-              "ipAddress": "Any",
-              "action": "Allow",
-              "priority": 1,
-              "name": "Allow all",
-              "description": "Allow all access"
-            }
-          ],
-          "scmIpSecurityRestrictionsUseMain": false,
-          "http20Enabled": false,
-          "minTlsVersion": "1.2",
-          "ftpsState": "AllAllowed",
-          "numberOfWorkers": 1,
-          "defaultDocuments": [
-            "Default.htm",
-            "Default.html",
-            "Default.asp",
-            "index.htm",
-            "index.html",
-            "iisstart.htm",
-            "default.aspx",
-            "index.php",
-            "hostingstart.html"
-          ],
-          "netFrameworkVersion": "v4.0",
-          "phpVersion": "5.6",
-          "requestTracingEnabled": false,
-          "remoteDebuggingEnabled": false,
-          "httpLoggingEnabled": true,
-          "logsDirectorySizeLimit": 35,
-          "detailedErrorLoggingEnabled": false,
-          "publishingUsername": "[variables('publishingUsername')]"
-        },
-        "scmSiteAlsoStopped": false,
-        "clientAffinityEnabled": true,
-        "hostNamesDisabled": false,
-        "clientCertEnabled": false,
-        "httpsOnly": false,
-        "redundancyMode": "None"
-      }
+        }
+      ]
     },
     {
       "type": "Microsoft.Web/sites/hostNameBindings",

--- a/build/templates/template-function-bot-resources.json
+++ b/build/templates/template-function-bot-resources.json
@@ -1,0 +1,210 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "appId": {
+      "type": "string",
+      "metadata": {
+        "description": "Active Directory App ID, set as MicrosoftAppId in the Web App's Application Settings."
+      }
+    },
+    "appSecret": {
+      "type": "string",
+      "metadata": {
+        "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings."
+      }
+    },
+    "botName": {
+      "type": "string"
+    },
+    "botLocation": {
+      "type": "string"
+    },
+    "appInsightsName": {
+      "type": "string",
+      "defaultValue": ""
+    },
+    "appServicePlanName": {
+      "type": "string"
+    },
+    "appServicePlanResourceGroup": {
+      "type": "string"
+    },
+    "botSku": {
+      "type": "string",
+      "defaultValue": "F0",
+      "metadata": {
+        "description": "The pricing tier of the Bot Service Registration. Acceptable values are F0 and S1."
+      }
+    }
+  },
+  "variables": {
+    "siteHost": "[concat(parameters('botName'), '.azurewebsites.net')]",
+    "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]",
+    "publishingUsername": "[concat('$', parameters('botName'))]"
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Web/sites",
+      "apiVersion": "2020-09-01",
+      "name": "[parameters('botName')]",
+      "location": "[parameters('botLocation')]",
+      "kind": "app",
+      "properties": {
+        "enabled": true,
+        "hostNameSslStates": [
+          {
+            "name": "[concat(parameters('botName'), '.azurewebsites.net')]",
+            "sslState": "Disabled",
+            "hostType": "Standard"
+          },
+          {
+            "name": "[concat(parameters('botName'), '.scm.azurewebsites.net')]",
+            "sslState": "Disabled",
+            "hostType": "Repository"
+          }
+        ],
+        "serverFarmId": "[concat('/subscriptions/', subscription().id,'/resourcegroups/', parameters('appServicePlanResourceGroup'), '/providers/Microsoft.Web/serverfarms/', parameters('appServicePlanName'))]",
+        "reserved": true,
+        "hyperV": false,
+        "siteConfig": {
+          "appSettings": [
+            {
+              "name": "WEBSITE_NODE_DEFAULT_VERSION",
+              "value": "10.14.1"
+            },
+            {
+              "name": "MicrosoftAppId",
+              "value": "[parameters('appId')]"
+            },
+            {
+              "name": "MicrosoftAppPassword",
+              "value": "[parameters('appSecret')]"
+            },
+            {
+              "name": "APPINSIGHTS_INSTRUMENTATIONKEY",
+              "value": "[if(empty(parameters('appInsightsName')), '', reference(resourceId(parameters('appServicePlanResourceGroup'),'Microsoft.Insights/components', parameters('appInsightsName')), '2015-05-01', 'Full').properties.InstrumentationKey)]"
+            },
+            {
+              "name": "APPLICATIONINSIGHTS_CONNECTION_STRING",
+              "value": "[if(empty(parameters('appInsightsName')), '', reference(resourceId(parameters('appServicePlanResourceGroup'),'Microsoft.Insights/components', parameters('appInsightsName')), '2015-05-01', 'Full').properties.ConnectionString)]"
+            },
+            {
+              "name": "ApplicationInsightsAgent_EXTENSION_VERSION",
+              "value": "~2"
+            }
+          ],
+          "webSocketsEnabled": true,
+          "scmType": "None",
+          "use32BitWorkerProcess": true,
+          "alwaysOn": true,
+          "managedPipelineMode": "Integrated",
+          "virtualApplications": [
+            {
+              "virtualPath": "/",
+              "physicalPath": "site\\wwwroot",
+              "preloadEnabled": true
+            }
+          ],
+          "loadBalancing": "LeastRequests",
+          "experiments": {
+            "rampUpRules": []
+          },
+          "autoHealEnabled": false,
+          "cors": {
+            "allowedOrigins": [
+              "https://botservice.hosting.portal.azure.net",
+              "https://hosting.onecloud.azure-test.net/"
+            ],
+            "supportCredentials": false
+          },
+          "localMySqlEnabled": false,
+          "ipSecurityRestrictions": [
+            {
+              "ipAddress": "Any",
+              "action": "Allow",
+              "priority": 1,
+              "name": "Allow all",
+              "description": "Allow all access"
+            }
+          ],
+          "scmIpSecurityRestrictions": [
+            {
+              "ipAddress": "Any",
+              "action": "Allow",
+              "priority": 1,
+              "name": "Allow all",
+              "description": "Allow all access"
+            }
+          ],
+          "scmIpSecurityRestrictionsUseMain": false,
+          "http20Enabled": false,
+          "minTlsVersion": "1.2",
+          "ftpsState": "AllAllowed",
+          "numberOfWorkers": 1,
+          "defaultDocuments": [
+            "Default.htm",
+            "Default.html",
+            "Default.asp",
+            "index.htm",
+            "index.html",
+            "iisstart.htm",
+            "default.aspx",
+            "index.php",
+            "hostingstart.html"
+          ],
+          "netFrameworkVersion": "v4.0",
+          "phpVersion": "5.6",
+          "requestTracingEnabled": false,
+          "remoteDebuggingEnabled": false,
+          "httpLoggingEnabled": true,
+          "logsDirectorySizeLimit": 35,
+          "detailedErrorLoggingEnabled": false,
+          "publishingUsername": "[variables('publishingUsername')]"
+        },
+        "scmSiteAlsoStopped": false,
+        "clientAffinityEnabled": true,
+        "hostNamesDisabled": false,
+        "clientCertEnabled": false,
+        "httpsOnly": false,
+        "redundancyMode": "None"
+      }
+    },
+    {
+      "type": "Microsoft.Web/sites/hostNameBindings",
+      "apiVersion": "2020-09-01",
+      "name": "[concat(parameters('botName'), '/', parameters('botName'), '.azurewebsites.net')]",
+      "location": "[parameters('botLocation')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.Web/sites', parameters('botName'))]"
+      ],
+      "properties": {
+        "siteName": "[parameters('botName')]",
+        "hostNameType": "Verified"
+      }
+    },
+    {
+      "type": "Microsoft.BotService/botServices",
+      "apiVersion": "2020-06-02",
+      "name": "[parameters('botName')]",
+      "location": "global",
+      "kind": "bot",
+      "sku": {
+        "name": "[parameters('botSku')]"
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Web/sites', parameters('botName'))]"
+      ],
+      "properties": {
+        "name": "[parameters('botName')]",
+        "displayName": "[parameters('botName')]",
+        "endpoint": "[variables('botEndpoint')]",
+        "msaAppId": "[parameters('appId')]",
+        "developerAppInsightsApplicationId": "",
+        "developerAppInsightKey": "",
+        "publishingCredentials": null,
+        "storageResourceId": null
+      }
+    }
+  ]
+}

--- a/build/templates/template-function-dotnet-bot-resources.json
+++ b/build/templates/template-function-dotnet-bot-resources.json
@@ -1,0 +1,115 @@
+{
+  "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentTemplate.json#",
+  "contentVersion": "1.0.0.0",
+  "parameters": {
+    "appId": {
+      "type": "string",
+      "metadata": {
+        "description": "Active Directory App ID, set as MicrosoftAppId in the Web App's Application Settings."
+      }
+    },
+    "appSecret": {
+      "type": "string",
+      "metadata": {
+        "description": "Active Directory App Password, set as MicrosoftAppPassword in the Web App's Application Settings."
+      }
+    },
+    "botName": {
+      "type": "string"
+    },
+    "botLocation": {
+      "type": "string"
+    },
+    "appInsightsName": {
+      "type": "string",
+      "defaultValue": ""
+    },
+    "appServicePlanName": {
+      "type": "string"
+    },
+    "appServicePlanResourceGroup": {
+      "type": "string"
+    },
+    "botSku": {
+      "type": "string",
+      "defaultValue": "F0",
+      "metadata": {
+        "description": "The pricing tier of the Bot Service Registration. Acceptable values are F0 and S1."
+      }
+    }
+  },
+  "variables": {
+    "siteHost": "[concat(parameters('botName'), '.azurewebsites.net')]",
+    "botEndpoint": "[concat('https://', variables('siteHost'), '/api/messages')]",
+    "publishingUsername": "[concat('$', parameters('botName'))]"
+  },
+  "resources": [
+    {
+      "type": "Microsoft.Web/sites",
+      "apiVersion": "2015-08-01",
+      "location": "[parameters('botLocation')]",
+      "kind": "functionapp",
+      "name": "[parameters('botName')]",
+      "properties": {
+        "name": "[parameters('botName')]",
+        "kind": "functionapp",
+        "httpsOnly": true,
+        "alwaysOn": true,
+        "webSocketsEnabled": true
+      },
+      "resources": [
+        {
+          "name": "appsettings",
+          "type": "config",
+          "apiVersion": "2015-08-01",
+          "dependsOn": [
+            "[concat('Microsoft.Web/Sites/', parameters('botName'))]"
+          ],
+          "properties": {
+            "FUNCTIONS_EXTENSION_VERSION": "~3",
+            "FUNCTIONS_WORKER_RUNTIME": "dotnet",
+            "APPINSIGHTS_INSTRUMENTATIONKEY": "[if(empty(parameters('appInsightsName')), '', reference(resourceId(parameters('appServicePlanResourceGroup'),'Microsoft.Insights/components', parameters('appInsightsName')), '2015-05-01', 'Full').properties.InstrumentationKey)]",
+            "MicrosoftAppId": "[parameters('appId')]",
+            "MicrosoftAppPassword": "[parameters('appSecret')]"
+          }
+        }
+      ]
+    },
+    {
+      "type": "Microsoft.Web/sites/hostNameBindings",
+      "apiVersion": "2020-09-01",
+      "name": "[concat(parameters('botName'), '/', parameters('botName'), '.azurewebsites.net')]",
+      "location": "[parameters('botLocation')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.Web/sites', parameters('botName'))]"
+      ],
+      "properties": {
+        "siteName": "[parameters('botName')]",
+        "hostNameType": "Verified"
+      }
+    },
+    {
+      "type": "Microsoft.BotService/botServices",
+      "apiVersion": "2020-06-02",
+      "name": "[parameters('botName')]",
+      "location": "global",
+      "kind": "bot",
+      "sku": {
+        "name": "[parameters('botSku')]"
+      },
+      "dependsOn": [
+        "[resourceId('Microsoft.Web/sites', parameters('botName'))]"
+      ],
+      "properties": {
+        "name": "[parameters('botName')]",
+        "displayName": "[parameters('botName')]",
+        "endpoint": "[variables('botEndpoint')]",
+        "msaAppId": "[parameters('appId')]",
+        "developerAppInsightsApplicationId": "",
+        "developerAppInsightKey": "",
+        "publishingCredentials": null,
+        "storageResourceId": null
+      }
+    }
+  ]
+}

--- a/build/templates/template-function-js-bot-resources.json
+++ b/build/templates/template-function-js-bot-resources.json
@@ -54,7 +54,8 @@
         "name": "[parameters('botName')]",
         "kind": "functionapp",
         "httpsOnly": true,
-        "alwaysOn": true
+        "alwaysOn": true,
+        "webSocketsEnabled": true
       },
       "resources": [
         {
@@ -66,7 +67,8 @@
           ],
           "properties": {
             "FUNCTIONS_EXTENSION_VERSION": "~3",
-            "FUNCTIONS_WORKER_RUNTIME": "dotnet",
+            "FUNCTIONS_WORKER_RUNTIME": "node",
+            "WEBSITE_NODE_DEFAULT_VERSION": "~14",
             "APPINSIGHTS_INSTRUMENTATIONKEY": "[if(empty(parameters('appInsightsName')), '', reference(resourceId(parameters('appServicePlanResourceGroup'),'Microsoft.Insights/components', parameters('appInsightsName')), '2015-05-01', 'Full').properties.InstrumentationKey)]",
             "MicrosoftAppId": "[parameters('appId')]",
             "MicrosoftAppPassword": "[parameters('appSecret')]"

--- a/tests/functional/Tests/ComponentsFunctionalTests/Common/HostBot.cs
+++ b/tests/functional/Tests/ComponentsFunctionalTests/Common/HostBot.cs
@@ -11,8 +11,18 @@ namespace ComponentsFunctionalTests.Common
         EmptyBotDotNetWebApp,
 
         /// <summary>
+        /// Empty bot implemented using DotNet and Functions.
+        /// </summary>
+        EmptyBotDotNetFunctions,
+
+        /// <summary>
         /// Empty bot implemented using JS and Web App.
         /// </summary>
-        EmptyBotJSWebApp
+        EmptyBotJSWebApp,
+
+        /// <summary>
+        /// Empty bot implemented using JS and Functions.
+        /// </summary>
+        EmptyBotJSFunctions
     }
 }

--- a/tests/functional/Tests/ComponentsFunctionalTests/EmptyBot/EmptyBotTests.cs
+++ b/tests/functional/Tests/ComponentsFunctionalTests/EmptyBot/EmptyBotTests.cs
@@ -37,7 +37,9 @@ namespace ComponentsFunctionalTests.EmptyBot
             var hostBots = new List<HostBot>
             {
                 HostBot.EmptyBotDotNetWebApp,
-                HostBot.EmptyBotJSWebApp
+                HostBot.EmptyBotDotNetFunctions,
+                HostBot.EmptyBotJSWebApp,
+                HostBot.EmptyBotJSFunctions
             };
 
             var scripts = new List<string> { "EmptyBot.json" };

--- a/tests/functional/Tests/ComponentsFunctionalTests/appsettings.json
+++ b/tests/functional/Tests/ComponentsFunctionalTests/appsettings.json
@@ -13,8 +13,16 @@
       "BotId": "bfcfnemptybotdotnetwebapp",
       "DirectLineSecret": ""
     },
+    "EmptyBotDotNetFunctions": {
+      "BotId": "bfcfnemptybotdotnetfunctions",
+      "DirectLineSecret": ""
+    },
     "EmptyBotJSWebApp": {
       "BotId": "bfcfnemptybotjswebapp",
+      "DirectLineSecret": ""
+    },
+    "EmptyBotJSFunctions": {
+      "BotId": "bfcfnemptybotjsfunctions",
       "DirectLineSecret": ""
     }
   }

--- a/tests/functional/build/yaml/deployBotResources/dotnet/deploy.yml
+++ b/tests/functional/build/yaml/deployBotResources/dotnet/deploy.yml
@@ -154,30 +154,57 @@ stages:
               pathToPublish: "$(SYSTEM.DEFAULTWORKINGDIRECTORY)/${{ parameters.buildFolder }}/${{ bot.name }}/${{ bot.name }}.zip"
               artifactName: dotnet-$(BUILD.BUILDID)
 
+          - ${{ if eq(bot.project.integration, 'webapp') }}:
           # Create App Service and Bot Channel Registration
-          - template: ../common/createAppService.yml
-            parameters:
-              appId: $(APPID)
-              appInsight: "${{ parameters.appInsight }}"
-              appSecret: $(APPSECRET)
-              appServicePlan: "${{ parameters.appServicePlan }}"
-              appServicePlanRG: "${{ parameters.appServicePlanRG }}"
-              azureSubscription: "${{ parameters.azureSubscription }}"
-              botGroup: "${{ parameters.resourceGroup }}"
-              botName: "${{ bot.name }}"
-              botPricingTier: "${{ parameters.botPricingTier }}"
-              resourceSuffix: "${{ parameters.resourceSuffix }}"
-              templateFile: "build/templates/template-bot-resources.json"
+            - template: ../common/createAppService.yml
+              parameters:
+                appId: $(APPID)
+                appInsight: "${{ parameters.appInsight }}"
+                appSecret: $(APPSECRET)
+                appServicePlan: "${{ parameters.appServicePlan }}"
+                appServicePlanRG: "${{ parameters.appServicePlanRG }}"
+                azureSubscription: "${{ parameters.azureSubscription }}"
+                botGroup: "${{ parameters.resourceGroup }}"
+                botName: "${{ bot.name }}"
+                botPricingTier: "${{ parameters.botPricingTier }}"
+                resourceSuffix: "${{ parameters.resourceSuffix }}"
+                templateFile: "build/templates/template-bot-resources.json"
 
-          # Deploy bot
-          - task: AzureWebApp@1
-            displayName: 'Deploy Azure Web App : ${{ bot.name }}-$(BUILD.BUILDID)'
-            inputs:
-              azureSubscription: "${{ parameters.azureSubscription }}"
-              appName: '${{ bot.name }}${{ parameters.resourceSuffix }}-$(BUILD.BUILDID)'
-              resourceGroupName: '${{ parameters.resourceGroup }}'
-              package: '$(SYSTEM.DEFAULTWORKINGDIRECTORY)/${{ parameters.buildFolder }}/${{ bot.name }}/${{ bot.name }}.zip'
-              deploymentMethod: runFromPackage
+          # Deploy bot to Azure Web App
+            - task: AzureWebApp@1
+              displayName: 'Deploy Azure Web App : ${{ bot.name }}-$(BUILD.BUILDID)'
+              inputs:
+                azureSubscription: "${{ parameters.azureSubscription }}"
+                appName: '${{ bot.name }}${{ parameters.resourceSuffix }}-$(BUILD.BUILDID)'
+                resourceGroupName: '${{ parameters.resourceGroup }}'
+                package: '$(SYSTEM.DEFAULTWORKINGDIRECTORY)/${{ parameters.buildFolder }}/${{ bot.name }}/${{ bot.name }}.zip'
+                deploymentMethod: runFromPackage
+
+          - ${{ if eq(bot.project.integration, 'functions') }}:
+          # Create Functions App and Bot Channel Registration
+            - template: ../common/createAppService.yml
+              parameters:
+                appId: $(APPID)
+                appInsight: "${{ parameters.appInsight }}"
+                appSecret: $(APPSECRET)
+                appServicePlan: "${{ parameters.appServicePlan }}"
+                appServicePlanRG: "${{ parameters.appServicePlanRG }}"
+                azureSubscription: "${{ parameters.azureSubscription }}"
+                botGroup: "${{ parameters.resourceGroup }}"
+                botName: "${{ bot.name }}"
+                botPricingTier: "${{ parameters.botPricingTier }}"
+                resourceSuffix: "${{ parameters.resourceSuffix }}"
+                templateFile: "build/templates/template-function-bot-resources.json"
+
+          # Deploy bot to Azure Web App
+            - task: AzureWebApp@1
+              displayName: 'Deploy Azure Web App : ${{ bot.name }}-$(BUILD.BUILDID)'
+              inputs:
+                azureSubscription: "${{ parameters.azureSubscription }}"
+                appName: '${{ bot.name }}${{ parameters.resourceSuffix }}-$(BUILD.BUILDID)'
+                resourceGroupName: '${{ parameters.resourceGroup }}'
+                package: '$(SYSTEM.DEFAULTWORKINGDIRECTORY)/${{ parameters.buildFolder }}/${{ bot.name }}/${{ bot.name }}.zip'
+                deploymentMethod: runFromPackage
 
           # Configure OAuth
           - ${{ if eq(bot.type, 'Skill') }}:

--- a/tests/functional/build/yaml/deployBotResources/dotnet/deploy.yml
+++ b/tests/functional/build/yaml/deployBotResources/dotnet/deploy.yml
@@ -194,7 +194,7 @@ stages:
                 botName: "${{ bot.name }}"
                 botPricingTier: "${{ parameters.botPricingTier }}"
                 resourceSuffix: "${{ parameters.resourceSuffix }}"
-                templateFile: "build/templates/template-function-bot-resources.json"
+                templateFile: "build/templates/template-function-dotnet-bot-resources.json"
 
           # Deploy bot to Azure Functions
             - task: AzureFunctionApp@1

--- a/tests/functional/build/yaml/deployBotResources/dotnet/deploy.yml
+++ b/tests/functional/build/yaml/deployBotResources/dotnet/deploy.yml
@@ -196,13 +196,13 @@ stages:
                 resourceSuffix: "${{ parameters.resourceSuffix }}"
                 templateFile: "build/templates/template-function-bot-resources.json"
 
-          # Deploy bot to Azure Web App
-            - task: AzureWebApp@1
-              displayName: 'Deploy Azure Web App : ${{ bot.name }}-$(BUILD.BUILDID)'
+          # Deploy bot to Azure Functions
+            - task: AzureFunctionApp@1
+              displayName: 'Deploy Functions App : ${{ bot.name }}-$(BUILD.BUILDID)'
               inputs:
                 azureSubscription: "${{ parameters.azureSubscription }}"
+                appType: 'functionApp'
                 appName: '${{ bot.name }}${{ parameters.resourceSuffix }}-$(BUILD.BUILDID)'
-                resourceGroupName: '${{ parameters.resourceGroup }}'
                 package: '$(SYSTEM.DEFAULTWORKINGDIRECTORY)/${{ parameters.buildFolder }}/${{ bot.name }}/${{ bot.name }}.zip'
                 deploymentMethod: runFromPackage
 

--- a/tests/functional/build/yaml/deployBotResources/js/deploy.yml
+++ b/tests/functional/build/yaml/deployBotResources/js/deploy.yml
@@ -212,7 +212,7 @@ stages:
                 botName: "${{ bot.name }}"
                 botPricingTier: "${{ parameters.botPricingTier }}"
                 resourceSuffix: "${{ parameters.resourceSuffix }}"
-                templateFile: "build/templates/template-function-bot-resources.json"
+                templateFile: "build/templates/template-function-js-bot-resources.json"
 
           # Deploy bot to Azure Functions
             - task: AzureFunctionApp@1

--- a/tests/functional/build/yaml/deployBotResources/js/deploy.yml
+++ b/tests/functional/build/yaml/deployBotResources/js/deploy.yml
@@ -195,7 +195,7 @@ stages:
                 azureSubscription: "${{ parameters.azureSubscription }}"
                 appName: '${{ bot.name }}${{ parameters.resourceSuffix }}-$(BUILD.BUILDID)'
                 resourceGroupName: '${{ parameters.resourceGroup }}'
-                package: '$(SYSTEM.DEFAULTWORKINGDIRECTORY)/build/${{ bot.name }}/${{ bot.name }}.zip'
+                package: '$(SYSTEM.DEFAULTWORKINGDIRECTORY)/build/${{ bot.name }}.zip'
                 deploymentMethod: runFromPackage
 
           - ${{ if eq(bot.project.integration, 'functions') }}:
@@ -221,7 +221,7 @@ stages:
                 azureSubscription: "${{ parameters.azureSubscription }}"
                 appType: 'functionApp'
                 appName: '${{ bot.name }}${{ parameters.resourceSuffix }}-$(BUILD.BUILDID)'
-                package: '$(SYSTEM.DEFAULTWORKINGDIRECTORY)/build/${{ bot.name }}/${{ bot.name }}.zip'
+                package: '$(SYSTEM.DEFAULTWORKINGDIRECTORY)/build/${{ bot.name }}.zip'
                 deploymentMethod: runFromPackage
 
           # Configure OAuth

--- a/tests/functional/build/yaml/deployBotResources/js/deploy.yml
+++ b/tests/functional/build/yaml/deployBotResources/js/deploy.yml
@@ -172,30 +172,57 @@ stages:
               pathToPublish: '$(SYSTEM.DEFAULTWORKINGDIRECTORY)/build/${{ bot.name }}.zip'
               artifactName: javascript-$(BUILD.BUILDID)
 
+          - ${{ if eq(bot.project.integration, 'webapp') }}:
           # Create App Service and Bot Channel Registration
-          - template: ../common/createAppService.yml
-            parameters:
-              appId: $(APPID)
-              appInsight: "${{ parameters.appInsight }}"
-              appSecret: $(APPSECRET)
-              appServicePlan: "${{ parameters.appServicePlan }}"
-              appServicePlanRG: "${{ parameters.appServicePlanRG }}"
-              azureSubscription: "${{ parameters.azureSubscription }}"
-              botGroup: "${{ parameters.resourceGroup }}"
-              botName: "${{ bot.name }}"
-              botPricingTier: "${{ parameters.botPricingTier }}"
-              resourceSuffix: "${{ parameters.resourceSuffix }}"
-              templateFile: "build/templates/template-bot-resources.json"
+            - template: ../common/createAppService.yml
+              parameters:
+                appId: $(APPID)
+                appInsight: "${{ parameters.appInsight }}"
+                appSecret: $(APPSECRET)
+                appServicePlan: "${{ parameters.appServicePlan }}"
+                appServicePlanRG: "${{ parameters.appServicePlanRG }}"
+                azureSubscription: "${{ parameters.azureSubscription }}"
+                botGroup: "${{ parameters.resourceGroup }}"
+                botName: "${{ bot.name }}"
+                botPricingTier: "${{ parameters.botPricingTier }}"
+                resourceSuffix: "${{ parameters.resourceSuffix }}"
+                templateFile: "build/templates/template-bot-resources.json"
 
-          # Deploy bot
-          - task: AzureWebApp@1
-            displayName: 'Deploy Azure Web App : ${{ bot.name }}-$(BUILD.BUILDID)'
-            inputs:
-              azureSubscription: "${{ parameters.azureSubscription }}"
-              appName: '${{ bot.name }}${{ parameters.resourceSuffix }}-$(BUILD.BUILDID)'
-              resourceGroupName: '${{ parameters.resourceGroup }}'
-              package: '$(SYSTEM.DEFAULTWORKINGDIRECTORY)/build/${{ bot.name }}.zip'
-              deploymentMethod: runFromPackage
+          # Deploy bot to Azure Web App
+            - task: AzureWebApp@1
+              displayName: 'Deploy Azure Web App : ${{ bot.name }}-$(BUILD.BUILDID)'
+              inputs:
+                azureSubscription: "${{ parameters.azureSubscription }}"
+                appName: '${{ bot.name }}${{ parameters.resourceSuffix }}-$(BUILD.BUILDID)'
+                resourceGroupName: '${{ parameters.resourceGroup }}'
+                package: '$(SYSTEM.DEFAULTWORKINGDIRECTORY)/build/${{ bot.name }}/${{ bot.name }}.zip'
+                deploymentMethod: runFromPackage
+
+          - ${{ if eq(bot.project.integration, 'functions') }}:
+          # Create Functions App and Bot Channel Registration
+            - template: ../common/createAppService.yml
+              parameters:
+                appId: $(APPID)
+                appInsight: "${{ parameters.appInsight }}"
+                appSecret: $(APPSECRET)
+                appServicePlan: "${{ parameters.appServicePlan }}"
+                appServicePlanRG: "${{ parameters.appServicePlanRG }}"
+                azureSubscription: "${{ parameters.azureSubscription }}"
+                botGroup: "${{ parameters.resourceGroup }}"
+                botName: "${{ bot.name }}"
+                botPricingTier: "${{ parameters.botPricingTier }}"
+                resourceSuffix: "${{ parameters.resourceSuffix }}"
+                templateFile: "build/templates/template-function-bot-resources.json"
+
+          # Deploy bot to Azure Functions
+            - task: AzureFunctionApp@1
+              displayName: 'Deploy Functions App : ${{ bot.name }}-$(BUILD.BUILDID)'
+              inputs:
+                azureSubscription: "${{ parameters.azureSubscription }}"
+                appType: 'functionApp'
+                appName: '${{ bot.name }}${{ parameters.resourceSuffix }}-$(BUILD.BUILDID)'
+                package: '$(SYSTEM.DEFAULTWORKINGDIRECTORY)/build/${{ bot.name }}/${{ bot.name }}.zip'
+                deploymentMethod: runFromPackage
 
           # Configure OAuth
           - ${{ if eq(bot.type, 'Skill') }}:

--- a/tests/functional/build/yaml/testScenarios/configureConsumers.yml
+++ b/tests/functional/build/yaml/testScenarios/configureConsumers.yml
@@ -429,7 +429,7 @@ steps:
             name      = "EmptyBot"; 
             consumers = @(
               "EmptyBotDotNetWebApp",
-              "EmptyBotJSFunctions",
+              "EmptyBotDotNetFunctions",
               "EmptyBotJSWebApp",
               "EmptyBotJSFunctions"
             );

--- a/tests/functional/build/yaml/testScenarios/configureConsumers.yml
+++ b/tests/functional/build/yaml/testScenarios/configureConsumers.yml
@@ -4,7 +4,9 @@ parameters:
   type: object
   default:
     EmptyBotDotNetWebApp: ""
+    EmptyBotDotNetFunctions: ""
     EmptyBotJSWebApp: ""
+    EmptyBotJSFunctions: ""
 
 - name: azureSubscription
   displayName: Azure Service Connection
@@ -402,8 +404,20 @@ steps:
             configType    = $types.Appsettings
           }
           @{
+            key           = "EmptyBotDotNetFunctions"
+            botName       = "bfcfnemptybotdotnetfunctions"
+            resourceGroup = $groups.DotNet
+            configType    = $types.Appsettings
+          }
+          @{
             key           = "EmptyBotJSWebApp"
             botName       = "bfcfnemptybotjswebapp"
+            resourceGroup = $groups.JS
+            configType    = $types.Appsettings
+          }
+          @{
+            key           = "EmptyBotJSFunctions"
+            botName       = "bfcfnemptybotjsfunctions"
             resourceGroup = $groups.JS
             configType    = $types.Appsettings
           }
@@ -415,7 +429,9 @@ steps:
             name      = "EmptyBot"; 
             consumers = @(
               "EmptyBotDotNetWebApp",
-              "EmptyBotJSWebApp"
+              "EmptyBotJSFunctions",
+              "EmptyBotJSWebApp",
+              "EmptyBotJSFunctions"
             );
           }
         )

--- a/tests/functional/build/yaml/testScenarios/runTestScenarios.yml
+++ b/tests/functional/build/yaml/testScenarios/runTestScenarios.yml
@@ -17,7 +17,9 @@ variables:
 
   ## Bots Configuration (Define these variables in Azure)
   # BfcfnEmptyBotDotNetWebAppId: (optional) App Id for BfcfnEmptyBotDotNetWebApp bot.
-  # BfcfnEmptyBotJSWebAppAppId: (optional) App Id for BfcfnEmptyBotJSWebApp bot.
+  # BfcfnEmptyBotDotNetFunctionsId: (optional) App Id for BfcfnEmptyBotDotNetFunctions bot.
+  # BfcfnEmptyBotJSWebAppId: (optional) App Id for BfcfnEmptyBotJSWebApp bot.
+  # BfcfnEmptyBotJSFunctionsId: (optional) App Id for BfcfnEmptyBotJSFunctions bot.
 
   # DeployBotResourcesGuid: (optional) Deploy Bot Resources pipeline GUID.
 
@@ -64,7 +66,9 @@ stages:
     parameters:
       appIds:
         EmptyBotDotNetWebApp: "$(BFCFNEMPTYBOTDOTNETWEBAPPID)"
+        EmptyBotDotNetFunctions: "$(BFCFNEMPTYBOTDOTNETFUNCTIONSID)"
         EmptyBotJSWebApp: "$(BFCFNEMPTYBOTJSWEBAPPID)"
+        EmptyBotJSFunctions: "$(BFCFNEMPTYBOTJSFUNCTIONSID)"
       azureSubscription: "$(AZURESUBSCRIPTION)"
       buildConfiguration: "$(BUILDCONFIGURATION)"
       buildIdSuffix: $[stageDependencies.Download_Variables.Download_Variables.outputs['Set_Variables.DeploymentBuildSuffix']]


### PR DESCRIPTION
### Purpose
Close #1069 

### Changes
Add ARM templates for Functions App deployment, taken from Composer's copy and modified. 

### Tests
Adds Empty Bot Dotnet/JS Functions App to test cases

### Feature Plan
This closes out the MVP for #1069, with an Empty Bot deploying in all variations and passing tests over Direct Line.

![image](https://user-images.githubusercontent.com/43043272/125689231-ef97f3a9-afa6-4c1a-a750-8496ad21e7a1.png)

![image](https://user-images.githubusercontent.com/43043272/125689169-92d0de3a-e996-4b38-9789-4919529864ca.png)

