### PR TITLE
fix: [#1338] Calendar Skill - Old adaptive card buttons trigger junk response

### DIFF
--- a/generators/generator-bot-enterprise-calendar/generators/app/templates/dialogs/GetEventsDialog/GetEventsDialog.dialog
+++ b/generators/generator-bot-enterprise-calendar/generators/app/templates/dialogs/GetEventsDialog/GetEventsDialog.dialog
@@ -47,13 +47,13 @@
             "id": "80CHa6",
             "comment": "If the eventId was passed as a dialog option, then perform an event lookup rather than a search. This is typically triggered by selecting an event from a list of search results. "
           },
-          "condition": "=$parameters.eventId != null",
+          "condition": "=not(empty($parameters.eventId))",
           "elseActions": [
             {
               "$kind": "Microsoft.EmitEvent",
               "$designer": {
                 "id": "IgNZGN",
-                "comment": "Triggers the OnEvent (GetEventById) handler. Performs an event search based on the parameters provided by the user."
+                "comment": "Triggers the OnEvent (GetEvents) handler. Performs an event search based on the parameters provided by the user."
               },
               "eventName": "GetEvents"
             }

--- a/skills/declarative/Calendar/Calendar/dialogs/GetEventsDialog/GetEventsDialog.dialog
+++ b/skills/declarative/Calendar/Calendar/dialogs/GetEventsDialog/GetEventsDialog.dialog
@@ -47,13 +47,13 @@
             "id": "80CHa6",
             "comment": "If the eventId was passed as a dialog option, then perform an event lookup rather than a search. This is typically triggered by selecting an event from a list of search results. "
           },
-          "condition": "=$parameters.eventId != null",
+          "condition": "=not(empty($parameters.eventId))",
           "elseActions": [
             {
               "$kind": "Microsoft.EmitEvent",
               "$designer": {
                 "id": "IgNZGN",
-                "comment": "Triggers the OnEvent (GetEventById) handler. Performs an event search based on the parameters provided by the user."
+                "comment": "Triggers the OnEvent (GetEvents) handler. Performs an event search based on the parameters provided by the user."
               },
               "eventName": "GetEvents"
             }


### PR DESCRIPTION
Fixes #1338

### Purpose

This PR fixes the error thrown after clicking on an adaptive card after confirming the creation of a new event.
It was trying to get the event's data but the eventId was unavailable.

### Changes

- Updated the if condition in **_GetEventsdialog_** to consider both null and empty values. If the _eventId_ is not empty, trigger the _GetEventById_ event, otherwise, trigger the _GetEvents_ event.

### Tests

These images show the error thrown before and the new behavior after the changes.
![image](https://user-images.githubusercontent.com/44245136/190190026-49d95784-536c-478f-ad06-1f91e87b425f.png)

![image](https://user-images.githubusercontent.com/44245136/190190074-89e0d1e5-9c9a-4e52-82f2-fd5d75b216bd.png)