### PR TITLE
chore: Telephony: Improve AllowInterruptions related behavior for recording actions 

### DIFF
--- a/packages/Telephony/Actions/BatchFixedLengthInput.cs
+++ b/packages/Telephony/Actions/BatchFixedLengthInput.cs
@@ -6,6 +6,7 @@ using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Bot.Builder.Dialogs;
+using Microsoft.Bot.Schema;
 using Newtonsoft.Json;
 
 namespace Microsoft.Bot.Components.Telephony.Actions
@@ -65,7 +66,8 @@ namespace Microsoft.Bot.Components.Telephony.Actions
         /// <inheritdoc/>
         public override Task<DialogTurnResult> ContinueDialogAsync(DialogContext dc, CancellationToken cancellationToken = default)
         {
-            if (Regex.Match(dc.Context.Activity.Text, _dtmfCharacterRegex).Success || dc.State.GetValue(TurnPath.Interrupted, () => false))
+            if ((dc.Context.Activity.Type == ActivityTypes.Message) &&
+                (Regex.Match(dc.Context.Activity.Text, _dtmfCharacterRegex).Success || dc.State.GetValue(TurnPath.Interrupted, () => false)))
             {
                 return base.ContinueDialogAsync(dc, cancellationToken);
             }

--- a/packages/Telephony/Actions/BatchTerminationCharacterInput.cs
+++ b/packages/Telephony/Actions/BatchTerminationCharacterInput.cs
@@ -6,6 +6,7 @@ using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Bot.Builder.Dialogs;
+using Microsoft.Bot.Schema;
 using Newtonsoft.Json;
 
 namespace Microsoft.Bot.Components.Telephony.Actions
@@ -59,7 +60,8 @@ namespace Microsoft.Bot.Components.Telephony.Actions
         /// <inheritdoc/>
         public override Task<DialogTurnResult> ContinueDialogAsync(DialogContext dc, CancellationToken cancellationToken = default)
         {
-            if (Regex.Match(dc.Context.Activity.Text, _dtmfCharacterRegex).Success || dc.State.GetValue(TurnPath.Interrupted, () => false))
+            if ((dc.Context.Activity.Type == ActivityTypes.Message) && 
+                (Regex.Match(dc.Context.Activity.Text, _dtmfCharacterRegex).Success || dc.State.GetValue(TurnPath.Interrupted, () => false)))
             {
                 return base.ContinueDialogAsync(dc, cancellationToken);
             }

--- a/packages/Telephony/Common/CommandDialog{T}.cs
+++ b/packages/Telephony/Common/CommandDialog{T}.cs
@@ -77,7 +77,9 @@ namespace Microsoft.Bot.Components.Telephony.Common
                     throw new ErrorResponseException($"{commandResult.Error.Code}: {commandResult.Error.Message}");
                 }
 
-                return await dc.EndDialogAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
+                return await dc.EndDialogAsync(
+                    new DialogTurnResult(DialogTurnStatus.Complete),
+                    cancellationToken: cancellationToken).ConfigureAwait(false);
             }
 
             // This activity was not the command result we were expecting. Mark as waiting and end the turn.

--- a/packages/Telephony/Common/CommandDialog{T}.cs
+++ b/packages/Telephony/Common/CommandDialog{T}.cs
@@ -25,7 +25,7 @@ namespace Microsoft.Bot.Components.Telephony.Common
     public class CommandDialog<T> : Dialog
     {
         /// <summary>
-        /// Gets or sets interruption policy. Default is FALSE since interruptions are tricky to model.
+        /// Gets or sets interruption policy.
         /// </summary>
         /// <value>
         /// Bool or expression which evalutes to bool.

--- a/packages/Telephony/Common/CommandDialog{T}.cs
+++ b/packages/Telephony/Common/CommandDialog{T}.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using AdaptiveExpressions.Properties;
@@ -24,13 +25,13 @@ namespace Microsoft.Bot.Components.Telephony.Common
     public class CommandDialog<T> : Dialog
     {
         /// <summary>
-        /// Gets or sets intteruption policy. 
+        /// Gets or sets interruption policy. Default is FALSE since interruptions are tricky to model.
         /// </summary>
         /// <value>
         /// Bool or expression which evalutes to bool.
         /// </value>
         [JsonProperty("allowInterruptions")]
-        public BoolExpression AllowInterruptions { get; set; } = true;
+        public BoolExpression AllowInterruptions { get; set; } = false;
 
         /// <summary>
         /// Gets or sets the name of the command.
@@ -104,6 +105,13 @@ namespace Microsoft.Bot.Components.Telephony.Common
 
                 // Stop bubbling if interruptions ar NOT allowed
                 return !canInterrupt;
+            }
+
+            // Mark activity as handled if this is the CommandResult that we are expecting.
+            if (dc.Context.Activity.Type == ActivityTypes.CommandResult
+                && dc.Context.Activity.Name == this.CommandName.GetValue(dc.State))
+            {
+                return true;
             }
 
             return false;

--- a/packages/Telephony/Common/RegexAggregatorInput.cs
+++ b/packages/Telephony/Common/RegexAggregatorInput.cs
@@ -36,13 +36,13 @@ namespace Microsoft.Bot.Components.Telephony.Actions
         }
 
         /// <summary>
