### PR TITLE
feat: Serial number post processing for STT

### DIFF
--- a/packages/Telephony/Actions/CallTransfer.cs
+++ b/packages/Telephony/Actions/CallTransfer.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Bot.Components.Telephony.Actions
         /// <param name="cancellationToken">A cancellation token that can be used by other objects
         /// or threads to receive notice of cancellation.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        public async override Task<DialogTurnResult> BeginDialogAsync(DialogContext dc, object options = null, CancellationToken cancellationToken = default(CancellationToken))
+        public async override Task<DialogTurnResult> BeginDialogAsync(DialogContext dc, object options = null, CancellationToken cancellationToken = default)
         {
             if (dc.Context.Activity.ChannelId == Channels.Telephony)
             {

--- a/packages/Telephony/Actions/SerialNumberInput.cs
+++ b/packages/Telephony/Actions/SerialNumberInput.cs
@@ -102,7 +102,7 @@ namespace Microsoft.Bot.Components.Telephony.Actions
 
             //Get value of termination string from expression
             string regexPattern = this.RegexPattern?.GetValue(dc.State);
-            SerialNumberPattern snp = new SerialNumberPattern(regexPattern);
+            SerialNumberPattern snp = new SerialNumberPattern(regexPattern, true);
 
             string[] choices = dc.State.GetValue<string[]>("this.ambiguousChoices");
             bool isAmbiguousPrompt = choices != null && choices.Length >= 2;

--- a/packages/Telephony/Actions/SerialNumberInput.cs
+++ b/packages/Telephony/Actions/SerialNumberInput.cs
@@ -159,6 +159,7 @@ namespace Microsoft.Bot.Components.Telephony.Actions
                 }
                 else
                 {
+                    dc.State.SetValue(AggregationDialogMemory, results[0]);
                     return new DialogTurnResult(DialogTurnStatus.Waiting);
                 }
             }

