### PR TITLE
fix: foreach bug in calendar for nested loop variables

### DIFF
--- a/generators/generator-bot-enterprise-calendar/generators/app/templates/dialogs/CreateEventDialog/CreateEventDialog.dialog
+++ b/generators/generator-bot-enterprise-calendar/generators/app/templates/dialogs/CreateEventDialog/CreateEventDialog.dialog
@@ -238,8 +238,8 @@
                     "id": "276TzP",
                     "comment": "Add all contacts to the event attendees array."
                   },
-                  "index": "$foreach.index",
-                  "value": "$foreach.value",
+                  "index": "$contactsLoop.index",
+                  "value": "$contactsLoop.value",
                   "itemsProperty": "$contacts",
                   "actions": [
                     {
@@ -249,7 +249,7 @@
                       },
                       "changeType": "push",
                       "itemsProperty": "$event.attendees",
-                      "value": "=$foreach.value"
+                      "value": "=$contactsLoop.value"
                     }
                   ]
                 }

--- a/generators/generator-bot-enterprise-calendar/generators/app/templates/dialogs/GetContactsDialog/GetContactsDialog.dialog
+++ b/generators/generator-bot-enterprise-calendar/generators/app/templates/dialogs/GetContactsDialog/GetContactsDialog.dialog
@@ -198,8 +198,8 @@
               "$designer": {
                 "id": "dXVR1S"
               },
-              "index": "$foreach.index",
-              "value": "$foreach.value",
+              "index": "$emailLoop.index",
+              "value": "$emailLoop.value",
               "itemsProperty": "$emailArray",
               "actions": [
                 {
@@ -214,7 +214,7 @@
                     },
                     {
                       "property": "$contact.EmailAddress.Address",
-                      "value": "=$foreach.value"
+                      "value": "=$emailLoop.value"
                     }
                   ]
                 },
@@ -262,8 +262,8 @@
               "$designer": {
                 "id": "XtcbtM"
               },
-              "index": "$foreach.index",
-              "value": "$foreach.value",
+              "index": "$contactLoop.index",
+              "value": "$contactLoop.value",
               "itemsProperty": "$contactArray",
               "actions": [
                 {
@@ -272,7 +272,7 @@
                     "id": "ugiGp1"
                   },
                   "eventName": "LookupContacts",
-                  "eventValue": "=$foreach.value"
+                  "eventValue": "=$contactLoop.value"
                 }
               ]
             }
@@ -346,8 +346,8 @@
                 "id": "oEq2mP",
                 "comment": "Each contact in MS Graph can have multiple email addresses. This loop add each email address for each contact to an array for the user to select the correct user/address to add."
               },
