### PR TITLE
fix: People list dialog error on interruption

### DIFF
--- a/generators/generator-bot-enterprise-people/generators/app/templates/dialogs/ListDialog/ListDialog.dialog
+++ b/generators/generator-bot-enterprise-people/generators/app/templates/dialogs/ListDialog/ListDialog.dialog
@@ -76,14 +76,6 @@
               ]
             },
             {
-              "$kind": "Microsoft.SetProperty",
-              "$designer": {
-                "id": "IuTIX8"
-              },
-              "property": "dialog.items",
-              "value": "=turn.items"
-            },
-            {
               "$kind": "Microsoft.ChoiceInput",
               "$designer": {
                 "id": "VygDK3",
@@ -177,6 +169,14 @@
           "value": "=null"
         },
         {
+          "$kind": "Microsoft.SetProperty",
+          "$designer": {
+            "id": "wZQHiW"
+          },
+          "property": "turn.items",
+          "value": "=dialog.items"
+        },
+        {
           "$kind": "Microsoft.EmitEvent",
           "$designer": {
             "id": "aVXgYo",
@@ -192,6 +192,14 @@
           },
           "property": "turn.items",
           "value": "=getProperty($itemsProperty)"
+        },
+        {
+          "$kind": "Microsoft.SetProperty",
+          "$designer": {
+            "id": "EuKh4L"
+          },
+          "property": "dialog.items",
+          "value": "=turn.items"
         },
         {
           "$kind": "Microsoft.IfCondition",

--- a/generators/generator-bot-enterprise-people/generators/app/templates/dialogs/ListDialog/ListDialog.dialog
+++ b/generators/generator-bot-enterprise-people/generators/app/templates/dialogs/ListDialog/ListDialog.dialog
@@ -76,6 +76,14 @@
               ]
             },
             {
+              "$kind": "Microsoft.SetProperty",
+              "$designer": {
+                "id": "IuTIX8"
+              },
+              "property": "dialog.items",
+              "value": "=turn.items"
+            },
+            {
               "$kind": "Microsoft.ChoiceInput",
               "$designer": {
                 "id": "VygDK3",
@@ -90,7 +98,7 @@
                 "noAction": false,
                 "noValue": false
               },
-              "choices": "=turn.choices",
+              "choices": "=dialog.choices",
               "style": "none",
               "alwaysPrompt": false,
               "allowInterruptions": "=(exists(#Next) || exists(#Previous) || exists(#Skip) || exists(#Cancel)) && turn.recognized.score > 0.8",
@@ -127,7 +135,7 @@
                     "comment": "Extracts the object from the items list matching the selected index."
                   },
                   "property": "turn.selection",
-                  "value": "=turn.pageItems[int(turn.selectedIndex) - 1]"
+                  "value": "=dialog.pageItems[int(turn.selectedIndex) - 1]"
                 }
               ]
             },
@@ -233,7 +241,7 @@
               "value": "=coalesce($pageindex * $pageSize, 0)"
             },
             {
-              "property": "turn.pageItems",
+              "property": "dialog.pageItems",
               "value": "=subArray(turn.items, $startIndex, min($startIndex + $pageSize, count(turn.items)))"
             },
             {
@@ -254,7 +262,7 @@
           },
           "index": "turn.itemsList.index",
           "value": "turn.itemsList.value",
-          "itemsProperty": "turn.pageItems",
+          "itemsProperty": "dialog.pageItems",
           "actions": [
             {
               "$kind": "Microsoft.SetProperty",
@@ -262,7 +270,7 @@
                 "id": "kNUEEQ",
                 "comment": "The index property represents the user-facing index of each item, rather than the zero-based index used by default. "
               },
-              "property": "turn.pageItems[turn.itemsList.index].index",
+              "property": "dialog.pageItems[turn.itemsList.index].index",
               "value": "=turn.itemsList.index + 1"
             },
             {
@@ -272,7 +280,7 @@
                 "comment": "The actionTitle property is passed via dialog options and indicates a field in the choice object that should be used as a way of selecting the item. For example, a contact object with a name and email property, may set the actionTitle to name so the user can select by saying the name of the option."
               },
               "property": "turn.actionTitle",
-              "value": "=turn.pageItems[turn.itemsList.index][$actionTitleProperty]"
+              "value": "=dialog.pageItems[turn.itemsList.index][$actionTitleProperty]"
             },
             {
               "$kind": "Microsoft.SetProperty",
@@ -281,7 +289,7 @@
                 "comment": "Builds the choiceItem in the object format needed for the choice prompt. \n{ \"value\": \"<value>\", \"action\": { \"type\": \"postBack\", \"title\": \"<title>\" }}"
               },
               "property": "turn.choiceItem",
