### PR TITLE
build: revert pipelines bug introduced in #1231

### DIFF
--- a/build/yaml/templates/nuget-versioning-steps.yml
+++ b/build/yaml/templates/nuget-versioning-steps.yml
@@ -9,17 +9,8 @@ steps:
       $componentType = "$env:COMPONENTTYPE";
       "Component Type = $componentType";
 
-    if ($deploymentRingOverride) {
-      $deploymentRing = $deploymentRingOverride;
-    }
-
-    if (($deploymentRing.ToLowerInvariant() -eq "rc") -or ($deploymentRing.ToLowerInvariant() -eq "preview")) {
-      $releaseCandidateNumber = "$env:RELEASECANDIDATENUMBER";
-      "Release Candidate Number = $releaseCandidateNumber";
-
-      if (-not $releaseCandidateNumber) {
-        Write-Host "Release Candidate Number not defined"
-        exit 1
+      if ($deploymentRingOverride) {
+        $deploymentRing = $deploymentRingOverride;
       }
 
       if (($deploymentRing.ToLowerInvariant() -eq "rc") -or ($deploymentRing.ToLowerInvariant() -eq "preview")) {


### PR DESCRIPTION
### Purpose
The merge from #1231 introduced some duplicate code in one of the yaml pipelines that doesn't allow any of them to be run. This reverts it back to a working state. Validated on the HelpAndCancel package (tests both nuget and npm variations)

#minor