-        /// Gets or sets intteruption policy. 
+        /// Gets or sets interruption policy. 
         /// </summary>
         /// <value>
         /// Bool or expression which evalutes to bool.
         /// </value>
         [JsonProperty("allowInterruptions")]
-        public BoolExpression AllowInterruptions { get; set; } = true;
+        public BoolExpression AllowInterruptions { get; set; } = false;
 
         /// <summary>
         /// Gets or sets the regex pattern to use to decide when the dialog has aggregated the whole message.

--- a/packages/Telephony/Readme.md
+++ b/packages/Telephony/Readme.md
@@ -38,13 +38,13 @@ The Start Recording action starts recording of the conversation.
 * AllowInterruptions [`true`,`false`]
 
 #### Usage
-* If a recording is started for a conversation, another recording for the same conversation cannot be started. In such case, the Telephony Channel returns an error indicating that the _"Recording is already in progress"_.
+* If a recording is started for a conversation, another recording for the same conversation cannot be started.
 * The start recording action is only valid when called in a conversation on the Telephony channel.
 
 #### Dialog Flow
-* By default AllowInterruptions is set to `true` i.e. dialog continues while the recording is started in the background.
-* To block the dialog when a recording is started, set AllowInterruptions to `false`.
-* When a start recording result is received and indicates success, the action is considered complete. If the dialog was blocked, interrruptions will be unblocked once the result is received.
+* By default AllowInterruptions is set to `false` i.e. dialog blocks while the recording is started in the background.
+* To allow the interruptions when the recording dialog when a recording is started, set AllowInterruptions to `true`.
+* When a start recording result is received and indicates success, the action is considered complete. If the dialog was blocked, interruptions will be unblocked once the result is received.
 
 #### Failures
 * When a start recording result is received and indicates error, the dialog throws an `ErrorResponseException`. 
@@ -56,13 +56,14 @@ The Pause Recording action pauses recording of the conversation. This action is 
 * AllowInterruptions [`true`,`false`] 
 
 #### Usage
-* If PauseRecording is called and there is no recording in progress, Telephony channel returns an error indicating that the _"Recording has not started"_.
+* If there is no recording in progress, the recording cannot be paused.
+* If a recording is already paused, the recording cannot be paused again.
 * The pause recording action is only valid when called in a conversation on the Telephony channel.
 
 #### Dialog Flow
-* By default AllowInterruptions is set to `true` i.e. dialog continues while the recording is being paused in the background.
-* To block the dialog when recording is paused, set AllowInterruptions to `false`.
-* When a pause recording result is received and indicates success, the action is considered complete. If the dialog was blocked, interrruptions will be unblocked once the result is received.
+* By default AllowInterruptions is set to `false` i.e. dialog blocks while the recording is being paused in the background.
+* To allow the interruptions when the recording dialog when a recording is started, set AllowInterruptions to `true`.
+* When a pause recording result is received and indicates success, the action is considered complete. If the dialog was blocked, interruptions will be unblocked once the result is received.
 
 #### Failures
 * When a pause recording result is received and indicates error, the dialog throws an `ErrorResponseException`. 
@@ -74,32 +75,33 @@ The Resume Recording action resumes recording of the conversation. This action i
 * AllowInterruptions [`true`,`false`] 
 
 #### Usage
-* [Open] _Add error details_
-* The pause recording action is only valid when called in a conversation on the Telephony channel.
+* If there is no recording in progress, the recording cannot be resumed.
+* If a recording is already resumed, the recording cannot be resumed again.
+* The resume recording action is only valid when called in a conversation on the Telephony channel.
 
 #### Dialog Flow