-              "index": "$foreach.searchResultIndex",
-              "value": "$foreach.searchResultValue",
+              "index": "$searchResultLoop.index",
+              "value": "$searchResultLoop.Value",
               "itemsProperty": "$searchResults",
               "actions": [
                 {
@@ -355,9 +355,9 @@
                   "$designer": {
                     "id": "xqotYJ"
                   },
-                  "index": "$foreach.EmailAddressIndex",
-                  "value": "$foreach.EmailAddressValue",
-                  "itemsProperty": "$foreach.searchResultValue.EmailAddresses",
+                  "index": "$emailAddressLoop.index",
+                  "value": "$emailAddressLoop.Value",
+                  "itemsProperty": "$searchResultLoop.value.EmailAddresses",
                   "actions": [
                     {
                       "$kind": "Microsoft.SetProperties",
@@ -367,11 +367,11 @@
                       "assignments": [
                         {
                           "property": "$candidate.email",
-                          "value": "=$foreach.EmailAddressValue"
+                          "value": "=$emailAddressLoop.value"
                         },
                         {
                           "property": "$candidate.name",
-                          "value": "=$foreach.searchResultValue.Name"
+                          "value": "=$searchResultLoop.Value.Name"
                         }
                       ]
                     },

--- a/generators/generator-bot-enterprise-calendar/generators/app/templates/dialogs/ListDialog/ListDialog.dialog
+++ b/generators/generator-bot-enterprise-calendar/generators/app/templates/dialogs/ListDialog/ListDialog.dialog
@@ -181,8 +181,8 @@
             "id": "DrAjqe",
             "comment": "Constructs the choice items to be shown in the ChoicePrompt. These settings allow the choice to be selected by the index or title property (configured in the dialog options) in addition to being selected via click."
           },
-          "index": "$foreach.index",
-          "value": "$foreach.value",
+          "index": "$pageItemLoop.index",
+          "value": "$pageItemLoop.value",
           "itemsProperty": "$pageItems",
           "actions": [
             {
@@ -191,8 +191,8 @@
                 "id": "kNUEEQ",
                 "comment": "The index property represents the user-facing index of each item, rather than the zero-based index used by default. "
               },
-              "property": "$pageItems[$foreach.index].index",
-              "value": "=$foreach.index + 1"
+              "property": "$pageItems[$pageItemLoop.index].index",
+              "value": "=$pageItemLoop.index + 1"
             },
             {
               "$kind": "Microsoft.SetProperty",
@@ -201,7 +201,7 @@
                 "comment": "The actionTitle property is passed via dialog options and indicates a field in the choice object that should be used as a way of selecting the item. For example, a contact object with a name and email property, may set the actionTitle to name so the user can select by saying the name of the option."
               },
               "property": "$actionTitle",
-              "value": "=$pageItems[$foreach.index][$actionTitleProperty]"
+              "value": "=$pageItems[$pageItemLoop.index][$actionTitleProperty]"
             },
             {
               "$kind": "Microsoft.SetProperty",
@@ -210,7 +210,7 @@
                 "comment": "Builds the choiceItem in the object format needed for the choice prompt. \n{ \"value\": \"<value>\", \"action\": { \"type\": \"postBack\", \"title\": \"<title>\" }}"
               },
               "property": "$choiceItem",
-              "value": "=json(concat('{ \"value\": \"', $pageItems[$foreach.index].index, '\", \"action\": { \"type\": \"postBack\", \"title\": \"', $actionTitle, '\" } }'))"
+              "value": "=json(concat('{ \"value\": \"', $pageItems[$pageItemLoop.index].index, '\", \"action\": { \"type\": \"postBack\", \"title\": \"', $actionTitle, '\" } }'))"
             },
             {
               "$kind": "Microsoft.EditArray",

--- a/generators/generator-bot-enterprise-calendar/generators/app/templates/dialogs/ResolveDateTimeDialog/ResolveDateTimeDialog.dialog
+++ b/generators/generator-bot-enterprise-calendar/generators/app/templates/dialogs/ResolveDateTimeDialog/ResolveDateTimeDialog.dialog
@@ -72,8 +72,8 @@
           "$designer": {
             "id": "ksIN1t"
           },
-          "index": "$foreach.index",
-          "value": "$foreach.value",
+          "index": "$recognitionResultsLoop.index",
+          "value": "$recognitionResultsLoop.value",
           "itemsProperty": "$recognitionResults",
           "actions": [
             {
@@ -82,7 +82,7 @@
                 "id": "vwdsTV",
                 "comment": "Skips any recognized values of type \"datetimeV2.set\" beause it can caused unexpected behavior."
               },
-              "condition": "=toLower($foreach.value.text) == \"my day\" || $foreach.value.typeName == \"datetimeV2.set\"",
+              "condition": "=toLower($recognitionResultsLoop.value.text) == \"my day\" || $recognitionResultsLoop.value.typeName == \"datetimeV2.set\"",
               "actions": [
                 {
                   "$kind": "Microsoft.ContinueLoop",
@@ -99,16 +99,16 @@
                 "comment": "Extracts the type of resolution."
               },
               "property": "$resolvedType",
-              "value": "=$foreach.value.Resolution.values[0].type"
+              "value": "=$recognitionResultsLoop.value.Resolution.values[0].type"
             },
             {
               "$kind": "Microsoft.Foreach",
               "$designer": {
                 "id": "et2uFP"
               },
-              "index": "dialog.foreach.index2",
-              "value": "dialog.foreach.value2",
-              "itemsProperty": "$foreach.value.Resolution.values",
+              "index": "$resolutionValuesLoop.index",
+              "value": "$resolutionValuesLoop.value",
+              "itemsProperty": "$recognitionResultsLoop.value.Resolution.values",
               "actions": [
                 {
                   "$kind": "Microsoft.SetProperties",
@@ -118,8 +118,8 @@
                   },
                   "assignments": [
                     {
-                      "property": "$foreach.value.Resolution.values[$foreach.index2].text",
-                      "value": "=$foreach.value.text"
+                      "property": "$recognitionResultsLoop.value.Resolution.values[$resolutionValuesLoop.index].text",
+                      "value": "=$recognitionResultsLoop.value.text"
                     }
                   ]
                 }
@@ -139,7 +139,7 @@
                 "id": "wUbrlv",
                 "comment": "If only one value was resolved."
               },
-              "condition": "=count($foreach.value.Resolution.values) == 1",
+              "condition": "=count($recognitionResultsLoop.value.Resolution.values) == 1",
               "actions": [
                 {
                   "$kind": "Microsoft.SetProperty",
@@ -148,7 +148,7 @@
                     "comment": "Returns resolved value to calling dialog."
                   },
                   "property": "$datetimeResolution",
-                  "value": "=$foreach.value.Resolution.values[0]"
+                  "value": "=$recognitionResultsLoop.value.Resolution.values[0]"
                 },
                 {
                   "$kind": "Microsoft.EndDialog",
@@ -175,7 +175,7 @@
                             "comment": "Prompts to diambiguate date values."
                           },
                           "eventName": "RefineDate",
-                          "eventValue": "=$foreach.value.Resolution.values"
+                          "eventValue": "=$recognitionResultsLoop.value.Resolution.values"
                         }
                       ]
                     },
@@ -189,7 +189,7 @@
                             "comment": "Prompts to diambiguate datetime values."
                           },
                           "eventName": "RefineDateTime",
-                          "eventValue": "=$foreach.value.Resolution.values"
+                          "eventValue": "=$recognitionResultsLoop.value.Resolution.values"
                         }
                       ]
                     },
@@ -203,7 +203,7 @@
                             "comment": "Prompts to diambiguate time values."
                           },
                           "eventName": "RefineTime",
-                          "eventValue": "=$foreach.value.Resolution.values"
+                          "eventValue": "=$recognitionResultsLoop.value.Resolution.values"
                         }
                       ]
                     },
