### PR TITLE
chore: implemented interrupt mask for digits in DTMF batching actions

### DIFF
--- a/packages/Telephony/Actions/BatchFixedLengthInput.cs
+++ b/packages/Telephony/Actions/BatchFixedLengthInput.cs
@@ -22,6 +22,7 @@ namespace Microsoft.Bot.Components.Telephony.Actions
         public const string Kind = "Microsoft.Telephony.BatchFixedLengthInput";
 
         private const string _dtmfCharacterRegex = @"^[\d#\*]+$";
+        private const string _interruptionMaskRegex = @"^[\d]+$";
         private int _batchLength;
 
         /// <summary>
@@ -36,6 +37,7 @@ namespace Microsoft.Bot.Components.Telephony.Actions
         {
             // enable instances of this command as debug break point
             this.RegisterSourceLocation(sourceFilePath, sourceLineNumber);
+            InterruptionMask = _interruptionMaskRegex;
         }
 
         /// <summary>

--- a/packages/Telephony/Actions/BatchTerminationCharacterInput.cs
+++ b/packages/Telephony/Actions/BatchTerminationCharacterInput.cs
@@ -22,6 +22,7 @@ namespace Microsoft.Bot.Components.Telephony.Actions
         public const string Kind = "Microsoft.Telephony.BatchTerminationCharacterInput";
 
         private const string _dtmfCharacterRegex = @"^[\d#\*]+$";
+        private const string _interruptionMaskRegex = @"^[\d]+$";
         private string _terminationCharacter;
 
         /// <summary>
@@ -36,6 +37,7 @@ namespace Microsoft.Bot.Components.Telephony.Actions
         {
             // enable instances of this command as debug break point
             this.RegisterSourceLocation(sourceFilePath, sourceLineNumber);
+            InterruptionMask = _interruptionMaskRegex;
         }
 
         /// <summary>

--- a/packages/Telephony/Readme.md
+++ b/packages/Telephony/Readme.md
@@ -120,7 +120,7 @@ Speech, DTMF inputs, and chat provided characters can all be used to provide inp
 
 #### Dialog Flow
 * The dialog will only end and continue to the next dialog when the batch length is reached.
-* If AllowInterruptions is true, the parent dialog will receive the input and can handle it as an intent.
+* If AllowInterruptions is true, the parent dialog will receive non-digit input and can handle it as an intent.
 * After the interruption is handled, control flow will resume with this dialog. If AlwaysPrompt is set to true, the dialog will attempt to start over, otherwise it will end this dialog without setting the output property.
 * Best practice recommendation when using interruptions is to validate that the output property has been set and handle the case in which it is and isn't set.'
 
@@ -145,7 +145,7 @@ Speech, DTMF inputs, and chat provided characters can all be used to provide inp
 
 #### Dialog Flow
 * The dialog will only end and continue to the next dialog when the termination character is sent.
-* If AllowInterruptions is true, the parent dialog will receive the input and can handle it as an intent.
+* If AllowInterruptions is true, the parent dialog will receive non-digit input and can handle it as an intent.
 * After the interruption is handled, control flow will resume with this dialog. If AlwaysPrompt is set to true, the dialog will attempt to start over, otherwise it will end this dialog without setting the output property.
 * Best practice recommendation when using interruptions is to validate that the output property has been set and handle the case in which it is and isn't set.'
 
