### PR TITLE
fix: make globby exclusion parameter explicit

### DIFF
--- a/generators/generator-bot-adaptive/baseGenerator.js
+++ b/generators/generator-bot-adaptive/baseGenerator.js
@@ -57,11 +57,12 @@ module.exports = class extends Generator {
     );
   }
 
-  _copyBotTemplateFiles({ path = ['**', '*.*'], templateContext = {} } = {}) {
+  _copyBotTemplateFiles({ path = ['**'], templateContext = {} } = {}) {
     const { botName } = this.options;
 
     const context = Object.assign({}, templateContext, { botName });
 
+    
     for (const filePath of this._selectTemplateFilePaths(...path)) {
       this.fs.copyTpl(
         this.templatePath(filePath),
@@ -71,7 +72,7 @@ module.exports = class extends Generator {
     }
   }
 
-  _selectTemplateFilePaths(...path) {
+  _selectTemplateFilePaths(path, exclusion = null) {
     // This function returns POSIX relative paths to template files that match
     // the specified path. For example, if the following template files existed:
     //
@@ -89,8 +90,12 @@ module.exports = class extends Generator {
     // (+1 for the trailing backslash that is not included in this.sourceRoot()).
     const beginIndex = normalize(this.sourceRoot()).length + 1;
 
+    let globbyParams = [normalize(this.templatePath(path))];
+    // only pass in the exclusion if it is not null
+    if (exclusion) globbyParams.push(exclusion);
+
     return globby
-      .sync(normalize(this.templatePath(...path)), {
+      .sync(globbyParams, {
         nodir: true,
       })
       .map((result) => result.slice(beginIndex));

--- a/generators/generator-bot-adaptive/baseGenerator.js
+++ b/generators/generator-bot-adaptive/baseGenerator.js
@@ -62,7 +62,6 @@ module.exports = class extends Generator {
 
     const context = Object.assign({}, templateContext, { botName });
 
-    
     for (const filePath of this._selectTemplateFilePaths(...path)) {
       this.fs.copyTpl(
         this.templatePath(filePath),

--- a/generators/generator-bot-enterprise-assistant/generators/app/index.js
+++ b/generators/generator-bot-enterprise-assistant/generators/app/index.js
@@ -78,7 +78,7 @@ module.exports = class extends BaseGenerator {
 
   writing() {
     this._copyBotTemplateFiles({
-      path: ['**', '!*.sln'],
+      path: ['**', '!**/*.sln'],
       templateContext: {},
     });
 


### PR DESCRIPTION
### Purpose

A recent update to the globby library has caused the generator to erroneously double-process the root .sln file.

The root cause is that the previous versions passed in a single path variable in the form [wildcard, exclusion] but this ended up being concated into "wildcard/exclusion" which no longer works as expected.

This PR splits these parameters to avoid confusion.

### Changes

Add an exclusion parameter explicitly. Change processing of globby params.

Fixes https://github.com/microsoft/BotFramework-Composer/issues/8927