--- a/packages/Telephony/Actions/SerialNumberPattern.cs
+++ b/packages/Telephony/Actions/SerialNumberPattern.cs
@@ -1,0 +1,511 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Diagnostics;
+using System.Linq;
+
+namespace Microsoft.Bot.Components.Telephony.Actions
+{
+    public class SerialNumberPattern
+    {
+        private static readonly Dictionary<char, char> AlphabetReplacementsTable = new Dictionary<char, char> { };
+        private static readonly Dictionary<char, char> DigitReplacementsTable = new Dictionary<char, char>
+        {
+            { 'A', '8' }
+        };
+
+        private static readonly Dictionary<string, char> DigitWordReplacementsTable = new Dictionary<string, char>
+        {
+            { "ZER0", '0' },
+            { "ONE", '1' },
+            { "TWO", '2' },
+            { "THREE", '3' },
+            { "FOR", '4' },
+            { "FOUR", '4' },
+            { "FIVE", '5' },
+            { "SIX", '6' },
+            { "SEVEN", '7' },
+            { "EIGHT", '8' },
+            { "NINE", '9' }
+        };
+
+        public SerialNumberPattern(IReadOnlyCollection<TextGroup> textGroups, string input)
+        {
+            Groups = textGroups;
+            InputString = input;
+
+            foreach (TextGroup group in Groups)
+            {
+                PatternLength += group.LengthInChars;
+            }
+        }
+
+        public SerialNumberPattern(string input)
+        {
+            // TODO: Make/set groups from input regex
+            Groups = new ReadOnlyCollection<TextGroup>(new List<TextGroup>());
+            InputString = input;
+        }
+
+        /// <summary>
+        /// Enum representing valid token type specified in pattern.
+        /// </summary>
+        public enum Token 
+        {
+            /// <summary>
+            /// Invalid token.
+            /// </summary>
+            Invalid,
+
+            /// <summary>
+            /// Alphabetic token.
+            /// </summary>
+            Alpha,
+
+            /// <summary>
+            /// Numeric token.
+            /// </summary>
+            Digit,
+
+            /// <summary>
+            /// Alphanumeric token.
+            /// </summary>
+            Both,
+
+            /// <summary>
+            /// The char - token.
+            /// </summary>
+            Dash
+        }
+
+        /// <summary>
+        /// Enum representing character replacement.
+        /// </summary>
+        public enum FixupType
+        {
+            /// <summary>
+            /// No replacement.
+            /// </summary>
+            None = 0,
+
+            /// <summary>
+            /// Character replacement.
+            /// </summary>
+            AlphaMapping = 1,
+
+            /// <summary>
+            /// As in replacement.
+            /// </summary>
+            AsIn = 2,
+        }
+
+        public string Regexp
+        {
+            get
+            {
+                string result = string.Empty;
+                foreach (TextGroup group in Groups)
+                {
+                    result += group.RegexString;
+                }
+
+                return result;
+            }
+        }
+
+        public string InputString { get; set; }
+
+        public IReadOnlyCollection<TextGroup> Groups { get; set; }
+
+        public int PatternLength { get; set; }
+
+        public Token PatternAt(int patternIndex)
+        {
+            int cumulativeIndex = 0;
+            int prevGroupCumulative = 0;
+            foreach (TextGroup group in Groups)
+            {
+                cumulativeIndex += group.LengthInChars;
+                if (cumulativeIndex > patternIndex)
+                {
+                    if (group.AcceptsDigits && group.AcceptsAlphabet)
+                    {
+                        return Token.Both;
+                    }
+
+                    if (group.AcceptsDigits)
+                    {
+                        return Token.Digit;
+                    }
+
+                    if (group.AcceptsAlphabet)
+                    {
+                        return Token.Alpha;
+                    }
+                }
+
+                prevGroupCumulative += group.LengthInChars;
+            }
+
+            return Token.Invalid;
+        }
+
+        public (char First, char Second) AmbiguousOptions(int inputIndex)
+        {
+            (char, char) result = ('*', '*');
+            char input = InputString[inputIndex];
+
+            switch (input)
+            {
+                case '8':
+                    result = ('A', input);
+                    break;
+                default:
+                    Debug.Assert(false, "No ambiguous input is found");
+                    break;
+            }
+
+            return result;
+        }
+
+        public bool DetectDigitFixup(int inputIndex)
+        {
+            char ch = InputString[inputIndex];
+
+            // Handle (One) = 1
+            string restOfInput = InputString.Substring(inputIndex);
+            string firstToken = restOfInput.Split(' ').FirstOrDefault();
+            if (firstToken != null)
+            {
+                string token = firstToken;
+                if (DigitWordReplacementsTable.ContainsKey(token))
+                {
+                    return true;
+                }
+            }
+
+            // Handle (A) = 8
+            return DigitReplacementsTable.ContainsKey(ch);
+        }
+
+        public char DigitFixup(int inputIndex, ref int newOffset)
+        {
+            char ch = InputString[inputIndex];
+            char replacement = char.MinValue;
+
+            // Handle (One) = 1
+            string restOfInput = InputString.Substring(inputIndex);
+            string firstToken = restOfInput.Split(' ').FirstOrDefault();
+            if (firstToken != null)
+            {
+                string token = firstToken;
+                if (DigitWordReplacementsTable.ContainsKey(token))
+                {
+                    replacement = DigitWordReplacementsTable[token];
+                    newOffset = inputIndex + token.Length;
+                }
+            }
+
+            // Handle (A) = 8
+            if (DigitReplacementsTable.ContainsKey(ch))
+            {
+                replacement = DigitReplacementsTable[ch];
+            }
+
+            Debug.WriteLine($"Digit {ch} was replaced by character {replacement}");
+            return replacement;
+        }
+
+        public FixupType DetectAlphabetFixup(int inputIndex)
+        {
+            char ch = InputString[inputIndex];
+            string restOfInput = InputString.Substring(inputIndex);
+
+            // (A as in Apple)BC
+            // ABC, as in Charlie Z as in Zeta.  
+            // [A-Z]{3}
+            var asInResult = FindAsInFixup(restOfInput);
+            if (asInResult.FixedUp)
+            {
+                return FixupType.AsIn;
+            }
+
+            // Find direct letter mapping
+            return AlphabetReplacementsTable.ContainsKey(ch) ? FixupType.AlphaMapping : FixupType.None;
+        }
+
+        public char AlphabetFixup(int inputIndex, ref int offset)
+        {
+            char ch = InputString[inputIndex];
+            string restOfInput = InputString.Substring(inputIndex);
+            offset = 1;
+            switch (DetectAlphabetFixup(inputIndex))
+            {
+                case FixupType.None:
+                    return ch;
+                case FixupType.AlphaMapping:
+                    char replacement = AlphabetReplacementsTable[ch];
+                    Console.WriteLine($"Alphabetic Character {ch} was replaced by digit {replacement}");
+                    return replacement;
+                case FixupType.AsIn:
+                    AsInResult asInResult;
+                    asInResult = FindAsInFixup(restOfInput);
+                    if (asInResult.FixedUp)
+                    {
+                        Debug.WriteLine($"'as in' fixed up {restOfInput} to letter {asInResult.Char}");
+                        offset = asInResult.NewOffset;
+                        return asInResult.Char;
+                    }
+
+                    throw new Exception("Should have returned a char described by as in");
+            }
+
+            // TODO: Do additional fixups here
+            return ch;
+        }
+
+        // Pattern : 2 alphabetic, 1 numeric
+        // Input:    katie 4
+        public string[] Inference()
+        {
+            List<string> results = new List<string>();
+            Console.WriteLine($"Original text      : '{InputString}'");
+            Console.WriteLine($"Regular Expression : '{Regexp}'");
+
+            // Trivial Length check - must be at least pattern length (most likely longer).
+            if (InputString.Length < PatternLength)
+            {
+                Console.WriteLine($"Input string is too short!  Must be at least {PatternLength} characters/digits.");
+                return results.ToArray();
+            }
+
+            int patternIndex = 0;
+            int inputIndex = 0;
+
+            List<int> ambiguousInputIndexes = new List<int>();
+            bool isMatch = true;
+            string fixedUpString = string.Empty;
+
+            // Initial Scan to see how many things to correct
+            while (patternIndex < PatternLength && inputIndex < InputString.Length)
+            {
+                var elementType = PatternAt(patternIndex);    // What type the pattern is expecting
+                var inputElement = InputString[inputIndex];
+
+                // Skip white space, period, comma, dash if not expected
+                if (inputElement == ' ' || inputElement == '.' || inputElement == ',' || 
+                    (inputElement == '-' && elementType != Token.Dash))
+                {
+                    inputIndex++;
+                    continue;
+                }
+                
+                Debug.WriteLine($"Token at index {patternIndex} is {elementType}");
+                Debug.WriteLine($"Input at index {inputIndex} is {inputElement}");
+
+                patternIndex++;  // Bump to next element in pattern.
+
+                var inferResult = InferMatch(inputIndex, elementType);
+
+                if (inferResult.IsAmbiguous)
+                {
+                    // Store ambiguity index from original string.
+                    ambiguousInputIndexes.Add(inputIndex);
+                    fixedUpString += '*'; // Mark ambiguity
+                }
+                else if (inferResult.IsFixedUp)
+                {
+                    fixedUpString += inferResult.Ch;
+                    inputIndex += inferResult.NewOffset - 1;
+                }
+                else
+                {
+                    fixedUpString += inputElement;
+                }
+
+                if (inferResult.IsNoMatch)
+                {
+                    Console.WriteLine("ERROR: No match");
+                    isMatch = false;
+                    break;
+                }
+                
+                inputIndex++;
+            }
+
+            if (!isMatch)
+            {
+                return results.ToArray();
+            }
+
+            // Handle ambiguous issues.
+            if (ambiguousInputIndexes.Count > 0)
+            {
+#pragma warning disable IDE0042 // Deconstruct variable declaration
+                var options = AmbiguousOptions(ambiguousInputIndexes.FirstOrDefault());
+#pragma warning restore IDE0042 // Deconstruct variable declaration
+                results.Add(fixedUpString.Replace('*', options.First));
+                results.Add(fixedUpString.Replace('*', options.Second));
+            }
+            else
+            {
+                results.Add(fixedUpString);
+            }
+     
+            return results.ToArray();
+        }
+
+        private AmbiguousResult CheckAmbiguous(ref int inputIndex)
+        {
+            AmbiguousResult match = new AmbiguousResult();
+            char input = InputString[inputIndex];
+            match.Ch = input;
+
+            switch (input)
+            {
+                case '8':
+                    match.IsAmbiguous = true;
+                    return match;
+                default:
+                    break;
+            }
+
+            return match;
+        }
+
+        private AsInResult FindAsInFixup(string input)
+        {
+            AsInResult result = new AsInResult();
+            char[] delimiters = { ' ', ',', '.', '/', '-' };
+            var tokens = input.Split(delimiters, StringSplitOptions.RemoveEmptyEntries);
+
+            if (tokens.Length > 3 && tokens[0].Length == 1)
+            {
+                char proposedChar = '*';
+                if (tokens[1].ToLowerInvariant() == "as" && tokens[2].ToLowerInvariant() == "in")
+                {
+                    proposedChar = tokens[3][0];
+                }
+
+                Debug.WriteLine($"'as in' detected character {proposedChar} as the proposed character replacement.");
+                result.FixedUp = true;
+                result.Char = proposedChar;
+                int initialOffset = input.IndexOf(" in ", StringComparison.Ordinal);
+                result.NewOffset = initialOffset + 4 + tokens[3].Length;
+            }
+
+            return result;
+        }
+
+        private InferResult InferMatch(int inputIndex, Token elementType)
+        {
+            InferResult result = new InferResult();
+            char currentInputChar = InputString[inputIndex];
+            result.Ch = currentInputChar;
+
+            switch (elementType)
+            {
+                case Token.Digit:
+                    TryFixupDigit(inputIndex, currentInputChar, elementType, result);
+                    break;
+                case Token.Alpha:
+                    if (char.IsLetter(currentInputChar) == false && DetectAlphabetFixup(inputIndex) == FixupType.None)
+                    {
+                        Console.WriteLine($"ERROR: Element index {inputIndex + 1} (character {currentInputChar}) is not alpha (Pattern wants {elementType})");
+                        result.IsNoMatch = true;
+                    }
+                    else
+                    {
+                        int newOffset = 1;
+                        result.IsFixedUp = true;
+                        result.Ch = AlphabetFixup(inputIndex, ref newOffset);
+                        result.NewOffset = newOffset;
+                    }
+
+                    break;
+                case Token.Both:
+                    AmbiguousResult ambiguousResult = CheckAmbiguous(ref inputIndex);
+                    result.Ch = ambiguousResult.Ch;
+                    if (ambiguousResult.IsAmbiguous)
+                    {
+                        result.IsAmbiguous = true;
+                        Console.WriteLine($"INFO: Element index {inputIndex + 1}(character {InputString[inputIndex]}) is ambiguous (Pattern wants {elementType})");
+                    }
+                    else
+                    {
+                        TryFixupDigit(inputIndex, currentInputChar, elementType, result);
+                    }
+
+                    break;
+                default:
+                    Console.WriteLine("Error");
+                    break;
+            }
+
+            return result;
+        }
+
+        private void TryFixupDigit(int inputIndex, char currentInputChar, Token elementType, InferResult result)
+        {
+            int newOffset = 1;
+            result.IsFixedUp = DetectDigitFixup(inputIndex);
+
+            if (char.IsDigit(currentInputChar) == false && !result.IsFixedUp)
+            {
+                if (elementType == Token.Digit)
+                {
+                    Console.WriteLine($"ERROR: Element index {inputIndex + 1} (character {currentInputChar}) is not digit (Pattern wants {elementType})");
+                    result.IsNoMatch = true;
+                }            
+            }
+            else if (result.IsFixedUp)
+            {
+                result.Ch = DigitFixup(inputIndex, ref newOffset);
+                result.NewOffset = newOffset;
+            }
+        }
+
+        private class AmbiguousResult
+        {
+            public char? Ch { get; set; }
+
+            public bool IsAmbiguous { get; set; }
+        }
+
+        private class AsInResult
+        {
+            public AsInResult()
+            {
+                NewOffset = 1;
+                Char = '*';
+            }
+
+            public bool FixedUp { get; set; }
+
+            public int NewOffset { get; set; }
+
+            public char Char { get; set; }
+        }
+
+        private class InferResult
+        {
+            public InferResult()
+            {
+                NewOffset = 1;
+            }
+
+            public char? Ch { get; set; }
+
+            public bool IsFixedUp { get; set; }
+
+            public bool IsAmbiguous { get; set; }
+
+            public bool IsNoMatch { get; set; }
+
+            public int NewOffset { get; set; }
+        }
+    }
+}