-* By default AllowInterruptions is set to `true` i.e. dialog continues while the recording is being resumed in the background.
-* To block the dialog when recording is resumed, set AllowInterruptions to `false`.
-* When a resume recording result is received and indicates success, the action is considered complete. If the dialog was blocked, interrruptions will be unblocked once the result is received.
+* By default AllowInterruptions is set to `false` i.e. dialog blocks while the recording is being resumed in the background.
+* To allow the interruptions when the recording dialog when a recording is started, set AllowInterruptions to `true`.
+* When a resume recording result is received and indicates success, the action is considered complete. If the dialog was blocked, interruptions will be unblocked once the result is received.
 
 #### Failures
 * When a resume recording result is received and indicates error, the dialog throws an `ErrorResponseException`. 
 
-### **Stop Recording**
+### **Stop Recording** _Pending Implementation_
 The Stop Recording action stops recording of the conversation. Note that it is not required to call StopRecording explicitly. The recording is always stopped when the bot/caller ends the conversation or if the call is transferred to an external phone number.
 
 #### Parameters
 * AllowInterruptions [`true`,`false`] 
 
 #### Usage
-* If StopRecording is called and there is no recording in progress, Telephony channel returns an error indicating that the _"Recording has not started"_.
+* If there is no recording in progress, the recording cannot be stopped.
 * If a recording for a single conversation is stopped and started again, the recordings appear as multiple recording sessions in the storage. We do not recommend using the pattern StartRecording-StopRecording-StartRecording-StopRecording since it creates multiple recording files for a single conversation. Instead, we recommend using StartRecording-PauseRecording-ResumeRecording-EndCall/StopRecording to create a single recording file for the converastion.
 * The stop recording action is only valid when called in a conversation on the Telephony channel.
 
 #### Dialog Flow
-* By default AllowInterruptions is set to `true` i.e. dialog continues while the recording is being stopped in the background.
-* To block the dialog when recording is stopped, set AllowInterruptions to `false`.
-* When a stop recording result is received and indicates success, the action is considered complete. If the dialog was blocked, interrruptions will be unblocked once the result is received.
+* By default AllowInterruptions is set to `false` i.e. dialog blockss while the recording is being stopped in the background.
+* To allow the interruptions when the recording dialog when a recording is started, set AllowInterruptions to `true`.
+* When a resume recording result is received and indicates success, the action is considered complete. If the dialog was blocked, interruptions will be unblocked once the result is received.
 
 #### Failures
 * When a stop recording result is received and indicates error, the dialog throws an `ErrorResponseException`.

--- a/packages/Telephony/Schemas/Microsoft.Telephony.BatchFixedLengthInput.schema
+++ b/packages/Telephony/Schemas/Microsoft.Telephony.BatchFixedLengthInput.schema
@@ -38,7 +38,12 @@
     "allowInterruptions": {
       "$ref": "schema:#/definitions/booleanExpression",
       "title": "Allow Interruptions",
-      "description": "Allow the parent dialog to receive messages to handle while the aggregation is underway."
+      "description": "Allow the parent dialog to receive messages to handle while the aggregation is underway.",
+      "default": false,
+      "examples": [
+        true,
+        "=user.xyz"
+      ]
     },
     "alwaysPrompt": {
       "$ref": "schema:#/definitions/booleanExpression",

--- a/packages/Telephony/Schemas/Microsoft.Telephony.BatchTerminationCharacterInput.schema
+++ b/packages/Telephony/Schemas/Microsoft.Telephony.BatchTerminationCharacterInput.schema
@@ -38,7 +38,12 @@
     "allowInterruptions": {
       "$ref": "schema:#/definitions/booleanExpression",
       "title": "Allow Interruptions",
-      "description": "Allow the parent dialog to receive messages to handle while the aggregation is underway."
+      "description": "Allow the parent dialog to receive messages to handle while the aggregation is underway.",
+      "default": false,
+      "examples": [
+        true,
+        "=user.xyz"
+      ]
     },
     "alwaysPrompt": {
       "$ref": "schema:#/definitions/booleanExpression",

--- a/packages/Telephony/Schemas/Microsoft.Telephony.PauseRecording.schema
+++ b/packages/Telephony/Schemas/Microsoft.Telephony.PauseRecording.schema
@@ -9,7 +9,12 @@
     "allowInterruptions": {
       "$ref": "schema:#/definitions/booleanExpression",
       "title": "Allow Interruptions",
-      "description": "Allow the dialog to continue when recording pause operation is in progress"
+      "description": "Allow the dialog to continue when recording pause operation is in progress",
+      "default": false,
+      "examples": [
+        true,
+        "=user.xyz"
+      ]
     }
   }
 }