-              "value": "=json(concat('{ \"value\": \"', turn.pageItems[turn.itemsList.index].index, '\", \"action\": { \"type\": \"postBack\", \"title\": \"', turn.actionTitle, '\" } }'))"
+              "value": "=json(concat('{ \"value\": \"', dialog.pageItems[turn.itemsList.index].index, '\", \"action\": { \"type\": \"postBack\", \"title\": \"', turn.actionTitle, '\" } }'))"
             },
             {
               "$kind": "Microsoft.EditArray",
@@ -289,7 +297,7 @@
                 "id": "L4FUUg"
               },
               "changeType": "push",
-              "itemsProperty": "turn.choices",
+              "itemsProperty": "dialog.choices",
               "value": "=turn.choiceItem"
             }
           ]

--- a/generators/generator-bot-enterprise-people/generators/app/templates/dialogs/ListDialog/language-generation/en-us/ListDialog.en-us.lg
+++ b/generators/generator-bot-enterprise-people/generators/app/templates/dialogs/ListDialog/language-generation/en-us/ListDialog.en-us.lg
@@ -25,19 +25,19 @@
 # InitialChoicePrompt()
 [Activity
     text = ${if($turnCount == 1, template($templates.initialPrompt), null)}
-    attachments = ${json(ListCard(count(turn.items), $pageSize, turn.pageItems, $templates.icon, $templates.title, $templates.item, $pageIndex + 1, $pageCount))}
+    attachments = ${json(ListCard(count(dialog.items), $pageSize, dialog.pageItems, $templates.icon, $templates.title, $templates.item, $pageIndex + 1, $pageCount))}
 ]
 
 # RepromptChoicePrompt()
 [Activity
     deliveryMode = update
     id = ${turn.activity.replyToId}
-    attachments = ${json(ListCard(count(turn.items), $pageSize, turn.pageItems, $templates.icon, $templates.title, $templates.item, $pageIndex + 1, $pageCount))}
+    attachments = ${json(ListCard(count(dialog.items), $pageSize, dialog.pageItems, $templates.icon, $templates.title, $templates.item, $pageIndex + 1, $pageCount))}
 ]
 
 # Bot.SendActivityPlus_Activity_UcmH0c()
 [Activity
-    attachments = ${json(ListCard(count(turn.items), $pageSize, turn.pageItems, $templates.icon, $templates.title, $templates.item, $pageIndex + 1, $pageCount))}
+    attachments = ${json(ListCard(count(dialog.items), $pageSize, dialog.pageItems, $templates.icon, $templates.title, $templates.item, $pageIndex + 1, $pageCount))}
 ]
 
 # ChoiceInput_Prompt_VygDK3()

--- a/skills/declarative/People/People/dialogs/ListDialog/ListDialog.dialog
+++ b/skills/declarative/People/People/dialogs/ListDialog/ListDialog.dialog
@@ -76,14 +76,6 @@
               ]
             },
             {
-              "$kind": "Microsoft.SetProperty",
-              "$designer": {
-                "id": "IuTIX8"
-              },
-              "property": "dialog.items",
-              "value": "=turn.items"
-            },
-            {
               "$kind": "Microsoft.ChoiceInput",
               "$designer": {
                 "id": "VygDK3",
@@ -177,6 +169,14 @@
           "value": "=null"
         },
         {
+          "$kind": "Microsoft.SetProperty",
+          "$designer": {
+            "id": "wZQHiW"
+          },
+          "property": "turn.items",
+          "value": "=dialog.items"
+        },
+        {
           "$kind": "Microsoft.EmitEvent",
           "$designer": {
             "id": "aVXgYo",
@@ -192,6 +192,14 @@
           },
           "property": "turn.items",
           "value": "=getProperty($itemsProperty)"
+        },
+        {
+          "$kind": "Microsoft.SetProperty",
+          "$designer": {
+            "id": "EuKh4L"
+          },
+          "property": "dialog.items",
+          "value": "=turn.items"
         },
         {
           "$kind": "Microsoft.IfCondition",

--- a/skills/declarative/People/People/dialogs/ListDialog/ListDialog.dialog
+++ b/skills/declarative/People/People/dialogs/ListDialog/ListDialog.dialog
@@ -76,6 +76,14 @@
               ]
             },
             {
+              "$kind": "Microsoft.SetProperty",
+              "$designer": {
+                "id": "IuTIX8"
+              },
+              "property": "dialog.items",
+              "value": "=turn.items"
+            },
+            {
               "$kind": "Microsoft.ChoiceInput",
               "$designer": {
                 "id": "VygDK3",
@@ -90,7 +98,7 @@
                 "noAction": false,
                 "noValue": false
               },
-              "choices": "=turn.choices",
+              "choices": "=dialog.choices",
               "style": "none",
               "alwaysPrompt": false,
               "allowInterruptions": "=(exists(#Next) || exists(#Previous) || exists(#Skip) || exists(#Cancel)) && turn.recognized.score > 0.8",
@@ -127,7 +135,7 @@
                     "comment": "Extracts the object from the items list matching the selected index."
                   },
                   "property": "turn.selection",
-                  "value": "=turn.pageItems[int(turn.selectedIndex) - 1]"
+                  "value": "=dialog.pageItems[int(turn.selectedIndex) - 1]"
                 }
               ]
             },
