### PR TITLE
chore: Ignore NU5048 to allow packages to be built locally

### DIFF
--- a/packages/Directory.Build.props
+++ b/packages/Directory.Build.props
@@ -18,7 +18,6 @@
     <RepositoryType />
     <NeutralLanguage>en-US</NeutralLanguage>
     <RepositoryUrl>https://github.com/Microsoft/botframework-components</RepositoryUrl>
-    <NoWarn>$(NoWarn);NU5048</NoWarn>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
@@ -26,7 +25,7 @@
 
   <PropertyGroup>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <NoWarn>NU1701</NoWarn>
+    <NoWarn>$(NoWarn),NU1701,NU5048</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/packages/Telephony/Microsoft.Bot.Components.Telephony.csproj
+++ b/packages/Telephony/Microsoft.Bot.Components.Telephony.csproj
@@ -48,7 +48,8 @@
   <PropertyGroup>
     <!-- Disable warning for SA0001 "XML comment analysis is disabled due to project configuration" which is not true -->
     <!-- Disable warning for SA1649 "file name should match first type name" due to use of generics -->
-    <NoWarn>$(NoWarn),SA0001,SA1649</NoWarn>    
+    <NoWarn>$(NoWarn),SA0001,SA1649</NoWarn>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>    
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
### Purpose

Ignore NU5048 to allow packages to be built locally. This was being overwritten by a second NoWarn clause in Directory.Build.props.

### Changes

- Ignore NU5048 to allow packages to be built locally. This was being overwritten by a second NoWarn clause in Directory.Build.props.
- Always generate Telephony package in local build

### Tests

- Ensure Microsoft.Bot.Component.sln builds successfully and Telephony package can be generated.

#minor