@@ -217,7 +217,7 @@
                             "comment": "Prompts to diambiguate date range values."
                           },
                           "eventName": "RefineDateRange",
-                          "eventValue": "=$foreach.value.Resolution.values"
+                          "eventValue": "=$recognitionResultsLoop.value.Resolution.values"
                         }
                       ]
                     },
@@ -231,7 +231,7 @@
                             "comment": "Prompts to diambiguate date time range values."
                           },
                           "eventName": "RefineDateTimeRange",
-                          "eventValue": "=$foreach.value.Resolution.values"
+                          "eventValue": "=$recognitionResultsLoop.value.Resolution.values"
                         }
                       ]
                     },
@@ -245,7 +245,7 @@
                             "comment": "Prompts to diambiguate time range values."
                           },
                           "eventName": "RefineTimeRange",
-                          "eventValue": "=$foreach.value.Resolution.values"
+                          "eventValue": "=$recognitionResultsLoop.value.Resolution.values"
                         }
                       ]
                     }
@@ -308,8 +308,8 @@
             "id": "a43OOw",
             "comment": "Removes any options that do not pass validation against the $minDate option."
           },
-          "index": "$foreach.index",
-          "value": "$foreach.value",
+          "index": "$dateLoop.index",
+          "value": "$dateLoop.value",
           "itemsProperty": "turn.dialogEvent.Value",
           "actions": [
             {
@@ -317,14 +317,14 @@
               "$designer": {
                 "id": "IQInq1"
               },
-              "condition": "=$minDate != null && ticks(formatDateTime($foreach.value.value)) < ticks(formatDateTime(date($minDate)))",
+              "condition": "=$minDate != null && ticks(formatDateTime($dateLoop.value.value)) < ticks(formatDateTime(date($minDate)))",
               "actions": [
                 {
                   "$kind": "Microsoft.SetProperty",
                   "$designer": {
                     "id": "GLkygU"
                   },
-                  "property": "$foreach.skip",
+                  "property": "$dateLoop.skip",
                   "value": "=true"
                 }
               ],
@@ -334,7 +334,7 @@
                   "$designer": {
                     "id": "OlWE0O"
                   },
-                  "property": "$foreach.skip",
+                  "property": "$dateLoop.skip",
                   "value": "=false"
                 }
               ]
@@ -344,7 +344,7 @@
               "$designer": {
                 "id": "Xv3qc4"
               },
-              "condition": "=$foreach.skip != true",
+              "condition": "=$dateLoop.skip != true",
               "actions": [
                 {
                   "$kind": "Microsoft.SetProperty",
@@ -353,7 +353,7 @@
                     "comment": "Formats the value into a readable format."
                   },
                   "property": "$formattedOption",
-                  "value": "=formatDateTime($foreach.value.value, \"dddd, MMMM d, yyyy\")"
+                  "value": "=formatDateTime($dateLoop.value.value, \"dddd, MMMM d, yyyy\")"
                 },
                 {
                   "$kind": "Microsoft.EditArray",
@@ -465,8 +465,8 @@
             "id": "b2a4gT",
             "comment": "Removes any options that do not pass validation against the $minDate option."
           },
-          "index": "$foreach.index",
-          "value": "$foreach.value",
+          "index": "$datetimeLoop.index",
+          "value": "$datetimeLoop.value",
           "itemsProperty": "turn.dialogEvent.Value",
           "actions": [
             {
@@ -474,14 +474,14 @@
               "$designer": {
                 "id": "4nSPCc"
               },
-              "condition": "=$minDate != null && ticks(formatDateTime($foreach.value.value)) < ticks(formatDateTime($minDate))",
+              "condition": "=$minDate != null && ticks(formatDateTime($datetimeLoop.value.value)) < ticks(formatDateTime($minDate))",
               "actions": [
                 {
                   "$kind": "Microsoft.SetProperty",
                   "$designer": {
                     "id": "DQfu8f"
                   },
-                  "property": "$foreach.skip",
+                  "property": "$datetimeLoop.skip",
                   "value": "=true"
                 }
               ],
@@ -491,7 +491,7 @@
                   "$designer": {
                     "id": "OifsS5"
                   },
-                  "property": "$foreach.skip",
+                  "property": "$datetimeLoop.skip",
                   "value": "=false"
                 }
               ]
@@ -501,7 +501,7 @@
               "$designer": {
                 "id": "bYsQ7q"
               },