--- a/packages/Telephony/Schemas/Microsoft.Telephony.PauseRecording.uischema
+++ b/packages/Telephony/Schemas/Microsoft.Telephony.PauseRecording.uischema
@@ -7,6 +7,11 @@
       "*"
     ],
     "properties": {
+      "allowInterruptions": {
+        "intellisenseScopes": [
+          "variable-scopes"
+        ]
+      }
     }
   },
   "menu": {

--- a/packages/Telephony/Schemas/Microsoft.Telephony.ResumeRecording.schema
+++ b/packages/Telephony/Schemas/Microsoft.Telephony.ResumeRecording.schema
@@ -9,7 +9,12 @@
     "allowInterruptions": {
       "$ref": "schema:#/definitions/booleanExpression",
       "title": "Allow Interruptions",
-      "description": "Allow the dialog to continue when recording resume operation is in progress"
+      "description": "Allow the dialog to continue when recording resume operation is in progress",
+      "default": false,
+      "examples": [
+        true,
+        "=user.xyz"
+      ]
     }
   }
 }

--- a/packages/Telephony/Schemas/Microsoft.Telephony.ResumeRecording.uischema
+++ b/packages/Telephony/Schemas/Microsoft.Telephony.ResumeRecording.uischema
@@ -7,6 +7,11 @@
       "*"
     ],
     "properties": {
+      "allowInterruptions": {
+        "intellisenseScopes": [
+          "variable-scopes"
+        ]
+      }
     }
   },
   "menu": {

--- a/packages/Telephony/Schemas/Microsoft.Telephony.StartRecording.schema
+++ b/packages/Telephony/Schemas/Microsoft.Telephony.StartRecording.schema
@@ -9,7 +9,12 @@
     "allowInterruptions": {
       "$ref": "schema:#/definitions/booleanExpression",
       "title": "Allow Interruptions",
-      "description": "Allow the dialog to continue when recording start operation is in progress"
+      "description": "Allow the dialog to continue when recording start operation is in progress",
+      "default": false,
+      "examples": [
+        true,
+        "=user.xyz"
+      ]
     }
   }
 }

--- a/packages/Telephony/Schemas/Microsoft.Telephony.StartRecording.uischema
+++ b/packages/Telephony/Schemas/Microsoft.Telephony.StartRecording.uischema
@@ -4,9 +4,15 @@
     "label": "Recording Start",
     "subtitle": "Starts recording the current conversation",
     "order": [
+      "allowInterruptions",
       "*"
     ],
     "properties": {
+      "allowInterruptions": {
+        "intellisenseScopes": [
+          "variable-scopes"
+        ]
+      }
     }
   },
   "menu": {

--- a/tests/unit/packages/Microsoft.Bot.Components.Telephony.Tests/BatchInputTests.cs
+++ b/tests/unit/packages/Microsoft.Bot.Components.Telephony.Tests/BatchInputTests.cs
@@ -35,6 +35,12 @@ namespace Microsoft.Bot.Components.Telephony.Tests
         }
 
         [Fact]
+        public async Task BatchInput_Termination_WithTangent_InterruptionEnabled_EventInterrupt()
+        {
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer, adapterChannel: Channels.Telephony);
+        }
+
+        [Fact]
         public async Task BatchInput_Termination_WithTangent_InterruptionDisabled()
         {
             await TestUtils.RunTestScript(
@@ -83,5 +89,12 @@ namespace Microsoft.Bot.Components.Telephony.Tests
                     .AddInMemoryCollection(new Dictionary<string, string>() { { "allowInterruptions", "false" } })
                     .Build());
         }
+
+        [Fact]
+        public async Task BatchInput_FixedLength_WithTangent_InterruptionEnabled_EventInterrupt()
+        {
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer, adapterChannel: Channels.Telephony);
+        }
+
     }
 }

