### PR TITLE
fix: Set controller Newtonsoft MaxDepth to null

### DIFF
--- a/generators/generator-bot-adaptive/generators/app/templates/dotnet/functions/ActivitySerializationSettings.cs
+++ b/generators/generator-bot-adaptive/generators/app/templates/dotnet/functions/ActivitySerializationSettings.cs
@@ -8,7 +8,8 @@ namespace <%= botName %>
     {
         internal static readonly JsonSerializerSettings Default = new JsonSerializerSettings
         {
-            NullValueHandling = NullValueHandling.Ignore,
+            NullValueHandling = NullValueHandling.Ignore, 
+            MaxDepth = null,
             Formatting = Formatting.Indented,
             DateFormatHandling = DateFormatHandling.IsoDateFormat,
             DateTimeZoneHandling = DateTimeZoneHandling.Utc,

--- a/generators/generator-bot-adaptive/generators/app/templates/dotnet/webapp/Startup.cs
+++ b/generators/generator-bot-adaptive/generators/app/templates/dotnet/webapp/Startup.cs
@@ -20,7 +20,9 @@ namespace <%= botName %>
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-            services.AddControllers().AddNewtonsoftJson();
+            services.AddControllers().AddNewtonsoftJson(options => {
+                options.SerializerSettings.MaxDepth = 128;
+            });
             services.AddBotRuntime(Configuration);
         }
 

--- a/generators/generator-bot-adaptive/generators/app/templates/dotnet/webapp/Startup.cs
+++ b/generators/generator-bot-adaptive/generators/app/templates/dotnet/webapp/Startup.cs
@@ -21,7 +21,7 @@ namespace <%= botName %>
         public void ConfigureServices(IServiceCollection services)
         {
             services.AddControllers().AddNewtonsoftJson(options => {
-                options.SerializerSettings.MaxDepth = 128;
+                options.SerializerSettings.MaxDepth = null;
             });
             services.AddBotRuntime(Configuration);
         }

--- a/packages/Telephony/Actions/BatchRegexInput.cs
+++ b/packages/Telephony/Actions/BatchRegexInput.cs
@@ -190,7 +190,7 @@ namespace Microsoft.Bot.Components.Telephony.Actions
             var properties = new Dictionary<string, string>()
                 {
                     { "template", JsonConvert.SerializeObject(template) },
-                    { "result", msg == null ? string.Empty : JsonConvert.SerializeObject(msg, new JsonSerializerSettings() { NullValueHandling = NullValueHandling.Ignore }) },
+                    { "result", msg == null ? string.Empty : JsonConvert.SerializeObject(msg, new JsonSerializerSettings() { NullValueHandling = NullValueHandling.Ignore, MaxDepth = null }) },
                 };
             TelemetryClient.TrackEvent("GeneratorResult", properties);
 

--- a/packages/Telephony/Actions/SerialNumberInput.cs
+++ b/packages/Telephony/Actions/SerialNumberInput.cs
@@ -266,7 +266,7 @@ namespace Microsoft.Bot.Components.Telephony.Actions
             var properties = new Dictionary<string, string>()
                 {
                     { "template", JsonConvert.SerializeObject(template) },
-                    { "result", msg == null ? string.Empty : JsonConvert.SerializeObject(msg, new JsonSerializerSettings() { NullValueHandling = NullValueHandling.Ignore }) },
+                    { "result", msg == null ? string.Empty : JsonConvert.SerializeObject(msg, new JsonSerializerSettings() { NullValueHandling = NullValueHandling.Ignore, MaxDepth = null }) },
                 };
             TelemetryClient.TrackEvent("GeneratorResult", properties);
 

--- a/skills/csharp/calendarskill/Services/CalendarLuis.cs
+++ b/skills/csharp/calendarskill/Services/CalendarLuis.cs
@@ -119,7 +119,7 @@ namespace Luis
 
         public void Convert(dynamic result)
         {
-            var app = JsonConvert.DeserializeObject<CalendarLuis>(JsonConvert.SerializeObject(result, new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore }));
+            var app = JsonConvert.DeserializeObject<CalendarLuis>(JsonConvert.SerializeObject(result, new JsonSerializerSettings() { NullValueHandling = NullValueHandling.Ignore, MaxDepth = null }));
             Text = app.Text;
             AlteredText = app.AlteredText;
             Intents = app.Intents;

--- a/skills/csharp/calendarskill/Startup.cs
+++ b/skills/csharp/calendarskill/Startup.cs
@@ -50,7 +50,9 @@ namespace CalendarSkill
         public void ConfigureServices(IServiceCollection services)
         {
             // Configure MVC
-            services.AddControllers().AddNewtonsoftJson();
+            services.AddControllers().AddNewtonsoftJson(options => {
+                options.SerializerSettings.MaxDepth = 128;
+            });
 
             // Configure server options
             services.Configure<KestrelServerOptions>(options =>

--- a/skills/csharp/calendarskill/Startup.cs
+++ b/skills/csharp/calendarskill/Startup.cs
@@ -51,7 +51,7 @@ namespace CalendarSkill
         {
             // Configure MVC
             services.AddControllers().AddNewtonsoftJson(options => {
-                options.SerializerSettings.MaxDepth = 128;
+                options.SerializerSettings.MaxDepth = null;
             });
 
             // Configure server options

--- a/skills/csharp/emailskill/Services/EmailLuis.cs
+++ b/skills/csharp/emailskill/Services/EmailLuis.cs
@@ -93,7 +93,7 @@ namespace Luis
 
         public void Convert(dynamic result)
         {
-            var app = JsonConvert.DeserializeObject<EmailLuis>(JsonConvert.SerializeObject(result, new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore }));
+            var app = JsonConvert.DeserializeObject<EmailLuis>(JsonConvert.SerializeObject(result, new JsonSerializerSettings() { NullValueHandling = NullValueHandling.Ignore, MaxDepth = null }));
             Text = app.Text;
             AlteredText = app.AlteredText;
             Intents = app.Intents;

--- a/skills/csharp/emailskill/Startup.cs
+++ b/skills/csharp/emailskill/Startup.cs
@@ -49,7 +49,7 @@ namespace EmailSkill
         {
             // Configure MVC
             services.AddControllers().AddNewtonsoftJson(options => {
-                options.SerializerSettings.MaxDepth = 128;
+                options.SerializerSettings.MaxDepth = null;
             });
 
             // Configure server options

--- a/skills/csharp/emailskill/Startup.cs
+++ b/skills/csharp/emailskill/Startup.cs
@@ -48,7 +48,9 @@ namespace EmailSkill
         public void ConfigureServices(IServiceCollection services)
         {
             // Configure MVC
-            services.AddControllers().AddNewtonsoftJson();
+            services.AddControllers().AddNewtonsoftJson(options => {
+                options.SerializerSettings.MaxDepth = 128;
+            });
 
             // Configure server options
             services.Configure<KestrelServerOptions>(options =>

--- a/skills/csharp/experimental/automotiveskill/Services/SettingsDispatchLuis.cs
+++ b/skills/csharp/experimental/automotiveskill/Services/SettingsDispatchLuis.cs
@@ -52,7 +52,7 @@ namespace Luis
 
         public void Convert(dynamic result)
         {
-            var app = JsonConvert.DeserializeObject<SettingsDispatchLuis>(JsonConvert.SerializeObject(result, new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore }));
+            var app = JsonConvert.DeserializeObject<SettingsDispatchLuis>(JsonConvert.SerializeObject(result, new JsonSerializerSettings() { NullValueHandling = NullValueHandling.Ignore, MaxDepth = null }));
             Text = app.Text;
             AlteredText = app.AlteredText;
             Intents = app.Intents;

--- a/skills/csharp/experimental/automotiveskill/Services/SettingsLuis.cs
+++ b/skills/csharp/experimental/automotiveskill/Services/SettingsLuis.cs
@@ -52,7 +52,7 @@ namespace Luis
 
         public void Convert(dynamic result)
         {
-            var app = JsonConvert.DeserializeObject<SettingsLuis>(JsonConvert.SerializeObject(result, new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore }));
+            var app = JsonConvert.DeserializeObject<SettingsLuis>(JsonConvert.SerializeObject(result, new JsonSerializerSettings() { NullValueHandling = NullValueHandling.Ignore, MaxDepth = null }));
             Text = app.Text;
             AlteredText = app.AlteredText;
             Intents = app.Intents;

--- a/skills/csharp/experimental/automotiveskill/Services/SettingsNameLuis.cs
+++ b/skills/csharp/experimental/automotiveskill/Services/SettingsNameLuis.cs
@@ -42,7 +42,7 @@ namespace Luis
 
         public void Convert(dynamic result)
         {
-            var app = JsonConvert.DeserializeObject<SettingsNameLuis>(JsonConvert.SerializeObject(result, new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore }));
+            var app = JsonConvert.DeserializeObject<SettingsNameLuis>(JsonConvert.SerializeObject(result, new JsonSerializerSettings() { NullValueHandling = NullValueHandling.Ignore, MaxDepth = null }));
             Text = app.Text;
             AlteredText = app.AlteredText;
             Intents = app.Intents;

--- a/skills/csharp/experimental/automotiveskill/Services/SettingsValueLuis.cs
+++ b/skills/csharp/experimental/automotiveskill/Services/SettingsValueLuis.cs
@@ -50,7 +50,7 @@ namespace Luis
 
         public void Convert(dynamic result)
         {
-            var app = JsonConvert.DeserializeObject<SettingsValueLuis>(JsonConvert.SerializeObject(result, new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore }));
+            var app = JsonConvert.DeserializeObject<SettingsValueLuis>(JsonConvert.SerializeObject(result, new JsonSerializerSettings() { NullValueHandling = NullValueHandling.Ignore, MaxDepth = null }));
             Text = app.Text;
             AlteredText = app.AlteredText;
             Intents = app.Intents;

--- a/skills/csharp/experimental/automotiveskill/Startup.cs
+++ b/skills/csharp/experimental/automotiveskill/Startup.cs
@@ -53,7 +53,7 @@ namespace AutomotiveSkill
         {
             // Configure MVC
             services.AddControllers().AddNewtonsoftJson(options => {
-                options.SerializerSettings.MaxDepth = 128;
+                options.SerializerSettings.MaxDepth = null;
             });
 
             // Configure server options

--- a/skills/csharp/experimental/automotiveskill/Startup.cs
+++ b/skills/csharp/experimental/automotiveskill/Startup.cs
@@ -52,7 +52,9 @@ namespace AutomotiveSkill
         public void ConfigureServices(IServiceCollection services)
         {
             // Configure MVC
-            services.AddControllers().AddNewtonsoftJson();
+            services.AddControllers().AddNewtonsoftJson(options => {
+                options.SerializerSettings.MaxDepth = 128;
+            });
 
             // Configure server options
             services.Configure<KestrelServerOptions>(options =>

--- a/skills/csharp/experimental/bingsearchskill/Startup.cs
+++ b/skills/csharp/experimental/bingsearchskill/Startup.cs
@@ -47,7 +47,7 @@ namespace BingSearchSkill
         {
             // Configure MVC
             services.AddControllers().AddNewtonsoftJson(options => {
-                options.SerializerSettings.MaxDepth = 128;
+                options.SerializerSettings.MaxDepth = null;
             });
 
             // Configure server options

--- a/skills/csharp/experimental/bingsearchskill/Startup.cs
+++ b/skills/csharp/experimental/bingsearchskill/Startup.cs
@@ -46,7 +46,9 @@ namespace BingSearchSkill
         public void ConfigureServices(IServiceCollection services)
         {
             // Configure MVC
-            services.AddControllers().AddNewtonsoftJson();
+            services.AddControllers().AddNewtonsoftJson(options => {
+                options.SerializerSettings.MaxDepth = 128;
+            });
 
             // Configure server options
             services.Configure<KestrelServerOptions>(options =>

--- a/skills/csharp/experimental/eventskill/Services/EventLuis.cs
+++ b/skills/csharp/experimental/eventskill/Services/EventLuis.cs
@@ -37,7 +37,7 @@ namespace Luis
 
         public void Convert(dynamic result)
         {
-            var app = JsonConvert.DeserializeObject<EventLuis>(JsonConvert.SerializeObject(result, new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore }));
+            var app = JsonConvert.DeserializeObject<EventLuis>(JsonConvert.SerializeObject(result, new JsonSerializerSettings() { NullValueHandling = NullValueHandling.Ignore, MaxDepth = null }));
             Text = app.Text;
             AlteredText = app.AlteredText;
             Intents = app.Intents;

--- a/skills/csharp/experimental/eventskill/Services/GeneralLuis.cs
+++ b/skills/csharp/experimental/eventskill/Services/GeneralLuis.cs
@@ -62,7 +62,7 @@ namespace Luis
 
         public void Convert(dynamic result)
         {
-            var app = JsonConvert.DeserializeObject<GeneralLuis>(JsonConvert.SerializeObject(result, new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore }));
+            var app = JsonConvert.DeserializeObject<GeneralLuis>(JsonConvert.SerializeObject(result, new JsonSerializerSettings() { NullValueHandling = NullValueHandling.Ignore, MaxDepth = null }));
             Text = app.Text;
             AlteredText = app.AlteredText;
             Intents = app.Intents;

--- a/skills/csharp/experimental/eventskill/Startup.cs
+++ b/skills/csharp/experimental/eventskill/Startup.cs
@@ -46,7 +46,9 @@ namespace EventSkill
         public void ConfigureServices(IServiceCollection services)
         {
             // Configure MVC
-            services.AddControllers().AddNewtonsoftJson();
+            services.AddControllers().AddNewtonsoftJson(options => {
+                options.SerializerSettings.MaxDepth = 128;
+            });
 
             // Configure server options
             services.Configure<KestrelServerOptions>(options =>

--- a/skills/csharp/experimental/eventskill/Startup.cs
+++ b/skills/csharp/experimental/eventskill/Startup.cs
@@ -47,7 +47,7 @@ namespace EventSkill
         {
             // Configure MVC
             services.AddControllers().AddNewtonsoftJson(options => {
-                options.SerializerSettings.MaxDepth = 128;
+                options.SerializerSettings.MaxDepth = null;
             });
 
             // Configure server options

--- a/skills/csharp/experimental/hospitalityskill/Services/GeneralLuis.cs
+++ b/skills/csharp/experimental/hospitalityskill/Services/GeneralLuis.cs
@@ -62,7 +62,7 @@ namespace Luis
 
         public void Convert(dynamic result)
         {
-            var app = JsonConvert.DeserializeObject<GeneralLuis>(JsonConvert.SerializeObject(result, new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore }));
+            var app = JsonConvert.DeserializeObject<GeneralLuis>(JsonConvert.SerializeObject(result, new JsonSerializerSettings() { NullValueHandling = NullValueHandling.Ignore, MaxDepth = null }));
             Text = app.Text;
             AlteredText = app.AlteredText;
             Intents = app.Intents;

--- a/skills/csharp/experimental/hospitalityskill/Services/HospitalityLuis.cs
+++ b/skills/csharp/experimental/hospitalityskill/Services/HospitalityLuis.cs
@@ -109,7 +109,7 @@ namespace Luis
 
         public void Convert(dynamic result)
         {
-            var app = JsonConvert.DeserializeObject<HospitalityLuis>(JsonConvert.SerializeObject(result, new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore }));
+            var app = JsonConvert.DeserializeObject<HospitalityLuis>(JsonConvert.SerializeObject(result, new JsonSerializerSettings() { NullValueHandling = NullValueHandling.Ignore, MaxDepth = null }));
             Text = app.Text;
             AlteredText = app.AlteredText;
             Intents = app.Intents;

--- a/skills/csharp/experimental/hospitalityskill/Startup.cs
+++ b/skills/csharp/experimental/hospitalityskill/Startup.cs
@@ -47,7 +47,9 @@ namespace HospitalitySkill
         public void ConfigureServices(IServiceCollection services)
         {
             // Configure MVC
-            services.AddControllers().AddNewtonsoftJson();
+            services.AddControllers().AddNewtonsoftJson(options => {
+                options.SerializerSettings.MaxDepth = 128;
+            });
 
             // Configure server options
             services.Configure<KestrelServerOptions>(options =>

--- a/skills/csharp/experimental/hospitalityskill/Startup.cs
+++ b/skills/csharp/experimental/hospitalityskill/Startup.cs
@@ -48,7 +48,7 @@ namespace HospitalitySkill
         {
             // Configure MVC
             services.AddControllers().AddNewtonsoftJson(options => {
-                options.SerializerSettings.MaxDepth = 128;
+                options.SerializerSettings.MaxDepth = null;
             });
 
             // Configure server options

--- a/skills/csharp/experimental/itsmskill/Services/ITSMLuis.cs
+++ b/skills/csharp/experimental/itsmskill/Services/ITSMLuis.cs
@@ -71,7 +71,7 @@ namespace Luis
             var app = JsonConvert.DeserializeObject<ITSMLuis>(
                 JsonConvert.SerializeObject(
                     result,
-                    new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore, Error = OnError }
+                    new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore, MaxDepth = null, Error = OnError }
                 )
             );
             Text = app.Text;

--- a/skills/csharp/experimental/itsmskill/Services/ServiceNow/Management.cs
+++ b/skills/csharp/experimental/itsmskill/Services/ServiceNow/Management.cs
@@ -417,7 +417,7 @@ namespace ITSMSkill.Services.ServiceNow
 
             public string Serialize(object obj)
             {
-                return JsonConvert.SerializeObject(obj, new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore });
+                return JsonConvert.SerializeObject(obj, new JsonSerializerSettings() { NullValueHandling = NullValueHandling.Ignore, MaxDepth = null });
             }
         }
     }

--- a/skills/csharp/experimental/itsmskill/Startup.cs
+++ b/skills/csharp/experimental/itsmskill/Startup.cs
@@ -62,7 +62,9 @@ namespace ITSMSkill
         public void ConfigureServices(IServiceCollection services)
         {
             // Configure MVC
-            services.AddControllers().AddNewtonsoftJson(); ;
+            services.AddControllers().AddNewtonsoftJson(options => {
+                options.SerializerSettings.MaxDepth = 128;
+            });
 
             // Configure server options
             services.Configure<KestrelServerOptions>(options =>

--- a/skills/csharp/experimental/itsmskill/Startup.cs
+++ b/skills/csharp/experimental/itsmskill/Startup.cs
@@ -63,7 +63,7 @@ namespace ITSMSkill
         {
             // Configure MVC
             services.AddControllers().AddNewtonsoftJson(options => {
-                options.SerializerSettings.MaxDepth = 128;
+                options.SerializerSettings.MaxDepth = null;
             });
 
             // Configure server options

--- a/skills/csharp/experimental/musicskill/Services/GeneralLuis.cs
+++ b/skills/csharp/experimental/musicskill/Services/GeneralLuis.cs
@@ -69,7 +69,7 @@ namespace Luis
 
         public void Convert(dynamic result)
         {
-            var app = JsonConvert.DeserializeObject<GeneralLuis>(JsonConvert.SerializeObject(result, new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore }));
+            var app = JsonConvert.DeserializeObject<GeneralLuis>(JsonConvert.SerializeObject(result, new JsonSerializerSettings() { NullValueHandling = NullValueHandling.Ignore, MaxDepth = null }));
             Text = app.Text;
             AlteredText = app.AlteredText;
             Intents = app.Intents;

--- a/skills/csharp/experimental/musicskill/Startup.cs
+++ b/skills/csharp/experimental/musicskill/Startup.cs
@@ -49,7 +49,7 @@ namespace MusicSkill
         {
             // Configure MVC
             services.AddControllers().AddNewtonsoftJson(options => {
-                options.SerializerSettings.MaxDepth = 128;
+                options.SerializerSettings.MaxDepth = null;
             });
 
             // Configure server options

--- a/skills/csharp/experimental/musicskill/Startup.cs
+++ b/skills/csharp/experimental/musicskill/Startup.cs
@@ -48,7 +48,9 @@ namespace MusicSkill
         public void ConfigureServices(IServiceCollection services)
         {
             // Configure MVC
-            services.AddControllers().AddNewtonsoftJson();
+            services.AddControllers().AddNewtonsoftJson(options => {
+                options.SerializerSettings.MaxDepth = 128;
+            });
 
             // Configure server options
             services.Configure<KestrelServerOptions>(options =>

--- a/skills/csharp/experimental/newsskill/Startup.cs
+++ b/skills/csharp/experimental/newsskill/Startup.cs
@@ -55,7 +55,7 @@ namespace NewsSkill
         {
             // Configure MVC
             services.AddControllers().AddNewtonsoftJson(options => {
-                options.SerializerSettings.MaxDepth = 128;
+                options.SerializerSettings.MaxDepth = null;
             });
 
             // Configure server options

--- a/skills/csharp/experimental/newsskill/Startup.cs
+++ b/skills/csharp/experimental/newsskill/Startup.cs
@@ -54,7 +54,9 @@ namespace NewsSkill
         public void ConfigureServices(IServiceCollection services)
         {
             // Configure MVC
-            services.AddControllers().AddNewtonsoftJson();
+            services.AddControllers().AddNewtonsoftJson(options => {
+                options.SerializerSettings.MaxDepth = 128;
+            });
 
             // Configure server options
             services.Configure<KestrelServerOptions>(options =>

--- a/skills/csharp/experimental/phoneskill/Services/Luis/ContactSelectionLuis.cs
+++ b/skills/csharp/experimental/phoneskill/Services/Luis/ContactSelectionLuis.cs
@@ -42,7 +42,7 @@ namespace PhoneSkill.Services.Luis
 
         public void Convert(dynamic result)
         {
-            var app = JsonConvert.DeserializeObject<ContactSelectionLuis>(JsonConvert.SerializeObject(result, new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore }));
+            var app = JsonConvert.DeserializeObject<ContactSelectionLuis>(JsonConvert.SerializeObject(result, new JsonSerializerSettings() { NullValueHandling = NullValueHandling.Ignore, MaxDepth = null }));
             Text = app.Text;
             AlteredText = app.AlteredText;
             Intents = app.Intents;

--- a/skills/csharp/experimental/phoneskill/Services/Luis/PhoneLuis.cs
+++ b/skills/csharp/experimental/phoneskill/Services/Luis/PhoneLuis.cs
@@ -50,7 +50,7 @@ namespace PhoneSkill.Services.Luis
 
         public void Convert(dynamic result)
         {
-            var app = JsonConvert.DeserializeObject<PhoneLuis>(JsonConvert.SerializeObject(result, new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore }));
+            var app = JsonConvert.DeserializeObject<PhoneLuis>(JsonConvert.SerializeObject(result, new JsonSerializerSettings() { NullValueHandling = NullValueHandling.Ignore, MaxDepth = null }));
             Text = app.Text;
             AlteredText = app.AlteredText;
             Intents = app.Intents;

--- a/skills/csharp/experimental/phoneskill/Services/Luis/PhoneNumberSelectionLuis.cs
+++ b/skills/csharp/experimental/phoneskill/Services/Luis/PhoneNumberSelectionLuis.cs
@@ -44,7 +44,7 @@ namespace PhoneSkill.Services.Luis
 
         public void Convert(dynamic result)
         {
-            var app = JsonConvert.DeserializeObject<PhoneNumberSelectionLuis>(JsonConvert.SerializeObject(result, new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore }));
+            var app = JsonConvert.DeserializeObject<PhoneNumberSelectionLuis>(JsonConvert.SerializeObject(result, new JsonSerializerSettings() { NullValueHandling = NullValueHandling.Ignore, MaxDepth = null }));
             Text = app.Text;
             AlteredText = app.AlteredText;
             Intents = app.Intents;

--- a/skills/csharp/experimental/phoneskill/Startup.cs
+++ b/skills/csharp/experimental/phoneskill/Startup.cs
@@ -47,7 +47,9 @@ namespace PhoneSkill
         public void ConfigureServices(IServiceCollection services)
         {
             // Configure MVC
-            services.AddControllers().AddNewtonsoftJson();
+            services.AddControllers().AddNewtonsoftJson(options => {
+                options.SerializerSettings.MaxDepth = 128;
+            });
 
             // Configure server options
             services.Configure<KestrelServerOptions>(options =>

--- a/skills/csharp/experimental/phoneskill/Startup.cs
+++ b/skills/csharp/experimental/phoneskill/Startup.cs
@@ -48,7 +48,7 @@ namespace PhoneSkill
         {
             // Configure MVC
             services.AddControllers().AddNewtonsoftJson(options => {
-                options.SerializerSettings.MaxDepth = 128;
+                options.SerializerSettings.MaxDepth = null;
             });
 
             // Configure server options

--- a/skills/csharp/experimental/restaurantbookingskill/Services/ReservationLuis.cs
+++ b/skills/csharp/experimental/restaurantbookingskill/Services/ReservationLuis.cs
@@ -69,7 +69,7 @@ namespace Luis
 
         public void Convert(dynamic result)
         {
-            var app = JsonConvert.DeserializeObject<ReservationLuis>(JsonConvert.SerializeObject(result, new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore }));
+            var app = JsonConvert.DeserializeObject<ReservationLuis>(JsonConvert.SerializeObject(result, new JsonSerializerSettings() { NullValueHandling = NullValueHandling.Ignore, MaxDepth = null }));
             Text = app.Text;
             AlteredText = app.AlteredText;
             Intents = app.Intents;

--- a/skills/csharp/experimental/restaurantbookingskill/Startup.cs
+++ b/skills/csharp/experimental/restaurantbookingskill/Startup.cs
@@ -56,7 +56,9 @@ namespace RestaurantBooking
         public void ConfigureServices(IServiceCollection services)
         {
             // Configure MVC
-            services.AddControllers().AddNewtonsoftJson();
+            services.AddControllers().AddNewtonsoftJson(options => {
+                options.SerializerSettings.MaxDepth = 128;
+            });
 
             // Configure channel provider
             services.AddSingleton<IChannelProvider, ConfigurationChannelProvider>();

--- a/skills/csharp/experimental/restaurantbookingskill/Startup.cs
+++ b/skills/csharp/experimental/restaurantbookingskill/Startup.cs
@@ -57,7 +57,7 @@ namespace RestaurantBooking
         {
             // Configure MVC
             services.AddControllers().AddNewtonsoftJson(options => {
-                options.SerializerSettings.MaxDepth = 128;
+                options.SerializerSettings.MaxDepth = null;
             });
 
             // Configure channel provider

--- a/skills/csharp/experimental/weatherskill/Services/WeatherSkillLuis.cs
+++ b/skills/csharp/experimental/weatherskill/Services/WeatherSkillLuis.cs
@@ -78,7 +78,7 @@ namespace Luis
 
         public void Convert(dynamic result)
         {
-            var app = JsonConvert.DeserializeObject<WeatherSkillLuis>(JsonConvert.SerializeObject(result, new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore }));
+            var app = JsonConvert.DeserializeObject<WeatherSkillLuis>(JsonConvert.SerializeObject(result, new JsonSerializerSettings() { NullValueHandling = NullValueHandling.Ignore, MaxDepth = null }));
             Text = app.Text;
             AlteredText = app.AlteredText;
             Intents = app.Intents;

--- a/skills/csharp/experimental/weatherskill/Startup.cs
+++ b/skills/csharp/experimental/weatherskill/Startup.cs
@@ -51,7 +51,9 @@ namespace WeatherSkill
         public void ConfigureServices(IServiceCollection services)
         {
             // Configure MVC
-            services.AddControllers().AddNewtonsoftJson();
+            services.AddControllers().AddNewtonsoftJson(options => {
+                options.SerializerSettings.MaxDepth = 128;
+            });
 
             // Configure channel provider
             services.AddSingleton<IChannelProvider, ConfigurationChannelProvider>();

--- a/skills/csharp/experimental/weatherskill/Startup.cs
+++ b/skills/csharp/experimental/weatherskill/Startup.cs
@@ -52,7 +52,7 @@ namespace WeatherSkill
         {
             // Configure MVC
             services.AddControllers().AddNewtonsoftJson(options => {
-                options.SerializerSettings.MaxDepth = 128;
+                options.SerializerSettings.MaxDepth = null;
             });
 
             // Configure channel provider

--- a/skills/csharp/pointofinterestskill/Services/PointOfInterestLuis.cs
+++ b/skills/csharp/pointofinterestskill/Services/PointOfInterestLuis.cs
@@ -70,7 +70,7 @@ namespace Luis
             var app = JsonConvert.DeserializeObject<PointOfInterestLuis>(
                 JsonConvert.SerializeObject(
                     result,
-                    new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore, Error = OnError }
+                    new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore, MaxDepth = null, Error = OnError }
                 )
             );
             Text = app.Text;

--- a/skills/csharp/pointofinterestskill/Startup.cs
+++ b/skills/csharp/pointofinterestskill/Startup.cs
@@ -55,7 +55,7 @@ namespace PointOfInterestSkill
         {
             // Configure MVC
             services.AddControllers().AddNewtonsoftJson(options => {
-                options.SerializerSettings.MaxDepth = 128;
+                options.SerializerSettings.MaxDepth = null;
             });
 
             // Configure server options

--- a/skills/csharp/pointofinterestskill/Startup.cs
+++ b/skills/csharp/pointofinterestskill/Startup.cs
@@ -54,7 +54,9 @@ namespace PointOfInterestSkill
         public void ConfigureServices(IServiceCollection services)
         {
             // Configure MVC
-            services.AddControllers().AddNewtonsoftJson();
+            services.AddControllers().AddNewtonsoftJson(options => {
+                options.SerializerSettings.MaxDepth = 128;
+            });
 
             // Configure server options
             services.Configure<KestrelServerOptions>(options =>

--- a/skills/csharp/todoskill/Services/ToDoLuis.cs
+++ b/skills/csharp/todoskill/Services/ToDoLuis.cs
@@ -71,7 +71,7 @@ namespace Luis
             var app = JsonConvert.DeserializeObject<ToDoLuis>(
                 JsonConvert.SerializeObject(
                     result,
-                    new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore, Error = OnError }
+                    new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore, MaxDepth = null, Error = OnError }
                 )
             );
             Text = app.Text;

--- a/skills/csharp/todoskill/Startup.cs
+++ b/skills/csharp/todoskill/Startup.cs
@@ -49,7 +49,9 @@ namespace ToDoSkill
         public void ConfigureServices(IServiceCollection services)
         {
             // Configure MVC
-            services.AddControllers().AddNewtonsoftJson();
+            services.AddControllers().AddNewtonsoftJson(options => {
+                options.SerializerSettings.MaxDepth = 128;
+            });
 
             // Configure channel provider
             services.AddSingleton<IChannelProvider, ConfigurationChannelProvider>();

--- a/skills/csharp/todoskill/Startup.cs
+++ b/skills/csharp/todoskill/Startup.cs
@@ -50,7 +50,7 @@ namespace ToDoSkill
         {
             // Configure MVC
             services.AddControllers().AddNewtonsoftJson(options => {
-                options.SerializerSettings.MaxDepth = 128;
+                options.SerializerSettings.MaxDepth = null;
             });
 
             // Configure channel provider

--- a/skills/declarative/Calendar/Calendar/Startup.cs
+++ b/skills/declarative/Calendar/Calendar/Startup.cs
@@ -19,7 +19,9 @@ namespace Calendar
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-            services.AddControllers().AddNewtonsoftJson();
+            services.AddControllers().AddNewtonsoftJson(options => {
+                options.SerializerSettings.MaxDepth = 128;
+            });
             services.AddBotRuntime(Configuration);
         }
 

--- a/skills/declarative/Calendar/Calendar/Startup.cs
+++ b/skills/declarative/Calendar/Calendar/Startup.cs
@@ -20,7 +20,7 @@ namespace Calendar
         public void ConfigureServices(IServiceCollection services)
         {
             services.AddControllers().AddNewtonsoftJson(options => {
-                options.SerializerSettings.MaxDepth = 128;
+                options.SerializerSettings.MaxDepth = null;
             });
             services.AddBotRuntime(Configuration);
         }

--- a/skills/declarative/People/People/Startup.cs
+++ b/skills/declarative/People/People/Startup.cs
@@ -21,7 +21,7 @@ namespace People
         public void ConfigureServices(IServiceCollection services)
         {
             services.AddControllers().AddNewtonsoftJson(options => {
-                options.SerializerSettings.MaxDepth = 128;
+                options.SerializerSettings.MaxDepth = null;
             });
             services.AddBotRuntime(Configuration);
         }

--- a/skills/declarative/People/People/Startup.cs
+++ b/skills/declarative/People/People/Startup.cs
@@ -20,7 +20,9 @@ namespace People
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-            services.AddControllers().AddNewtonsoftJson();
+            services.AddControllers().AddNewtonsoftJson(options => {
+                options.SerializerSettings.MaxDepth = 128;
+            });
             services.AddBotRuntime(Configuration);
         }
 

--- a/tests/functional/Libraries/TranscriptConverter/ConvertTranscriptHandler.cs
+++ b/tests/functional/Libraries/TranscriptConverter/ConvertTranscriptHandler.cs
@@ -60,7 +60,8 @@ namespace TranscriptConverter
                 Formatting.Indented,
                 new JsonSerializerSettings
                 {
-                    NullValueHandling = NullValueHandling.Ignore
+                    NullValueHandling = NullValueHandling.Ignore,
+                    MaxDepth = null
                 });
 
             using var streamWriter = new StreamWriter(Path.GetFullPath(targetScript));

--- a/tests/functional/Libraries/TranscriptConverter/Converter.cs
+++ b/tests/functional/Libraries/TranscriptConverter/Converter.cs
@@ -107,7 +107,8 @@ namespace TranscriptConverter
                 Formatting.None,
                 new JsonSerializerSettings
                 {
-                    NullValueHandling = NullValueHandling.Ignore
+                    NullValueHandling = NullValueHandling.Ignore,
+                    MaxDepth = null
                 });
 
             var token = JToken.Parse(json);


### PR DESCRIPTION
fixes: #1357

### Purpose
Some dependency must have been updated, which now includes a default nesting level of 32 for incoming json content. This pull request increases the asp.net newtonsoft configuration default to null