-              "condition": "=$foreach.skip != true",
+              "condition": "=$datetimeLoop.skip != true",
               "actions": [
                 {
                   "$kind": "Microsoft.SetProperty",
@@ -510,7 +510,7 @@
                     "comment": "Formats the value into a readable format."
                   },
                   "property": "$formattedOption",
-                  "value": "=formatDateTime($foreach.value.value, \"dddd, MMMM d, yyyy 'at' h:mm tt\")"
+                  "value": "=formatDateTime($datetimeLoop.value.value, \"dddd, MMMM d, yyyy 'at' h:mm tt\")"
                 },
                 {
                   "$kind": "Microsoft.EditArray",
@@ -619,8 +619,8 @@
           "$designer": {
             "id": "UtKCFb"
           },
-          "index": "$foreach.index",
-          "value": "$foreach.value",
+          "index": "$timeLoop.index",
+          "value": "$timeLoop.value",
           "itemsProperty": "turn.dialogEvent.Value",
           "actions": [
             {
@@ -630,7 +630,7 @@
                 "comment": "Formats the value into a readable format."
               },
               "property": "$formattedOption",
-              "value": "=formatDateTime($foreach.value.value, \"h:mm tt\")"
+              "value": "=formatDateTime($timeLoop.value.value, \"h:mm tt\")"
             },
             {
               "$kind": "Microsoft.EditArray",
@@ -688,8 +688,8 @@
           "$designer": {
             "id": "ZAwl4T"
           },
-          "index": "$foreach.index",
-          "value": "$foreach.value",
+          "index": "$dateRangeLoop.index",
+          "value": "$dateRangeLoop.value",
           "itemsProperty": "turn.dialogEvent.Value",
           "actions": [
             {
@@ -699,7 +699,7 @@
                 "comment": "Formats the value into a readable format."
               },
               "property": "$formattedOption",
-              "value": "=concat(formatDateTime($foreach.value.start, \"dddd, MMMM d, yyyy\"), ' - ', formatDateTime($foreach.value.end, \"dddd, MMMM d, yyyy\"))"
+              "value": "=concat(formatDateTime($dateRangeLoop.value.start, \"dddd, MMMM d, yyyy\"), ' - ', formatDateTime($dateRangeLoop.value.end, \"dddd, MMMM d, yyyy\"))"
             },
             {
               "$kind": "Microsoft.EditArray",
@@ -757,8 +757,8 @@
           "$designer": {
             "id": "Mjqbll"
           },
-          "index": "$foreach.index",
-          "value": "$foreach.value",
+          "index": "$datetimeRangeLoop.index",
+          "value": "$datetimeRangeLoop.value",
           "itemsProperty": "turn.dialogEvent.Value",
           "actions": [
             {
@@ -768,7 +768,7 @@
                 "comment": "Formats the value into a readable format."
               },
               "property": "$formattedOption",
-              "value": "=concat(formatDateTime($foreach.value.start, \"dddd, MMMM d, yyyy 'at' h:mm tt\"), ' - ', formatDateTime($foreach.value.end, \"dddd, MMMM d, yyyy 'at' h:mm tt\"))"
+              "value": "=concat(formatDateTime($datetimeRangeLoop.value.start, \"dddd, MMMM d, yyyy 'at' h:mm tt\"), ' - ', formatDateTime($datetimeRangeLoop.value.end, \"dddd, MMMM d, yyyy 'at' h:mm tt\"))"
             },
             {
               "$kind": "Microsoft.EditArray",
@@ -826,8 +826,8 @@
           "$designer": {
             "id": "3eMz8z"
           },
-          "index": "$foreach.index",
-          "value": "$foreach.value",
+          "index": "$timeRangeLoop.index",
+          "value": "$timeRangeLoop.value",
           "itemsProperty": "turn.dialogEvent.Value",
           "actions": [
             {
@@ -837,7 +837,7 @@
                 "comment": "Formats the value into a readable format."
               },
               "property": "$formattedOption",
-              "value": "=concat(formatDateTime($foreach.value.start, \"h:mm tt\"), ' - ', formatDateTime($foreach.value.end, \"h:mm tt\"))"
+              "value": "=concat(formatDateTime($timeRangeLoop.value.start, \"h:mm tt\"), ' - ', formatDateTime($timeRangeLoop.value.end, \"h:mm tt\"))"
             },
             {
               "$kind": "Microsoft.EditArray",

--- a/generators/generator-bot-enterprise-calendar/generators/app/templates/dialogs/UpdateEventDialog/UpdateEventDialog.dialog
+++ b/generators/generator-bot-enterprise-calendar/generators/app/templates/dialogs/UpdateEventDialog/UpdateEventDialog.dialog
@@ -481,8 +481,8 @@
                   "$designer": {
                     "id": "cHmZ4Y"
                   },
-                  "index": "$foreach.index",
-                  "value": "$foreach.value",
+                  "index": "$contactLoop.index",
+                  "value": "$contactLoop.value",
                   "itemsProperty": "$contacts",
                   "actions": [
                     {
@@ -492,7 +492,7 @@
                       },
                       "changeType": "push",
                       "itemsProperty": "$event.attendees",
-                      "value": "=$foreach.value"
+                      "value": "=$contactLoop.value"
                     }
                   ]
                 }
@@ -1315,7 +1315,8 @@
           "defaultValueResponse": "",
           "choiceOptions": {
             "includeNumbers": true,
-            "inlineOrMore": ", or "
+            "inlineOrMore": ", or ",
+            "inlineOr": " or "
           },
           "property": "$cancelConfirmed",
           "prompt": "${ConfirmInput_Prompt_br66dN()}"

--- a/skills/declarative/Calendar/Calendar/dialogs/CancelEventDialog/CancelEventDialog.dialog
+++ b/skills/declarative/Calendar/Calendar/dialogs/CancelEventDialog/CancelEventDialog.dialog
@@ -198,6 +198,5 @@
   ],
   "generator": "CancelEventDialog.lg",
   "recognizer": "CancelEventDialog.lu.qna",
-  "id": "CancelEventDialog",
-  "dialogs": []
+  "id": "CancelEventDialog"
 }

--- a/skills/declarative/Calendar/Calendar/dialogs/CreateEventDialog/CreateEventDialog.dialog
+++ b/skills/declarative/Calendar/Calendar/dialogs/CreateEventDialog/CreateEventDialog.dialog
@@ -238,8 +238,8 @@
                     "id": "276TzP",
                     "comment": "Add all contacts to the event attendees array."
                   },