--- a/tests/unit/packages/Microsoft.Bot.Components.Telephony.Tests/Integration/BatchInputTests/BatchInput_FixedLengthBaseScenario.test.dialog
+++ b/tests/unit/packages/Microsoft.Bot.Components.Telephony.Tests/Integration/BatchInputTests/BatchInput_FixedLengthBaseScenario.test.dialog
@@ -29,6 +29,15 @@
           "activity": "On help intent handler"
         }
       ]
+    },
+    {
+      "$kind": "Microsoft.OnEventActivity",
+      "actions": [
+        {
+          "$kind": "Microsoft.SendActivity",
+          "activity": "Event received"
+        }
+      ]
     }
   ],
   "recognizer": {

--- a/tests/unit/packages/Microsoft.Bot.Components.Telephony.Tests/Integration/BatchInputTests/BatchInput_FixedLength_WithTangent_InterruptionEnabled_EventInterrupt.test.dialog
+++ b/tests/unit/packages/Microsoft.Bot.Components.Telephony.Tests/Integration/BatchInputTests/BatchInput_FixedLength_WithTangent_InterruptionEnabled_EventInterrupt.test.dialog
@@ -1,0 +1,60 @@
+{
+  "$schema": "../../../tests.schema",
+  "$kind": "Microsoft.Test.Script",
+  "dialog": "BatchInput_FixedLengthBaseScenario.test",
+  "script": [
+    {
+      "$kind": "Microsoft.Test.UserConversationUpdate",
+      "membersAdded": [ "user" ]
+    },
+    {
+      "$kind": "Microsoft.Test.AssertReplyActivity",
+      "assertions": [
+        "type == 'message'",
+        "text == 'Enter your 6 digit phone number.'"
+      ]
+    },
+    {
+      "$kind": "Microsoft.Test.UserSays",
+      "text": "1"
+    },
+    {
+      "$kind": "Microsoft.Test.UserSays",
+      "text": "2"
+    },
+    {
+      "$kind": "Microsoft.Test.UserSays",
+      "text": "3"
+    },
+    {
+      "$kind": "Microsoft.Test.UserSays",
+      "text": "4"
+    },
+    {
+      "$kind": "Microsoft.Test.UserSays",
+      "text": "5"
+    },
+    {
+      "$kind": "Microsoft.Test.UserActivity",
+      "activity": {
+        "type": "event",
+        "name": "random_test_event"
+      }
+    },
+    {
+      "$kind": "Microsoft.Test.AssertReply",
+      "text": "Event received"
+    },
+    {
+      "$kind": "Microsoft.Test.UserSays",
+      "text": "9"
+    },
+    {
+      "$kind": "Microsoft.Test.AssertReplyActivity",
+      "assertions": [
+        "type == 'message'",
+        "text == '123459'"
+      ]
+    }
+  ]
+}

--- a/tests/unit/packages/Microsoft.Bot.Components.Telephony.Tests/Integration/BatchInputTests/BatchInput_TerminationBaseScenario.test.dialog
+++ b/tests/unit/packages/Microsoft.Bot.Components.Telephony.Tests/Integration/BatchInputTests/BatchInput_TerminationBaseScenario.test.dialog
@@ -29,6 +29,15 @@
           "activity": "On help intent handler"
         }
       ]