--- a/packages/Telephony/Actions/SerialNumberPattern.cs
+++ b/packages/Telephony/Actions/SerialNumberPattern.cs
@@ -262,7 +262,6 @@ namespace Microsoft.Bot.Components.Telephony.Actions
                     return ch;
                 case FixupType.AlphaMapping:
                     char replacement = AlphabetReplacementsTable[ch];
-                    Console.WriteLine($"Alphabetic Character {ch} was replaced by digit {replacement}");
                     return replacement;
                 case FixupType.AsIn:
                     AsInResult asInResult;
@@ -342,7 +341,6 @@ namespace Microsoft.Bot.Components.Telephony.Actions
 
                 if (inferResult.IsNoMatch)
                 {
-                    Console.WriteLine("ERROR: No match");
                     isMatch = false;
                     break;
                 }

--- a/packages/Telephony/Actions/SerialNumberPattern.cs
+++ b/packages/Telephony/Actions/SerialNumberPattern.cs
@@ -44,8 +44,9 @@ namespace Microsoft.Bot.Components.Telephony.Actions
             }
         }
 
-        public SerialNumberPattern(string regex)
+        public SerialNumberPattern(string regex, bool allowBatching = false)
         {
+            AllowBatching = allowBatching;
             List<TextGroup> groups = new List<TextGroup>();
             string[] regexGroups = regex.Split(GroupEndDelimiter, StringSplitOptions.RemoveEmptyEntries);
 
@@ -130,6 +131,8 @@ namespace Microsoft.Bot.Components.Telephony.Actions
         public int PatternLength { get; set; }
 
         public string InputString { get; private set; }
+
+        public bool AllowBatching { get; set; }
 
         public Token PatternAt(int patternIndex, out HashSet<char> invalidChars)
         {
@@ -285,13 +288,10 @@ namespace Microsoft.Bot.Components.Telephony.Actions
             InputString = inputString;
 
             List<string> results = new List<string>();
-            Console.WriteLine($"Original text      : '{inputString}'");
-            Console.WriteLine($"Regular Expression : '{Regexp}'");
 
             // Trivial Length check - must be at least pattern length (most likely longer).
-            if (inputString.Length < PatternLength)
+            if (inputString.Length < PatternLength && !AllowBatching)
             {
-                Console.WriteLine($"Input string is too short!  Must be at least {PatternLength} characters/digits.");
                 return results.ToArray();
             }
 

--- a/packages/Telephony/Actions/SerialNumberPattern.cs
+++ b/packages/Telephony/Actions/SerialNumberPattern.cs
@@ -53,7 +53,7 @@ namespace Microsoft.Bot.Components.Telephony.Actions
         /// <summary>
         /// Enum representing valid token type specified in pattern.
         /// </summary>
-        public enum Token 
+        public enum Token
         {
             /// <summary>
             /// Invalid token.
@@ -178,7 +178,7 @@ namespace Microsoft.Bot.Components.Telephony.Actions
             // Handle (One) = 1
             string restOfInput = InputString.Substring(inputIndex);
             string firstToken = restOfInput.Split(' ').FirstOrDefault();
-            if (firstToken != null)
+            if (!string.IsNullOrWhiteSpace(firstToken))
             {
                 string token = firstToken;
                 if (DigitWordReplacementsTable.ContainsKey(token))
@@ -199,7 +199,7 @@ namespace Microsoft.Bot.Components.Telephony.Actions
             // Handle (One) = 1
             string restOfInput = InputString.Substring(inputIndex);
             string firstToken = restOfInput.Split(' ').FirstOrDefault();
-            if (firstToken != null)
+            if (!string.IsNullOrWhiteSpace(firstToken))
             {
                 string token = firstToken;
                 if (DigitWordReplacementsTable.ContainsKey(token))
@@ -296,13 +296,13 @@ namespace Microsoft.Bot.Components.Telephony.Actions
                 var inputElement = InputString[inputIndex];
 
                 // Skip white space, period, comma, dash if not expected
-                if (inputElement == ' ' || inputElement == '.' || inputElement == ',' || 
+                if (inputElement == ' ' || inputElement == '.' || inputElement == ',' ||
                     (inputElement == '-' && elementType != Token.Dash))
                 {
                     inputIndex++;
                     continue;
                 }
-                
+
                 Debug.WriteLine($"Token at index {patternIndex} is {elementType}");
                 Debug.WriteLine($"Input at index {inputIndex} is {inputElement}");
 
@@ -332,7 +332,7 @@ namespace Microsoft.Bot.Components.Telephony.Actions
                     isMatch = false;
                     break;
                 }
-                
+
                 inputIndex++;
             }
 
@@ -354,7 +354,7 @@ namespace Microsoft.Bot.Components.Telephony.Actions
             {
                 results.Add(fixedUpString);
             }
-     
+
             return results.ToArray();
         }
 
@@ -459,7 +459,7 @@ namespace Microsoft.Bot.Components.Telephony.Actions
                 {
                     Console.WriteLine($"ERROR: Element index {inputIndex + 1} (character {currentInputChar}) is not digit (Pattern wants {elementType})");
                     result.IsNoMatch = true;
-                }            
+                }
             }
             else if (result.IsFixedUp)
             {

--- a/packages/Telephony/Actions/SerialNumberTextGroup.cs
+++ b/packages/Telephony/Actions/SerialNumberTextGroup.cs
@@ -2,15 +2,76 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.Linq;
+using System.Runtime.CompilerServices;
 
 namespace Microsoft.Bot.Components.Telephony.Actions
 {
     public class TextGroup
     {
+        public TextGroup() 
+        {
+        }
+
+        public TextGroup(string regex)
+        {
+            if ((regex.IndexOf('(') < 0) || (regex.IndexOf('(') < 0) ||
+                (regex.IndexOf('[') < 0) || (regex.IndexOf(']') < 0) ||
+                (regex.IndexOf('{') < 0) || (regex.IndexOf('}') < 0))
+            {
+                throw new ArgumentException("Invalid regular expression");
+            }
+
+            // get character ranges
+            int start = regex.IndexOf('[');
+            int end = regex.IndexOf(']');
+            if ((start < 0) || (end < 0) || (end < (start + 2)))
+            {
+                throw new ArgumentException("Invalid regular expression");
+            }
+
+            string ranges = regex.Substring(start + 1, end - start - 1);
+            if (ranges.IndexOf("0-9", StringComparison.OrdinalIgnoreCase) >= 0)
+            {
+                this.AcceptsDigits = true;
+            }
+
+            if (ranges.IndexOf("A-Z", StringComparison.OrdinalIgnoreCase) >= 0)
+            {
+                this.AcceptsAlphabet = true;
+            }
+
+            // check for exclusion set
+            start = regex.IndexOf('^', end);
+            int endExclude = regex.IndexOf(']', end + 1);
+            if ((start > 0) && (endExclude > 0) && (endExclude >= (start + 2)))
+            {
+                string invalid = regex.Substring(start + 1, endExclude - start - 1);
+                this.InvalidChars = new HashSet<char>(invalid.ToCharArray());
+            }
+
+            // get length
+            start = regex.IndexOf('{', end);
+            end = regex.IndexOf('}', end);
+            if ((start < 0) || (end < 0) || (end < (start + 2)))
+            {
+                throw new ArgumentException("Invalid regular expression");
+            }
+
+            string length = regex.Substring(start + 1, end - start - 1);
+            this.LengthInChars = short.Parse(length, CultureInfo.InvariantCulture);
+        }
+
         public bool AcceptsAlphabet { get; set; } = false;
 
         public bool AcceptsDigits { get; set; } = false;
+
+#pragma warning disable CA2227 // Collection properties should be read only
+        public HashSet<char> InvalidChars { get; set; } = new HashSet<char>();
+#pragma warning restore CA2227 // Collection properties should be read only
 
         public short LengthInChars { get; set; } = 0;
 

--- a/packages/Telephony/Actions/SerialNumberTextGroup.cs
+++ b/packages/Telephony/Actions/SerialNumberTextGroup.cs
@@ -1,0 +1,57 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Linq;
+
+namespace Microsoft.Bot.Components.Telephony.Actions
+{
+    public class TextGroup
+    {
+        public bool AcceptsAlphabet { get; set; } = false;
+
+        public bool AcceptsDigits { get; set; } = false;
+
+        public short LengthInChars { get; set; } = 0;
+
+        public string Regex { get; set; } = string.Empty;
+
+        public string RegexString
+        {
+            get
+            {
+                string result = "([";
+                if (AcceptsDigits)
+                {
+                    result += "0-9";
+                }
+
+                if (AcceptsAlphabet)
+                {
+                    result += "a-zA-Z";
+                }
+
+                result += "]{" + LengthInChars + "})";
+                return result;
+            }
+        }
+
+        public string GenerateGroupExampleText()
+        {
+            string seed = string.Empty;
+            Random rnd = new Random();
+            if (AcceptsAlphabet)
+            {
+                seed += "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+            }
+
+            if (AcceptsDigits)
+            {
+                seed += "0123456789";
+            }
+
+            return new string(Enumerable.Repeat(seed, LengthInChars)
+                .Select(s => s[rnd.Next(s.Length)]).ToArray());
+        }
+    }
+}

--- a/packages/Telephony/Schemas/Microsoft.Telephony.SerialNumberInput.schema
+++ b/packages/Telephony/Schemas/Microsoft.Telephony.SerialNumberInput.schema
@@ -1,0 +1,65 @@
+﻿{
+  "$schema": "https://schemas.botframework.com/schemas/component/v1.0/component.schema",
+  "$role": "implements(Microsoft.IDialog)",
+  "title": "(Preview) Serial Number Input",
+  "description": "Prompts the user for multiple inputs that are aggregated until a regex matches the buffer.",
+  "type": "object",
+  "required": [
+    "regexPattern",
+    "prompt",
+    "*"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "regexPattern": {
+      "$ref": "schema:#/definitions/stringExpression",
+      "title": "Regex Match Pattern",
+      "description": "When matched, the batch is completed.",
+      "examples": [
+        "([a-zA-Z]{2})([0-9a-zA-Z]{5})"
+      ]
+    },
+    "property": {
+      "$ref": "schema:#/definitions/stringExpression",
+      "title": "Property",
+      "description": "Property to assign the batch result to",
+      "examples": [
+        "conversation.BatchResult"
+      ]
+    },
+    "prompt": {
+      "$kind": "Microsoft.IActivityTemplate",
+      "title": "Initial prompt",
+      "description": "Message to send to collect information.",
+      "examples": [
+        "Enter your serial number."
+      ]
+    },
+    "allowInterruptions": {
+      "$ref": "schema:#/definitions/booleanExpression",
+      "title": "Allow Interruptions",
+      "description": "Allow the parent dialog to receive messages to handle while the aggregation is underway.",
+      "default": false,
+      "examples": [
+        true,
+        "=user.xyz"
+      ]
+    },
+    "interruptionMask": {
+      "$ref": "schema:#/definitions/stringExpression",
+      "title": "Regex Match Pattern",
+      "description": "Input that matches the specified pattern is not bubbled for interruption handling.",
+      "examples": [
+        "^[\\d]+$"
+      ]
+    },
+    "alwaysPrompt": {
+      "$ref": "schema:#/definitions/booleanExpression",
+      "title": "Always Prompt",
+      "description": "When true, if batch is interrupted, it will attempt to restart the batch rather than abandon it."
+    }
+  },
+  "$policies": {
+    "interactive": true
+  }
+}

--- a/packages/Telephony/Schemas/Microsoft.Telephony.SerialNumberInput.uischema
+++ b/packages/Telephony/Schemas/Microsoft.Telephony.SerialNumberInput.uischema
@@ -1,0 +1,61 @@
+﻿{
+  "$schema": "https://schemas.botframework.com/schemas/ui/v1.0/ui.schema",
+  "form": {
+    "label": "Aggregate Serial Number Input | Preview",
+    "subtitle": "Aggregate input until a regex matches the buffer.",
+    "order": [
+      "prompt",
+      "regexPattern",
+      "property",
+      "allowInterruptions",
+      "alwaysPrompt",
+      "*"
+    ],
+    "properties": {
+      "regexPattern": {
+        "intellisenseScopes": [
+          "variable-scopes"
+        ]
+      },
+      "property": {
+        "intellisenseScopes": [
+          "variable-scopes"
+        ]
+      },
+      "allowInterruptions": {
+        "intellisenseScopes": [
+          "variable-scopes"
+        ]
+      },
+      "interruptionMask": {
+        "intellisenseScopes": [
+          "variable-scopes"
+        ]
+      },
+      "alwaysPrompt": {
+        "intellisenseScopes": [
+          "variable-scopes"
+        ]
+      }
+    }
+  },
+  "menu": {
+    "label": "Aggregate Serial Number Input | Preview",
+    "submenu": [ "Telephony" ]
+  },
+  "flow": {
+      "widget": "ActionCard",
+      "body": {
+          "widget": "LgWidget",
+          "field": "prompt"
+      },
+      "header": {
+          "widget": "ActionHeader",
+          "icon": "MessageBot",
+          "colors": {
+              "theme": "#EEEAF4",
+              "icon": "#5C2E91"
+          }
+      }
+  }
+}

--- a/packages/Telephony/TelephonyBotComponent.cs
+++ b/packages/Telephony/TelephonyBotComponent.cs
@@ -26,6 +26,7 @@ namespace Microsoft.Bot.Components.Telephony
             services.AddSingleton<DeclarativeType>(sp => new DeclarativeType<BatchTerminationCharacterInput>(BatchTerminationCharacterInput.Kind));
             services.AddSingleton<DeclarativeType>(sp => new DeclarativeType<BatchTerminationCharacterInput>(BatchRegexInput.Kind));
             services.AddSingleton<DeclarativeType>(sp => new DeclarativeType<TimeoutChoiceInput>(TimeoutChoiceInput.Kind));
+            services.AddSingleton<DeclarativeType>(sp => new DeclarativeType<SerialNumberInput>(SerialNumberInput.Kind));
         }
     }
 }

--- a/tests/unit/packages/Microsoft.Bot.Components.Telephony.Tests/Integration/SerialNumberInputTests/SerialNumberInput_BaseScenario.test.dialog
+++ b/tests/unit/packages/Microsoft.Bot.Components.Telephony.Tests/Integration/SerialNumberInputTests/SerialNumberInput_BaseScenario.test.dialog
@@ -10,6 +10,8 @@
           "$kind": "Microsoft.Telephony.SerialNumberInput",
           "property": "conversation.DTMFResult",
           "prompt": "Enter serial number number.",
+          "continuePrompt": "Please continue with next letter or digit.",
+          "confirmationPrompt": "Say or type 1 for {0} or 2 for {1}",
           "regexPattern": "([0-9a-zA-Z]{5})",
           "allowInterruptions": "=coalesce(settings.allowInterruptions, true)",
           "interruptionMask": "^[\\d]+$",

--- a/tests/unit/packages/Microsoft.Bot.Components.Telephony.Tests/Integration/SerialNumberInputTests/SerialNumberInput_BaseScenario.test.dialog
+++ b/tests/unit/packages/Microsoft.Bot.Components.Telephony.Tests/Integration/SerialNumberInputTests/SerialNumberInput_BaseScenario.test.dialog
@@ -1,0 +1,67 @@
+{
+  "$schema": "../../../tests.schema",
+  "$kind": "Microsoft.AdaptiveDialog",
+  "id": "SerialNumberInput_BaseScenario.test",
+  "triggers": [
+    {
+      "$kind": "Microsoft.OnConversationUpdateActivity",
+      "actions": [
+        {
+          "$kind": "Microsoft.Telephony.SerialNumberInput",
+          "property": "conversation.DTMFResult",
+          "prompt": "Enter serial number number.",
+          "regexPattern": "([0-9a-zA-Z]{5})",
+          "allowInterruptions": "=coalesce(settings.allowInterruptions, true)",
+          "interruptionMask": "^[\\d]+$",
+          "alwaysPrompt": "=coalesce(settings.alwaysPrompt, false)"
+        },
+        {
+          "$kind": "Microsoft.SendActivity",
+          "activity": "${coalesce(conversation.DTMFResult, 'empty')}"
+        }
+      ]
+    },
+    {
+      "$kind": "Microsoft.OnIntent",
+      "intent": "HelpIntent",
+      "actions": [
+        {
+          "$kind": "Microsoft.SendActivity",
+          "activity": "On help intent handler"
+        }
+      ]
+    },
+    {
+      "$kind": "Microsoft.OnEventActivity",
+      "actions": [
+        {
+          "$kind": "Microsoft.SendActivity",
+          "activity": "Event received"
+        }
+      ]
+    },
+    {
+      "$kind": "Microsoft.OnIntent",
+      "intent": "ZeroIntent",
+      "actions": [
+        {
+          "$kind": "Microsoft.SendActivity",
+          "activity": "On zero intent handler"
+        }
+      ]
+    }
+  ],
+  "recognizer": {
+    "$kind": "Microsoft.RegexRecognizer",
+    "intents": [
+      {
+        "intent": "HelpIntent",
+        "pattern": "help"
+      },
+      {
+        "intent": "ZeroIntent",
+        "pattern": "0"
+      }
+    ]
+  }
+}

--- a/tests/unit/packages/Microsoft.Bot.Components.Telephony.Tests/Integration/SerialNumberInputTests/SerialNumberInput_HappyPath.test.dialog
+++ b/tests/unit/packages/Microsoft.Bot.Components.Telephony.Tests/Integration/SerialNumberInputTests/SerialNumberInput_HappyPath.test.dialog
@@ -1,0 +1,63 @@
+{
+  "$schema": "../../../tests.schema",
+  "$kind": "Microsoft.Test.Script",
+  "dialog": "SerialNumberInput_BaseScenario.test",
+  "script": [
+    {
+      "$kind": "Microsoft.Test.UserConversationUpdate",
+      "membersAdded": [ "user" ]
+    },
+    {
+      "$kind": "Microsoft.Test.AssertReplyActivity",
+      "assertions": [
+        "type == 'message'",
+        "text == 'Enter serial number number.'"
+      ]
+    },
+    {
+      "$kind": "Microsoft.Test.UserSays",
+      "text": "8"
+    },
+    {
+      "$kind": "Microsoft.Test.AssertReplyActivity",
+      "assertions": [
+        "type == 'message'",
+        "text == 'Say or type 1 for A or 2 for 8'"
+      ]
+    },
+    {
+      "$kind": "Microsoft.Test.UserSays",
+      "text": "1"
+    },
+    {
+      "$kind": "Microsoft.Test.AssertReplyActivity",
+      "assertions": [
+        "type == 'message'",
+        "text == 'Please continue with next letter or digit.'"
+      ]
+    },
+    {
+      "$kind": "Microsoft.Test.UserSays",
+      "text": "F"
+    },
+    {
+      "$kind": "Microsoft.Test.UserSays",
+      "text": "0"
+    },
+    {
+      "$kind": "Microsoft.Test.UserSays",
+      "text": "0"
+    },
+    {
+      "$kind": "Microsoft.Test.UserSays",
+      "text": "9"
+    },
+    {
+      "$kind": "Microsoft.Test.AssertReplyActivity",
+      "assertions": [
+        "type == 'message'",
+        "text == '0F009L1213700A'"
+      ]
+    }
+  ]
+}

--- a/tests/unit/packages/Microsoft.Bot.Components.Telephony.Tests/Integration/SerialNumberInputTests/SerialNumberInput_HappyPath.test.dialog
+++ b/tests/unit/packages/Microsoft.Bot.Components.Telephony.Tests/Integration/SerialNumberInputTests/SerialNumberInput_HappyPath.test.dialog
@@ -56,7 +56,7 @@
       "$kind": "Microsoft.Test.AssertReplyActivity",
       "assertions": [
         "type == 'message'",
-        "text == '0F009L1213700A'"
+        "text == 'AF009'"
       ]
     }
   ]