-                  "index": "$foreach.index",
-                  "value": "$foreach.value",
+                  "index": "$contactsLoop.index",
+                  "value": "$contactsLoop.value",
                   "itemsProperty": "$contacts",
                   "actions": [
                     {
@@ -249,7 +249,7 @@
                       },
                       "changeType": "push",
                       "itemsProperty": "$event.attendees",
-                      "value": "=$foreach.value"
+                      "value": "=$contactsLoop.value"
                     }
                   ]
                 }

--- a/skills/declarative/Calendar/Calendar/dialogs/CreateEventDialog/language-generation/en-us/CreateEventDialog.en-us.lg
+++ b/skills/declarative/Calendar/Calendar/dialogs/CreateEventDialog/language-generation/en-us/CreateEventDialog.en-us.lg
@@ -43,7 +43,7 @@
 
 # CreateConfirmNotUnderstood()
 [Activity
-    text = Sorry, I didn't understand that. ${CreateConfirmPrompt()}
+    text = Sorry, I didn't understand that. ${CreateConfirmText()}
     attachments = ${json(EventDetailEditCard($event))}
 ]
 

--- a/skills/declarative/Calendar/Calendar/dialogs/GetContactsDialog/GetContactsDialog.dialog
+++ b/skills/declarative/Calendar/Calendar/dialogs/GetContactsDialog/GetContactsDialog.dialog
@@ -198,8 +198,8 @@
               "$designer": {
                 "id": "dXVR1S"
               },
-              "index": "$foreach.index",
-              "value": "$foreach.value",
+              "index": "$emailLoop.index",
+              "value": "$emailLoop.value",
               "itemsProperty": "$emailArray",
               "actions": [
                 {
@@ -214,7 +214,7 @@
                     },
                     {
                       "property": "$contact.EmailAddress.Address",
-                      "value": "=$foreach.value"
+                      "value": "=$emailLoop.value"
                     }
                   ]
                 },
@@ -262,8 +262,8 @@
               "$designer": {
                 "id": "XtcbtM"
               },
-              "index": "$foreach.index",
-              "value": "$foreach.value",
+              "index": "$contactLoop.index",
+              "value": "$contactLoop.value",
               "itemsProperty": "$contactArray",
               "actions": [
                 {
@@ -272,7 +272,7 @@
                     "id": "ugiGp1"
                   },
                   "eventName": "LookupContacts",
-                  "eventValue": "=$foreach.value"
+                  "eventValue": "=$contactLoop.value"
                 }
               ]
             }
@@ -346,8 +346,8 @@
                 "id": "oEq2mP",
                 "comment": "Each contact in MS Graph can have multiple email addresses. This loop add each email address for each contact to an array for the user to select the correct user/address to add."
               },