@@ -233,7 +241,7 @@
               "value": "=coalesce($pageindex * $pageSize, 0)"
             },
             {
-              "property": "turn.pageItems",
+              "property": "dialog.pageItems",
               "value": "=subArray(turn.items, $startIndex, min($startIndex + $pageSize, count(turn.items)))"
             },
             {
@@ -254,7 +262,7 @@
           },
           "index": "turn.itemsList.index",
           "value": "turn.itemsList.value",
-          "itemsProperty": "turn.pageItems",
+          "itemsProperty": "dialog.pageItems",
           "actions": [
             {
               "$kind": "Microsoft.SetProperty",
@@ -262,7 +270,7 @@
                 "id": "kNUEEQ",
                 "comment": "The index property represents the user-facing index of each item, rather than the zero-based index used by default. "
               },
-              "property": "turn.pageItems[turn.itemsList.index].index",
+              "property": "dialog.pageItems[turn.itemsList.index].index",
               "value": "=turn.itemsList.index + 1"
             },
             {
@@ -272,7 +280,7 @@
                 "comment": "The actionTitle property is passed via dialog options and indicates a field in the choice object that should be used as a way of selecting the item. For example, a contact object with a name and email property, may set the actionTitle to name so the user can select by saying the name of the option."
               },
               "property": "turn.actionTitle",
-              "value": "=turn.pageItems[turn.itemsList.index][$actionTitleProperty]"
+              "value": "=dialog.pageItems[turn.itemsList.index][$actionTitleProperty]"
             },
             {
               "$kind": "Microsoft.SetProperty",
@@ -281,7 +289,7 @@
                 "comment": "Builds the choiceItem in the object format needed for the choice prompt. \n{ \"value\": \"<value>\", \"action\": { \"type\": \"postBack\", \"title\": \"<title>\" }}"
               },
               "property": "turn.choiceItem",
-              "value": "=json(concat('{ \"value\": \"', turn.pageItems[turn.itemsList.index].index, '\", \"action\": { \"type\": \"postBack\", \"title\": \"', turn.actionTitle, '\" } }'))"
+              "value": "=json(concat('{ \"value\": \"', dialog.pageItems[turn.itemsList.index].index, '\", \"action\": { \"type\": \"postBack\", \"title\": \"', turn.actionTitle, '\" } }'))"
             },
             {
               "$kind": "Microsoft.EditArray",
@@ -289,7 +297,7 @@
                 "id": "L4FUUg"
               },
               "changeType": "push",
-              "itemsProperty": "turn.choices",
+              "itemsProperty": "dialog.choices",
               "value": "=turn.choiceItem"
             }
           ]

--- a/skills/declarative/People/People/dialogs/ListDialog/language-generation/en-us/ListDialog.en-us.lg
+++ b/skills/declarative/People/People/dialogs/ListDialog/language-generation/en-us/ListDialog.en-us.lg
@@ -25,19 +25,19 @@
 # InitialChoicePrompt()
 [Activity
     text = ${if($turnCount == 1, template($templates.initialPrompt), null)}
-    attachments = ${json(ListCard(count(turn.items), $pageSize, turn.pageItems, $templates.icon, $templates.title, $templates.item, $pageIndex + 1, $pageCount))}
+    attachments = ${json(ListCard(count(dialog.items), $pageSize, dialog.pageItems, $templates.icon, $templates.title, $templates.item, $pageIndex + 1, $pageCount))}
 ]
 
 # RepromptChoicePrompt()
 [Activity
     deliveryMode = update
     id = ${turn.activity.replyToId}
-    attachments = ${json(ListCard(count(turn.items), $pageSize, turn.pageItems, $templates.icon, $templates.title, $templates.item, $pageIndex + 1, $pageCount))}
+    attachments = ${json(ListCard(count(dialog.items), $pageSize, dialog.pageItems, $templates.icon, $templates.title, $templates.item, $pageIndex + 1, $pageCount))}
 ]
 
 # Bot.SendActivityPlus_Activity_UcmH0c()
 [Activity
-    attachments = ${json(ListCard(count(turn.items), $pageSize, turn.pageItems, $templates.icon, $templates.title, $templates.item, $pageIndex + 1, $pageCount))}
+    attachments = ${json(ListCard(count(dialog.items), $pageSize, dialog.pageItems, $templates.icon, $templates.title, $templates.item, $pageIndex + 1, $pageCount))}
 ]
 
 # ChoiceInput_Prompt_VygDK3()


### PR DESCRIPTION
<!-- This repository only accepts pull requests related to open issues, please link the open issue in description below. -->
<!-- See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. -->
<!-- For example - Close #123: Description goes here. -->

### Purpose
Resolves issue where turn.items is lost when ListDialog is interrupted

### Changes

<!-- Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.) -->

### Tests

<!-- Is this covered by existing tests or new ones? If no, why not? -->

### Feature Plan

<!-- Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues. -->