--- a/tests/unit/packages/Microsoft.Bot.Components.Telephony.Tests/Integration/SerialNumberInputTests/SerialNumberInput_WithInterruption.test.dialog
+++ b/tests/unit/packages/Microsoft.Bot.Components.Telephony.Tests/Integration/SerialNumberInputTests/SerialNumberInput_WithInterruption.test.dialog
@@ -1,0 +1,72 @@
+﻿{
+  "$schema": "../../../tests.schema",
+  "$kind": "Microsoft.Test.Script",
+  "dialog": "SerialNumberInput_BaseScenario.test",
+  "script": [
+    {
+      "$kind": "Microsoft.Test.UserConversationUpdate",
+      "membersAdded": [ "user" ]
+    },
+    {
+      "$kind": "Microsoft.Test.AssertReplyActivity",
+      "assertions": [
+        "type == 'message'",
+        "text == 'Enter serial number number.'"
+      ]
+    },
+    {
+      "$kind": "Microsoft.Test.UserSays",
+      "text": "1"
+    },
+    {
+      "$kind": "Microsoft.Test.UserSays",
+      "text": "2"
+    },
+    {
+      "$kind": "Microsoft.Test.UserSays",
+      "text": "3"
+    },
+    {
+      "$kind": "Microsoft.Test.UserSays",
+      "text": "help"
+    },
+    {
+      "$kind": "Microsoft.Test.AssertReply",
+      "text": "On help intent handler"
+    },
+    {
+      "$kind": "Microsoft.Test.AssertReplyActivity",
+      "assertions": [
+        "type == 'message'",
+        "text == 'Enter serial number number.'"
+      ]
+    },
+    {
+      "$kind": "Microsoft.Test.UserSays",
+      "text": "1"
+    },
+    {
+      "$kind": "Microsoft.Test.UserSays",
+      "text": "2"
+    },
+    {
+      "$kind": "Microsoft.Test.UserSays",
+      "text": "3"
+    },
+    {
+      "$kind": "Microsoft.Test.UserSays",
+      "text": "C"
+    },
+    {
+      "$kind": "Microsoft.Test.UserSays",
+      "text": "D"
+    },
+    {
+      "$kind": "Microsoft.Test.AssertReplyActivity",
+      "assertions": [
+        "type == 'message'",
+        "text == '123CD'"
+      ]
+    }
+  ]
+}