-              "index": "$foreach.searchResultIndex",
-              "value": "$foreach.searchResultValue",
+              "index": "$searchResultLoop.index",
+              "value": "$searchResultLoop.Value",
               "itemsProperty": "$searchResults",
               "actions": [
                 {
@@ -355,9 +355,9 @@
                   "$designer": {
                     "id": "xqotYJ"
                   },
-                  "index": "$foreach.EmailAddressIndex",
-                  "value": "$foreach.EmailAddressValue",
-                  "itemsProperty": "$foreach.searchResultValue.EmailAddresses",
+                  "index": "$emailAddressLoop.index",
+                  "value": "$emailAddressLoop.Value",
+                  "itemsProperty": "$searchResultLoop.value.EmailAddresses",
                   "actions": [
                     {
                       "$kind": "Microsoft.SetProperties",
@@ -367,11 +367,11 @@
                       "assignments": [
                         {
                           "property": "$candidate.email",
-                          "value": "=$foreach.EmailAddressValue"
+                          "value": "=$emailAddressLoop.value"
                         },
                         {
                           "property": "$candidate.name",
-                          "value": "=$foreach.searchResultValue.Name"
+                          "value": "=$searchResultLoop.Value.Name"
                         }
                       ]
                     },

--- a/skills/declarative/Calendar/Calendar/dialogs/GetEventsDialog/GetEventsDialog.dialog
+++ b/skills/declarative/Calendar/Calendar/dialogs/GetEventsDialog/GetEventsDialog.dialog
@@ -571,7 +571,7 @@
           "$designer": {
             "id": "eKetEB"
           },
-          "name": "Calendar.OnNoResultsEvent",
+          "name": "GetEvents.OnNoResultsEvent",
           "value": "=null"
         },
         {

--- a/skills/declarative/Calendar/Calendar/dialogs/ListDialog/ListDialog.dialog
+++ b/skills/declarative/Calendar/Calendar/dialogs/ListDialog/ListDialog.dialog
@@ -181,8 +181,8 @@
             "id": "DrAjqe",
             "comment": "Constructs the choice items to be shown in the ChoicePrompt. These settings allow the choice to be selected by the index or title property (configured in the dialog options) in addition to being selected via click."
           },
-          "index": "$foreach.index",
-          "value": "$foreach.value",
+          "index": "$pageItemLoop.index",
+          "value": "$pageItemLoop.value",
           "itemsProperty": "$pageItems",
           "actions": [
             {
@@ -191,8 +191,8 @@
                 "id": "kNUEEQ",
                 "comment": "The index property represents the user-facing index of each item, rather than the zero-based index used by default. "
               },
-              "property": "$pageItems[$foreach.index].index",
-              "value": "=$foreach.index + 1"
+              "property": "$pageItems[$pageItemLoop.index].index",
+              "value": "=$pageItemLoop.index + 1"
             },
             {
               "$kind": "Microsoft.SetProperty",
@@ -201,7 +201,7 @@
                 "comment": "The actionTitle property is passed via dialog options and indicates a field in the choice object that should be used as a way of selecting the item. For example, a contact object with a name and email property, may set the actionTitle to name so the user can select by saying the name of the option."
               },
               "property": "$actionTitle",
-              "value": "=$pageItems[$foreach.index][$actionTitleProperty]"
+              "value": "=$pageItems[$pageItemLoop.index][$actionTitleProperty]"
             },
             {
               "$kind": "Microsoft.SetProperty",
@@ -210,7 +210,7 @@
                 "comment": "Builds the choiceItem in the object format needed for the choice prompt. \n{ \"value\": \"<value>\", \"action\": { \"type\": \"postBack\", \"title\": \"<title>\" }}"
               },
               "property": "$choiceItem",
-              "value": "=json(concat('{ \"value\": \"', $pageItems[$foreach.index].index, '\", \"action\": { \"type\": \"postBack\", \"title\": \"', $actionTitle, '\" } }'))"
+              "value": "=json(concat('{ \"value\": \"', $pageItems[$pageItemLoop.index].index, '\", \"action\": { \"type\": \"postBack\", \"title\": \"', $actionTitle, '\" } }'))"
             },
             {
               "$kind": "Microsoft.EditArray",

--- a/skills/declarative/Calendar/Calendar/dialogs/ResolveDateTimeDialog/ResolveDateTimeDialog.dialog
+++ b/skills/declarative/Calendar/Calendar/dialogs/ResolveDateTimeDialog/ResolveDateTimeDialog.dialog
@@ -72,8 +72,8 @@
           "$designer": {
             "id": "ksIN1t"
           },
-          "index": "$foreach.index",
-          "value": "$foreach.value",
+          "index": "$recognitionResultsLoop.index",
+          "value": "$recognitionResultsLoop.value",
           "itemsProperty": "$recognitionResults",
           "actions": [
             {
@@ -82,7 +82,7 @@
                 "id": "vwdsTV",
                 "comment": "Skips any recognized values of type \"datetimeV2.set\" beause it can caused unexpected behavior."
               },
-              "condition": "=toLower($foreach.value.text) == \"my day\" || $foreach.value.typeName == \"datetimeV2.set\"",
+              "condition": "=toLower($recognitionResultsLoop.value.text) == \"my day\" || $recognitionResultsLoop.value.typeName == \"datetimeV2.set\"",
               "actions": [
                 {
                   "$kind": "Microsoft.ContinueLoop",
@@ -99,16 +99,16 @@
                 "comment": "Extracts the type of resolution."
               },
               "property": "$resolvedType",
-              "value": "=$foreach.value.Resolution.values[0].type"
+              "value": "=$recognitionResultsLoop.value.Resolution.values[0].type"
             },
             {
               "$kind": "Microsoft.Foreach",
               "$designer": {
                 "id": "et2uFP"
               },
-              "index": "dialog.foreach.index2",
-              "value": "dialog.foreach.value2",
-              "itemsProperty": "$foreach.value.Resolution.values",
+              "index": "$resolutionValuesLoop.index",
+              "value": "$resolutionValuesLoop.value",
+              "itemsProperty": "$recognitionResultsLoop.value.Resolution.values",
               "actions": [
                 {
                   "$kind": "Microsoft.SetProperties",
@@ -118,8 +118,8 @@
                   },
                   "assignments": [
                     {
-                      "property": "$foreach.value.Resolution.values[$foreach.index2].text",
-                      "value": "=$foreach.value.text"
+                      "property": "$recognitionResultsLoop.value.Resolution.values[$resolutionValuesLoop.index].text",
+                      "value": "=$recognitionResultsLoop.value.text"
                     }
                   ]
                 }
@@ -139,7 +139,7 @@
                 "id": "wUbrlv",
                 "comment": "If only one value was resolved."
               },
-              "condition": "=count($foreach.value.Resolution.values) == 1",
+              "condition": "=count($recognitionResultsLoop.value.Resolution.values) == 1",
               "actions": [
                 {
                   "$kind": "Microsoft.SetProperty",
@@ -148,7 +148,7 @@
                     "comment": "Returns resolved value to calling dialog."
                   },
                   "property": "$datetimeResolution",
-                  "value": "=$foreach.value.Resolution.values[0]"
+                  "value": "=$recognitionResultsLoop.value.Resolution.values[0]"
                 },
                 {
                   "$kind": "Microsoft.EndDialog",
@@ -175,7 +175,7 @@
                             "comment": "Prompts to diambiguate date values."
                           },
                           "eventName": "RefineDate",
-                          "eventValue": "=$foreach.value.Resolution.values"
+                          "eventValue": "=$recognitionResultsLoop.value.Resolution.values"
                         }
                       ]
                     },
