### PR TITLE
chore: Clean up ExtractCompressNuGet.ps1 in botframework-components

### DIFF
--- a/build/ExtractCompressNuGet.ps1
+++ b/build/ExtractCompressNuGet.ps1
@@ -10,10 +10,6 @@ param
 )
 pushd $path
 
-# Download temporary version of Archive module that fixes issue on macOS/Linux with path separator
-#Invoke-WebRequest -Uri "https://raw.githubusercontent.com/PowerShell/Microsoft.PowerShell.Archive/master/Microsoft.PowerShell.Archive/Microsoft.PowerShell.Archive.psm1" -OutFile .\archive.psm1
-#Import-Module .\archive.psm1
-
 # Ensure Powershell.Archive minimum version 1.2.3.0 is installed. That fixes a path separator issue on macOS/Linux. 
 # An "ObjectNotFound" error can result from a temporary Powershell module repository outage. 
 $ver = (Get-Command -Module Microsoft.PowerShell.Archive | Select-Object -Property version -First 1).Version.ToString()


### PR DESCRIPTION
Fixes #minor

## Proposed Changes
ExtractCompressNuGet.ps1 has outdated commented-out powershell patching code. 

This cleans it up.