--- a/tests/unit/packages/Microsoft.Bot.Components.Telephony.Tests/SerialNumberInputTests.cs
+++ b/tests/unit/packages/Microsoft.Bot.Components.Telephony.Tests/SerialNumberInputTests.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Bot.Connector;
+using Microsoft.Bot.Schema;
+using Microsoft.Extensions.Configuration;
+using Xunit;
+
+namespace Microsoft.Bot.Components.Telephony.Tests
+{
+    public class SerialNumberInputTests : IntegrationTestsBase
+    {
+        public SerialNumberInputTests(ResourceExplorerFixture resourceExplorerFixture) : base(resourceExplorerFixture)
+        {
+        }
+
+        [Fact]
+        public async Task SerialNumberInput_HappyPath()
+        {
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer, adapterChannel: Channels.Telephony);
+        }
+    }
+ }

--- a/tests/unit/packages/Microsoft.Bot.Components.Telephony.Tests/SerialNumberInputTests.cs
+++ b/tests/unit/packages/Microsoft.Bot.Components.Telephony.Tests/SerialNumberInputTests.cs
@@ -21,5 +21,17 @@ namespace Microsoft.Bot.Components.Telephony.Tests
         {
             await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer, adapterChannel: Channels.Telephony);
         }
+
+
+        [Fact]
+        public async Task SerialNumberInput_WithInterruption()
+        {
+            await TestUtils.RunTestScript(
+               _resourceExplorerFixture.ResourceExplorer,
+               adapterChannel: Channels.Telephony,
+               configuration: new ConfigurationBuilder()
+                   .AddInMemoryCollection(new Dictionary<string, string>() { { "alwaysPrompt", "true" } })
+                   .Build());
+        }
     }
  }


### PR DESCRIPTION
Added  SerialNumberPattern and SerialNumberInput dialog to post process STT result for serial numbers

<!-- This repository only accepts pull requests related to open issues, please link the open issue in description below. -->
<!-- See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. -->
<!-- For example - Close #123: Description goes here. -->

### Purpose
Post processing of result returned from speech for recognizing serial number patterns.

<!--What is the context of this pull request? Why is it being done? -->

### Changes
Classes to specify patterns for serial numbers and replace input received from STT.

<!-- Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.) -->

### Tests

<!-- Is this covered by existing tests or new ones? If no, why not? -->

### Feature Plan

<!-- Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues. -->

