### PR TITLE
fix: add qna template readme back in

### DIFF
--- a/generators/generator-bot-core-qna/README.md
+++ b/generators/generator-bot-core-qna/README.md
@@ -1,0 +1,26 @@
+# @microsoft/generator-bot-core-qna [![NPM version](https://badge.fury.io/js/%40microsoft%2Fgenerator-bot-core-qna.svg)](https://www.npmjs.com/package/@microsoft/generator-bot-core-qna)
+
+A simple question-and-answer bot with Azure QnA Maker.
+
+### Recommended use
+
+- Create a simple question-and-answer bot with Azure QnA Maker
+- Customize and extend question-and-answer pairs or connect to your website's FAQ
+- Extend your bot with [Azure Bot Framework components](https://aka.ms/ComponentTemplateDocumentation)
+
+### Included capabilities
+
+- Answer questions from a QnA Maker knowled gebase
+
+### Required Azure resources
+
+- [Azure Language Understanding (LUIS)](https://docs.microsoft.com/en-us/azure/cognitive-services/luis/what-is-luis), or another recognizer of your choice
+- [Azure QnA Maker](https://docs.microsoft.com/en-us/azure/cognitive-services/qnamaker/overview/overview)
+
+### Supported languages
+
+- English (en-US)
+
+### License
+
+[MIT License](https://github.com/microsoft/botframework-components/blob/main/LICENSE)


### PR DESCRIPTION
Close #1324 

QnA template in composer is dependent on the readme hosted in components repo, this was previously removed as the template generator code itself is not used.

Related Composer code: https://github.com/microsoft/BotFramework-Composer/blob/01ccbcee840d5b8fe40fbde513956ad919f10317/Composer/packages/server/src/controllers/asset.ts#L127