@@ -158,4 +158,3 @@ Learn more about [creating bots with telephony capabilities](https://github.com/
 
 ## Feedback and issues
 If you encounter any issues with this package, or would like to share any feedback please open an Issue in our [GitHub repository](https://github.com/microsoft/botframework-components/issues/new/choose).
-

--- a/tests/unit/packages/Microsoft.Bot.Components.Telephony.Tests/BatchInputTests.cs
+++ b/tests/unit/packages/Microsoft.Bot.Components.Telephony.Tests/BatchInputTests.cs
@@ -35,6 +35,12 @@ namespace Microsoft.Bot.Components.Telephony.Tests
         }
 
         [Fact]
+        public async Task BatchInput_Termination_InterruptionIgnoredForMaskedDigits()
+        {
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer, adapterChannel: Channels.Telephony);
+        }
+
+        [Fact]
         public async Task BatchInput_Termination_WithTangent_InterruptionDisabled()
         {
             await TestUtils.RunTestScript(
@@ -82,6 +88,12 @@ namespace Microsoft.Bot.Components.Telephony.Tests
                 configuration: new ConfigurationBuilder()
                     .AddInMemoryCollection(new Dictionary<string, string>() { { "allowInterruptions", "false" } })
                     .Build());
+        }
+
+        [Fact]
+        public async Task BatchInput_FixedLength_InterruptionIgnoredForMaskedDigits()
+        {
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer, adapterChannel: Channels.Telephony);
         }
     }
 }

--- a/tests/unit/packages/Microsoft.Bot.Components.Telephony.Tests/Integration/BatchInputTests/BatchInput_FixedLengthBaseScenario.test.dialog
+++ b/tests/unit/packages/Microsoft.Bot.Components.Telephony.Tests/Integration/BatchInputTests/BatchInput_FixedLengthBaseScenario.test.dialog
@@ -29,6 +29,16 @@
           "activity": "On help intent handler"
         }
       ]
+    },
+    {
+      "$kind": "Microsoft.OnIntent",
+      "intent": "ZeroIntent",
+      "actions": [
+        {
+          "$kind": "Microsoft.SendActivity",
+          "activity": "On zero intent handler"
+        }
+      ]
     }
   ],
   "recognizer": {
@@ -37,6 +47,10 @@
       {
         "intent": "HelpIntent",
         "pattern": "help"
+      },
+      {
+        "intent": "ZeroIntent",
+        "pattern": "0"
       }
     ]
   }

--- a/tests/unit/packages/Microsoft.Bot.Components.Telephony.Tests/Integration/BatchInputTests/BatchInput_FixedLength_InterruptionIgnoredForMaskedDigits.test.dialog
+++ b/tests/unit/packages/Microsoft.Bot.Components.Telephony.Tests/Integration/BatchInputTests/BatchInput_FixedLength_InterruptionIgnoredForMaskedDigits.test.dialog
@@ -1,0 +1,49 @@
+{
+  "$schema": "../../../tests.schema",
+  "$kind": "Microsoft.Test.Script",
+  "dialog": "BatchInput_FixedLengthBaseScenario.test",
+  "script": [
+    {
+      "$kind": "Microsoft.Test.UserConversationUpdate",
+      "membersAdded": [ "user" ]
+    },
+    {
+      "$kind": "Microsoft.Test.AssertReplyActivity",
+      "assertions": [
+        "type == 'message'",
+        "text == 'Enter your 6 digit phone number.'"
+      ]
+    },
+    {
+      "$kind": "Microsoft.Test.UserSays",
+      "text": "1"
+    },
+    {
+      "$kind": "Microsoft.Test.UserSays",
+      "text": "2"
+    },
+    {
+      "$kind": "Microsoft.Test.UserSays",
+      "text": "3"
+    },
+    {
+      "$kind": "Microsoft.Test.UserSays",
+      "text": "4"
+    },
+    {
+      "$kind": "Microsoft.Test.UserSays",
+      "text": "0"
+    },
+    {
+      "$kind": "Microsoft.Test.UserSays",
+      "text": "9"
+    },
+    {
+      "$kind": "Microsoft.Test.AssertReplyActivity",
+      "assertions": [
+        "type == 'message'",
+        "text == '123409'"
+      ]
+    }
+  ]
+}

--- a/tests/unit/packages/Microsoft.Bot.Components.Telephony.Tests/Integration/BatchInputTests/BatchInput_TerminationBaseScenario.test.dialog
+++ b/tests/unit/packages/Microsoft.Bot.Components.Telephony.Tests/Integration/BatchInputTests/BatchInput_TerminationBaseScenario.test.dialog
@@ -29,6 +29,16 @@
           "activity": "On help intent handler"
         }
       ]