+    },
+    {
+      "$kind": "Microsoft.OnEventActivity",
+      "actions": [
+        {
+          "$kind": "Microsoft.SendActivity",
+          "activity": "Event received"
+        }
+      ]
     }
   ],
   "recognizer": {

--- a/tests/unit/packages/Microsoft.Bot.Components.Telephony.Tests/Integration/BatchInputTests/BatchInput_Termination_WithTangent_InterruptionEnabled_EventInterrupt.test.dialog
+++ b/tests/unit/packages/Microsoft.Bot.Components.Telephony.Tests/Integration/BatchInputTests/BatchInput_Termination_WithTangent_InterruptionEnabled_EventInterrupt.test.dialog
@@ -1,0 +1,60 @@
+{
+  "$schema": "../../../tests.schema",
+  "$kind": "Microsoft.Test.Script",
+  "dialog": "BatchInput_TerminationBaseScenario.test",
+  "script": [
+    {
+      "$kind": "Microsoft.Test.UserConversationUpdate",
+      "membersAdded": [ "user" ]
+    },
+    {
+      "$kind": "Microsoft.Test.AssertReplyActivity",
+      "assertions": [
+        "type == 'message'",
+        "text == 'Enter phone number ending with 9.'"
+      ]
+    },
+    {
+      "$kind": "Microsoft.Test.UserSays",
+      "text": "1"
+    },
+    {
+      "$kind": "Microsoft.Test.UserSays",
+      "text": "2"
+    },
+    {
+      "$kind": "Microsoft.Test.UserSays",
+      "text": "3"
+    },
+    {
+      "$kind": "Microsoft.Test.UserSays",
+      "text": "4"
+    },
+    {
+      "$kind": "Microsoft.Test.UserSays",
+      "text": "5"
+    },
+    {
+      "$kind": "Microsoft.Test.UserActivity",
+      "activity": {
+        "type": "event",
+        "name": "random_test_event"
+      }
+    },
+    {
+      "$kind": "Microsoft.Test.AssertReply",
+      "text": "Event received"
+    },
+    {
+      "$kind": "Microsoft.Test.UserSays",
+      "text": "9"
+    },
+    {
+      "$kind": "Microsoft.Test.AssertReplyActivity",
+      "assertions": [
+        "type == 'message'",
+        "text == '123459'"
+      ]
+    }
+  ]
+}

--- a/tests/unit/packages/Microsoft.Bot.Components.Telephony.Tests/Integration/RecordingTests/Recording_BaseScenario.test.dialog
+++ b/tests/unit/packages/Microsoft.Bot.Components.Telephony.Tests/Integration/RecordingTests/Recording_BaseScenario.test.dialog
@@ -8,7 +8,7 @@
             "actions": [
                 {
                     "$kind": "Microsoft.Telephony.StartRecording",
-                    "allowInterruptions": "=coalesce(settings.allowInterruptions, true)"
+                    "allowInterruptions": "=coalesce(settings.allowInterruptions, false)"
                 },
                 {
                     "$kind": "Microsoft.SendActivity",

--- a/tests/unit/packages/Microsoft.Bot.Components.Telephony.Tests/Microsoft.Bot.Components.Telephony.Tests.csproj
+++ b/tests/unit/packages/Microsoft.Bot.Components.Telephony.Tests/Microsoft.Bot.Components.Telephony.Tests.csproj
@@ -36,6 +36,12 @@
     <None Update="Integration\BatchInputTests\BatchInput_FixedLengthHappyPath.test.dialog">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Update="Integration\BatchInputTests\BatchInput_FixedLength_WithTangent_InterruptionEnabled_EventInterrupt.test.dialog">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="Integration\BatchInputTests\BatchInput_Termination_WithTangent_InterruptionEnabled_EventInterrupt.test.dialog">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Update="Integration\BatchInputTests\BatchInput_Termination_WithTangent_InterruptionEnabled_WithReprompt.test.dialog">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>

--- a/tests/unit/packages/Microsoft.Bot.Components.Telephony.Tests/RecordingTests.cs
+++ b/tests/unit/packages/Microsoft.Bot.Components.Telephony.Tests/RecordingTests.cs
@@ -25,7 +25,12 @@ namespace Microsoft.Bot.Components.Telephony.Tests
         [Fact]
         public async Task StartRecording_WithTangent_InterruptionEnabled()
         {
-            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer, adapterChannel: Channels.Telephony);
+            await TestUtils.RunTestScript(
+                _resourceExplorerFixture.ResourceExplorer, 
+                adapterChannel: Channels.Telephony,
+                configuration: new ConfigurationBuilder()
+                    .AddInMemoryCollection(new Dictionary<string, string>() { { "allowInterruptions", "true" } })
+                    .Build());
         }
 
         [Fact]
@@ -33,10 +38,7 @@ namespace Microsoft.Bot.Components.Telephony.Tests
         {
             await TestUtils.RunTestScript(
                 _resourceExplorerFixture.ResourceExplorer,
-                adapterChannel: Channels.Telephony,
-                configuration: new ConfigurationBuilder()
-                    .AddInMemoryCollection(new Dictionary<string, string>() { { "allowInterruptions", "false" } })
-                    .Build());
+                adapterChannel: Channels.Telephony);
         }
 
         [Fact]


### PR DESCRIPTION
### Purpose

Add reliability fixes to the Telephony package 

### Changes

1. Set interruptions to false in recording / DTMF actions
2. CommandDialogs - disable interruptions when the incoming activity is a commandResult with the expected name
3. DTMF - process incoming activity only if its a message

### Tests
1. Updated tests to mark interruptions as false by default
2. Verified that all tests work after the changes

### Feature Plan
readme.md updated.

#minor