@@ -189,7 +189,7 @@
                             "comment": "Prompts to diambiguate datetime values."
                           },
                           "eventName": "RefineDateTime",
-                          "eventValue": "=$foreach.value.Resolution.values"
+                          "eventValue": "=$recognitionResultsLoop.value.Resolution.values"
                         }
                       ]
                     },
@@ -203,7 +203,7 @@
                             "comment": "Prompts to diambiguate time values."
                           },
                           "eventName": "RefineTime",
-                          "eventValue": "=$foreach.value.Resolution.values"
+                          "eventValue": "=$recognitionResultsLoop.value.Resolution.values"
                         }
                       ]
                     },
@@ -217,7 +217,7 @@
                             "comment": "Prompts to diambiguate date range values."
                           },
                           "eventName": "RefineDateRange",
-                          "eventValue": "=$foreach.value.Resolution.values"
+                          "eventValue": "=$recognitionResultsLoop.value.Resolution.values"
                         }
                       ]
                     },
@@ -231,7 +231,7 @@
                             "comment": "Prompts to diambiguate date time range values."
                           },
                           "eventName": "RefineDateTimeRange",
-                          "eventValue": "=$foreach.value.Resolution.values"
+                          "eventValue": "=$recognitionResultsLoop.value.Resolution.values"
                         }
                       ]
                     },
@@ -245,7 +245,7 @@
                             "comment": "Prompts to diambiguate time range values."
                           },
                           "eventName": "RefineTimeRange",
-                          "eventValue": "=$foreach.value.Resolution.values"
+                          "eventValue": "=$recognitionResultsLoop.value.Resolution.values"
                         }
                       ]
                     }
@@ -308,8 +308,8 @@
             "id": "a43OOw",
             "comment": "Removes any options that do not pass validation against the $minDate option."
           },
-          "index": "$foreach.index",
-          "value": "$foreach.value",
+          "index": "$dateLoop.index",
+          "value": "$dateLoop.value",
           "itemsProperty": "turn.dialogEvent.Value",
           "actions": [
             {
@@ -317,14 +317,14 @@
               "$designer": {
                 "id": "IQInq1"
               },
-              "condition": "=$minDate != null && ticks(formatDateTime($foreach.value.value)) < ticks(formatDateTime(date($minDate)))",
+              "condition": "=$minDate != null && ticks(formatDateTime($dateLoop.value.value)) < ticks(formatDateTime(date($minDate)))",
               "actions": [
                 {
                   "$kind": "Microsoft.SetProperty",
                   "$designer": {
                     "id": "GLkygU"
                   },
-                  "property": "$foreach.skip",
+                  "property": "$dateLoop.skip",
                   "value": "=true"
                 }
               ],
@@ -334,7 +334,7 @@
                   "$designer": {
                     "id": "OlWE0O"
                   },
-                  "property": "$foreach.skip",
+                  "property": "$dateLoop.skip",
                   "value": "=false"
                 }
               ]
@@ -344,7 +344,7 @@
               "$designer": {
                 "id": "Xv3qc4"
               },
-              "condition": "=$foreach.skip != true",
+              "condition": "=$dateLoop.skip != true",
               "actions": [
                 {
                   "$kind": "Microsoft.SetProperty",
@@ -353,7 +353,7 @@
                     "comment": "Formats the value into a readable format."
                   },
                   "property": "$formattedOption",
-                  "value": "=formatDateTime($foreach.value.value, \"dddd, MMMM d, yyyy\")"
+                  "value": "=formatDateTime($dateLoop.value.value, \"dddd, MMMM d, yyyy\")"
                 },
                 {
                   "$kind": "Microsoft.EditArray",
@@ -465,8 +465,8 @@
             "id": "b2a4gT",
             "comment": "Removes any options that do not pass validation against the $minDate option."
           },
-          "index": "$foreach.index",
-          "value": "$foreach.value",
+          "index": "$datetimeLoop.index",
+          "value": "$datetimeLoop.value",
           "itemsProperty": "turn.dialogEvent.Value",
           "actions": [
             {
@@ -474,14 +474,14 @@
               "$designer": {
                 "id": "4nSPCc"
               },
-              "condition": "=$minDate != null && ticks(formatDateTime($foreach.value.value)) < ticks(formatDateTime($minDate))",
+              "condition": "=$minDate != null && ticks(formatDateTime($datetimeLoop.value.value)) < ticks(formatDateTime($minDate))",
               "actions": [
                 {
                   "$kind": "Microsoft.SetProperty",
                   "$designer": {
                     "id": "DQfu8f"
                   },
-                  "property": "$foreach.skip",
+                  "property": "$datetimeLoop.skip",
                   "value": "=true"
                 }
               ],
@@ -491,7 +491,7 @@
                   "$designer": {
                     "id": "OifsS5"
                   },
-                  "property": "$foreach.skip",
+                  "property": "$datetimeLoop.skip",
                   "value": "=false"
                 }
               ]
@@ -501,7 +501,7 @@
               "$designer": {
                 "id": "bYsQ7q"
               },