+    },
+    {
+      "$kind": "Microsoft.OnIntent",
+      "intent": "ZeroIntent",
+      "actions": [
+        {
+          "$kind": "Microsoft.SendActivity",
+          "activity": "On zero intent handler"
+        }
+      ]
     }
   ],
   "recognizer": {
@@ -37,6 +47,10 @@
       {
         "intent": "HelpIntent",
         "pattern": "help"
+      },
+      {
+        "intent": "ZeroIntent",
+        "pattern": "0"
       }
     ]
   }

--- a/tests/unit/packages/Microsoft.Bot.Components.Telephony.Tests/Integration/BatchInputTests/BatchInput_Termination_InterruptionIgnoredForMaskedDigits.test.dialog
+++ b/tests/unit/packages/Microsoft.Bot.Components.Telephony.Tests/Integration/BatchInputTests/BatchInput_Termination_InterruptionIgnoredForMaskedDigits.test.dialog
@@ -1,0 +1,53 @@
+{
+  "$schema": "../../../tests.schema",
+  "$kind": "Microsoft.Test.Script",
+  "dialog": "BatchInput_TerminationBaseScenario.test",
+  "script": [
+    {
+      "$kind": "Microsoft.Test.UserConversationUpdate",
+      "membersAdded": [ "user" ]
+    },
+    {
+      "$kind": "Microsoft.Test.AssertReplyActivity",
+      "assertions": [
+        "type == 'message'",
+        "text == 'Enter phone number ending with 9.'"
+      ]
+    },
+    {
+      "$kind": "Microsoft.Test.UserSays",
+      "text": "1"
+    },
+    {
+      "$kind": "Microsoft.Test.UserSays",
+      "text": "2"
+    },
+    {
+      "$kind": "Microsoft.Test.UserSays",
+      "text": "3"
+    },
+    {
+      "$kind": "Microsoft.Test.UserSays",
+      "text": "4"
+    },
+    {
+      "$kind": "Microsoft.Test.UserSays",
+      "text": "5"
+    },
+    {
+      "$kind": "Microsoft.Test.UserSays",
+      "text": "0"
+    },
+    {
+      "$kind": "Microsoft.Test.UserSays",
+      "text": "9"
+    },
+    {
+      "$kind": "Microsoft.Test.AssertReplyActivity",
+      "assertions": [
+        "type == 'message'",
+        "text == '1234509'"
+      ]
+    }
+  ]
+}

--- a/tests/unit/packages/Microsoft.Bot.Components.Telephony.Tests/Microsoft.Bot.Components.Telephony.Tests.csproj
+++ b/tests/unit/packages/Microsoft.Bot.Components.Telephony.Tests/Microsoft.Bot.Components.Telephony.Tests.csproj
@@ -36,6 +36,12 @@
     <None Update="Integration\BatchInputTests\BatchInput_FixedLengthHappyPath.test.dialog">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Update="Integration\BatchInputTests\BatchInput_FixedLength_InterruptionIgnoredForMaskedDigits.test.dialog">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+    <None Update="Integration\BatchInputTests\BatchInput_Termination_InterruptionIgnoredForMaskedDigits.test.dialog">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
     <None Update="Integration\BatchInputTests\BatchInput_Termination_WithTangent_InterruptionEnabled_WithReprompt.test.dialog">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>


### PR DESCRIPTION
<!-- This repository only accepts pull requests related to open issues, please link the open issue in description below. -->
<!-- See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. -->
<!-- For example - Close #123: Description goes here. -->

### Purpose

We think it's probably better if DTMF batching doesn't bubble digits by default, in case people are using top level intents for their menus. I implemented this.

<!--What is the context of this pull request? Why is it being done? -->

### Changes

Added an "Interruption Mask" to the regex aggregator, and then utilized it in the DTMF actions

<!-- Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.) -->

### Tests
Added two new tests to cover this case.

<!-- Is this covered by existing tests or new ones? If no, why not? -->