-              "condition": "=$foreach.skip != true",
+              "condition": "=$datetimeLoop.skip != true",
               "actions": [
                 {
                   "$kind": "Microsoft.SetProperty",
@@ -510,7 +510,7 @@
                     "comment": "Formats the value into a readable format."
                   },
                   "property": "$formattedOption",
-                  "value": "=formatDateTime($foreach.value.value, \"dddd, MMMM d, yyyy 'at' h:mm tt\")"
+                  "value": "=formatDateTime($datetimeLoop.value.value, \"dddd, MMMM d, yyyy 'at' h:mm tt\")"
                 },
                 {
                   "$kind": "Microsoft.EditArray",
@@ -619,8 +619,8 @@
           "$designer": {
             "id": "UtKCFb"
           },
-          "index": "$foreach.index",
-          "value": "$foreach.value",
+          "index": "$timeLoop.index",
+          "value": "$timeLoop.value",
           "itemsProperty": "turn.dialogEvent.Value",
           "actions": [
             {
@@ -630,7 +630,7 @@
                 "comment": "Formats the value into a readable format."
               },
               "property": "$formattedOption",
-              "value": "=formatDateTime($foreach.value.value, \"h:mm tt\")"
+              "value": "=formatDateTime($timeLoop.value.value, \"h:mm tt\")"
             },
             {
               "$kind": "Microsoft.EditArray",
@@ -688,8 +688,8 @@
           "$designer": {
             "id": "ZAwl4T"
           },
-          "index": "$foreach.index",
-          "value": "$foreach.value",
+          "index": "$dateRangeLoop.index",
+          "value": "$dateRangeLoop.value",
           "itemsProperty": "turn.dialogEvent.Value",
           "actions": [
             {
@@ -699,7 +699,7 @@
                 "comment": "Formats the value into a readable format."
               },
               "property": "$formattedOption",
-              "value": "=concat(formatDateTime($foreach.value.start, \"dddd, MMMM d, yyyy\"), ' - ', formatDateTime($foreach.value.end, \"dddd, MMMM d, yyyy\"))"
+              "value": "=concat(formatDateTime($dateRangeLoop.value.start, \"dddd, MMMM d, yyyy\"), ' - ', formatDateTime($dateRangeLoop.value.end, \"dddd, MMMM d, yyyy\"))"
             },
             {
               "$kind": "Microsoft.EditArray",
@@ -757,8 +757,8 @@
           "$designer": {
             "id": "Mjqbll"
           },
-          "index": "$foreach.index",
-          "value": "$foreach.value",
+          "index": "$datetimeRangeLoop.index",
+          "value": "$datetimeRangeLoop.value",
           "itemsProperty": "turn.dialogEvent.Value",
           "actions": [
             {
@@ -768,7 +768,7 @@
                 "comment": "Formats the value into a readable format."
               },
               "property": "$formattedOption",
-              "value": "=concat(formatDateTime($foreach.value.start, \"dddd, MMMM d, yyyy 'at' h:mm tt\"), ' - ', formatDateTime($foreach.value.end, \"dddd, MMMM d, yyyy 'at' h:mm tt\"))"
+              "value": "=concat(formatDateTime($datetimeRangeLoop.value.start, \"dddd, MMMM d, yyyy 'at' h:mm tt\"), ' - ', formatDateTime($datetimeRangeLoop.value.end, \"dddd, MMMM d, yyyy 'at' h:mm tt\"))"
             },
             {
               "$kind": "Microsoft.EditArray",
@@ -826,8 +826,8 @@
           "$designer": {
             "id": "3eMz8z"
           },
-          "index": "$foreach.index",
-          "value": "$foreach.value",
+          "index": "$timeRangeLoop.index",
+          "value": "$timeRangeLoop.value",
           "itemsProperty": "turn.dialogEvent.Value",
           "actions": [
             {
@@ -837,7 +837,7 @@
                 "comment": "Formats the value into a readable format."
               },
               "property": "$formattedOption",
-              "value": "=concat(formatDateTime($foreach.value.start, \"h:mm tt\"), ' - ', formatDateTime($foreach.value.end, \"h:mm tt\"))"
+              "value": "=concat(formatDateTime($timeRangeLoop.value.start, \"h:mm tt\"), ' - ', formatDateTime($timeRangeLoop.value.end, \"h:mm tt\"))"
             },
             {
               "$kind": "Microsoft.EditArray",

--- a/skills/declarative/Calendar/Calendar/dialogs/UpdateEventDialog/UpdateEventDialog.dialog
+++ b/skills/declarative/Calendar/Calendar/dialogs/UpdateEventDialog/UpdateEventDialog.dialog
@@ -481,8 +481,8 @@
                   "$designer": {
                     "id": "cHmZ4Y"
                   },
-                  "index": "$foreach.index",
-                  "value": "$foreach.value",
+                  "index": "$contactLoop.index",
+                  "value": "$contactLoop.value",
                   "itemsProperty": "$contacts",
                   "actions": [
                     {
@@ -492,7 +492,7 @@
                       },
                       "changeType": "push",
                       "itemsProperty": "$event.attendees",
-                      "value": "=$foreach.value"
+                      "value": "=$contactLoop.value"
                     }
                   ]
                 }


### PR DESCRIPTION
This PR renamed all the foreach loop index and value variables to be unique as required by version 4.15.1 of the SDK. In this SDK version, the foreach action has been redesigned to resolve stackoverflow exceptions thrown by the previous implementation and improve bot performance. 

The foreach loop value and index variables should be unique within the dialog scope of the dialog so that external loop processing is not affected by internal loop processing. 

#minor