### PR TITLE
fix: [#1340] Calendar Skill - Marking an event tentative throws an error to the user

### DIFF
--- a/generators/generator-bot-enterprise-calendar/generators/app/templates/dialogs/RespondToEventDialog/RespondToEventDialog.dialog
+++ b/generators/generator-bot-enterprise-calendar/generators/app/templates/dialogs/RespondToEventDialog/RespondToEventDialog.dialog
@@ -112,42 +112,63 @@
                 "id": "OAx8M6"
               }
             }
+          ],
+          "elseActions": [
+            {
+              "$kind": "Microsoft.IfCondition",
+              "$designer": {
+                "id": "Ds9OUz",
+                "comment": "If the event's organizer requested responses, they can accept it."
+              },
+              "condition": "=$event.responseRequested",
+              "actions": [
+                {
+                  "$kind": "Microsoft.BeginDialog",
+                  "$designer": {
+                    "id": "r6bf1q",
+                    "comment": "Refreshes user token."
+                  },
+                  "activityProcessed": true,
+                  "dialog": "AuthenticationDialog"
+                },
+                {
+                  "$kind": "Microsoft.Graph.Calendar.AcceptEvent",
+                  "$designer": {
+                    "id": "2F9RxQ",
+                    "comment": "Updates the user's response to 'accepted' for the provided event."
+                  },
+                  "resultProperty": "$result",
+                  "token": "=turn.token.token",
+                  "eventId": "=$event.Id"
+                },
+                {
+                  "$kind": "Microsoft.SetProperty",
+                  "$designer": {
+                    "id": "Xs8DT3",
+                    "comment": "Updates the event response in state so the card UI will be updated."
+                  },
+                  "property": "$event.Response",
+                  "value": "='accepted'"
+                },
+                {
+                  "$kind": "Microsoft.SendActivity",
+                  "$designer": {
+                    "id": "P5pp9f"
+                  },
+                  "activity": "${SendActivity_P5pp9f()}"
+                }
+              ],
+              "elseActions": [
+                {
+                  "$kind": "Microsoft.SendActivity",
+                  "$designer": {
+                    "id": "tptZo3"
+                  },
+                  "activity": "${SendActivity_tptZo3()}"
+                }
+              ]
+            }
           ]
-        },
-        {
-          "$kind": "Microsoft.BeginDialog",
-          "$designer": {
-            "id": "r6bf1q",
-            "comment": "Refreshes user token."
-          },
-          "activityProcessed": true,
-          "dialog": "AuthenticationDialog"
-        },
-        {
-          "$kind": "Microsoft.Graph.Calendar.AcceptEvent",
-          "$designer": {
-            "id": "2F9RxQ",
-            "comment": "Updates the user's response to 'accepted' for the provided event."
-          },
-          "resultProperty": "$result",
-          "token": "=turn.token.token",
-          "eventId": "=$event.Id"
-        },
-        {
-          "$kind": "Microsoft.SetProperty",
-          "$designer": {
-            "id": "Xs8DT3",
-            "comment": "Updates the event response in state so the card UI will be updated."
-          },
-          "property": "$event.Response",
-          "value": "='accepted'"
-        },
-        {
-          "$kind": "Microsoft.SendActivity",
-          "$designer": {
-            "id": "P5pp9f"
-          },
-          "activity": "${SendActivity_P5pp9f()}"
         }
       ]
     },
@@ -193,42 +214,63 @@
                 "event": "=$event"
               }
             }
+          ],
+          "elseActions": [
+            {
+              "$kind": "Microsoft.IfCondition",
+              "$designer": {
+                "id": "T2Ub07",
+                "comment": "If the event's organizer requested responses, they can decline it."
+              },
+              "condition": "=$event.responseRequested",
+              "actions": [
+                {
+                  "$kind": "Microsoft.BeginDialog",
+                  "$designer": {
+                    "id": "8wZGwZ",
+                    "comment": "Refreshes user token."
+                  },
+                  "activityProcessed": true,
+                  "dialog": "AuthenticationDialog"
+                },
+                {
+                  "$kind": "Microsoft.Graph.Calendar.DeclineEvent",
+                  "$designer": {
+                    "id": "w2IgGa",
+                    "comment": "Updates the user's response to 'declined' for the provided event."
+                  },
+                  "resultProperty": "$result",
+                  "token": "=turn.token.token",
+                  "eventId": "=$event.Id"
+                },
+                {
+                  "$kind": "Microsoft.SetProperty",
+                  "$designer": {
+                    "id": "yzE1s5",
+                    "comment": "Updates the event response in state so the card UI will be updated."
+                  },
+                  "property": "$event.Response",
+                  "value": "='declined'"
+                },
+                {
+                  "$kind": "Microsoft.SendActivity",
+                  "$designer": {
+                    "id": "3DZbbg"
+                  },
+                  "activity": "${SendActivity_3DZbbg()}"
+                }
+              ],
+              "elseActions": [
+                {
+                  "$kind": "Microsoft.SendActivity",
+                  "$designer": {
+                    "id": "hlCvkR"
+                  },
+                  "activity": "${SendActivity_hlCvkR()}"
+                }
+              ]
+            }
           ]
-        },
-        {
-          "$kind": "Microsoft.BeginDialog",
-          "$designer": {
-            "id": "8wZGwZ",
-            "comment": "Refreshes user token."
-          },
-          "activityProcessed": true,
-          "dialog": "AuthenticationDialog"
-        },
-        {
-          "$kind": "Microsoft.Graph.Calendar.DeclineEvent",
-          "$designer": {
-            "id": "w2IgGa",
-            "comment": "Updates the user's response to 'declined' for the provided event."
-          },
-          "resultProperty": "$result",
-          "token": "=turn.token.token",
-          "eventId": "=$event.Id"
-        },
-        {
-          "$kind": "Microsoft.SetProperty",
-          "$designer": {
-            "id": "yzE1s5",
-            "comment": "Updates the event response in state so the card UI will be updated."
-          },
-          "property": "$event.Response",
-          "value": "='declined'"
-        },
-        {
-          "$kind": "Microsoft.SendActivity",
-          "$designer": {
-            "id": "3DZbbg"
-          },
-          "activity": "${SendActivity_3DZbbg()}"
         }
       ]
     },
@@ -271,45 +313,67 @@
               "activityProcessed": true,
               "dialog": "UpdateEventDialog",
               "options": {
-                "options.eventId": "=$event.Id"
+                "options": "=$options",
+                "event": "=$event"
               }
             }
+          ],
+          "elseActions": [
+            {
+              "$kind": "Microsoft.IfCondition",
+              "$designer": {
+                "id": "z7VIU1",
+                "comment": "If the event's organizer requested responses, they can tentatively accept it."
+              },
+              "condition": "=$event.responseRequested",
+              "actions": [
+                {
+                  "$kind": "Microsoft.BeginDialog",
+                  "$designer": {
+                    "id": "MIElov",
+                    "comment": "Refreshes user token."
+                  },
+                  "activityProcessed": true,
+                  "dialog": "AuthenticationDialog"
+                },
+                {
+                  "$kind": "Microsoft.Graph.Calendar.TentativelyAcceptEvent",
+                  "$designer": {
+                    "id": "baSSxn",
+                    "comment": "Updates the user's response to 'tentativelyAccepted' for the provided event."
+                  },
+                  "resultProperty": "$result",
+                  "token": "=turn.token.token",
+                  "eventId": "=$event.Id"
+                },
+                {
+                  "$kind": "Microsoft.SetProperty",
+                  "$designer": {
+                    "id": "C0GtDY",
+                    "comment": "Updates the event response in state so the card UI will be updated."
+                  },
+                  "property": "$event.Response",
+                  "value": "='tentativelyAccepted'"
+                },
+                {
+                  "$kind": "Microsoft.SendActivity",
+                  "$designer": {
+                    "id": "S2mcC8"
+                  },
+                  "activity": "${SendActivity_S2mcC8()}"
+                }
+              ],
+              "elseActions": [
+                {
+                  "$kind": "Microsoft.SendActivity",
+                  "$designer": {
+                    "id": "ThozAb"
+                  },
+                  "activity": "${SendActivity_ThozAb()}"
+                }
+              ]
+            }
           ]
-        },
-        {
-          "$kind": "Microsoft.BeginDialog",
-          "$designer": {
-            "id": "MIElov",
-            "comment": "Refreshes user token."
-          },
-          "activityProcessed": true,
-          "dialog": "AuthenticationDialog"
-        },
-        {
-          "$kind": "Microsoft.Graph.Calendar.TentativelyAcceptEvent",
-          "$designer": {
-            "id": "baSSxn",
-            "comment": "Updates the user's response to 'tentativelyAccepted' for the provided event."
-          },
-          "resultProperty": "$result",
-          "token": "=turn.token.token",
-          "eventId": "=$event.Id"
-        },
-        {
-          "$kind": "Microsoft.SetProperty",
-          "$designer": {
-            "id": "C0GtDY",
-            "comment": "Updates the event response in state so the card UI will be updated."
-          },
-          "property": "$event.Response",
-          "value": "='tentativelyAccepted'"
-        },
-        {
-          "$kind": "Microsoft.SendActivity",
-          "$designer": {
-            "id": "S2mcC8"
-          },
-          "activity": "${SendActivity_S2mcC8()}"
         }
       ]
     }

--- a/generators/generator-bot-enterprise-calendar/generators/app/templates/dialogs/RespondToEventDialog/language-generation/en-us/RespondToEventDialog.en-us.lg
+++ b/generators/generator-bot-enterprise-calendar/generators/app/templates/dialogs/RespondToEventDialog/language-generation/en-us/RespondToEventDialog.en-us.lg
@@ -33,3 +33,12 @@
 # SendActivity_uJzLWh()
 - You are the meeting organizer. I can help you cancel it instead.
 - You are the meeting owner. I'll help you cancel it instead.
+
+# SendActivity_ThozAb()
+- The event organizer didn't requested responses for this meeting.
+
+# SendActivity_hlCvkR()
+- The event organizer didn't requested responses for this meeting.
+
+# SendActivity_tptZo3()
+- The event organizer didn't requested responses for this meeting.

--- a/packages/Graph/Models/CalendarSkillEventModel.cs
+++ b/packages/Graph/Models/CalendarSkillEventModel.cs
@@ -52,6 +52,7 @@ namespace Microsoft.Bot.Components.Graph.Models
             this.Response = ev.ResponseStatus.Response;
             this.Organizer = ev.Organizer;
             this.WebLink = ev.WebLink;
+            this.ResponseRequested = ev.ResponseRequested;
         }
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "index", Required = Required.Default)]
@@ -113,5 +114,8 @@ namespace Microsoft.Bot.Components.Graph.Models
 
         [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "webLink", Required = Required.Default)]
         public string WebLink { get; set; }
+
+        [JsonProperty(NullValueHandling = NullValueHandling.Ignore, PropertyName = "responseRequested", Required = Required.Default)]
+        public bool? ResponseRequested { get; set; }
     }
 }

--- a/skills/declarative/Calendar/Calendar/dialogs/RespondToEventDialog/RespondToEventDialog.dialog
+++ b/skills/declarative/Calendar/Calendar/dialogs/RespondToEventDialog/RespondToEventDialog.dialog
@@ -271,45 +271,49 @@
               "activityProcessed": true,
               "dialog": "UpdateEventDialog",
               "options": {
-                "options.eventId": "=$event.Id"
+                "options": "=$options",
+                "event": "=$event"
               }
             }
+          ],
+          "elseActions": [
+            {
+              "$kind": "Microsoft.BeginDialog",
+              "$designer": {
+                "id": "MIElov",
+                "comment": "Refreshes user token."
+              },
+              "activityProcessed": true,
+              "dialog": "AuthenticationDialog"
+            },
+            {
+              "$kind": "Microsoft.Graph.Calendar.TentativelyAcceptEvent",
+              "$designer": {
+                "id": "baSSxn",
+                "comment": "Updates the user's response to 'tentativelyAccepted' for the provided event."
+              },
+              "resultProperty": "$result",
+              "token": "=turn.token.token",
+              "eventId": "=$event.Id"
+              "event": "=$event"
+            },
+            {
+              "$kind": "Microsoft.SetProperty",
+              "$designer": {
+                "id": "C0GtDY",
+                "comment": "Updates the event response in state so the card UI will be updated."
+              },
+              "property": "$event.Response",
+              "value": "='tentativelyAccepted'"
+            },
+            {
+              "$kind": "Microsoft.SendActivity",
+              "$designer": {
+                "id": "S2mcC8"
+              },
+              "activity": "${SendActivity_S2mcC8()}"
+            }
           ]
-        },
-        {
-          "$kind": "Microsoft.BeginDialog",
-          "$designer": {
-            "id": "MIElov",
-            "comment": "Refreshes user token."
-          },
-          "activityProcessed": true,
-          "dialog": "AuthenticationDialog"
-        },
-        {
-          "$kind": "Microsoft.Graph.Calendar.TentativelyAcceptEvent",
-          "$designer": {
-            "id": "baSSxn",
-            "comment": "Updates the user's response to 'tentativelyAccepted' for the provided event."
-          },
-          "resultProperty": "$result",
-          "token": "=turn.token.token",
-          "eventId": "=$event.Id"
-        },
-        {
-          "$kind": "Microsoft.SetProperty",
-          "$designer": {
-            "id": "C0GtDY",
-            "comment": "Updates the event response in state so the card UI will be updated."
-          },
-          "property": "$event.Response",
-          "value": "='tentativelyAccepted'"
-        },
-        {
-          "$kind": "Microsoft.SendActivity",
-          "$designer": {
-            "id": "S2mcC8"
-          },
-          "activity": "${SendActivity_S2mcC8()}"
         }
       ]
     }

--- a/skills/declarative/Calendar/Calendar/dialogs/RespondToEventDialog/RespondToEventDialog.dialog
+++ b/skills/declarative/Calendar/Calendar/dialogs/RespondToEventDialog/RespondToEventDialog.dialog
@@ -112,42 +112,63 @@
                 "id": "OAx8M6"
               }
             }
+          ],
+          "elseActions": [
+            {
+              "$kind": "Microsoft.IfCondition",
+              "$designer": {
+                "id": "Ds9OUz",
+                "comment": "If the event's organizer requested responses, they can accept it."
+              },
+              "condition": "=$event.responseRequested",
+              "actions": [
+                {
+                  "$kind": "Microsoft.BeginDialog",
+                  "$designer": {
+                    "id": "r6bf1q",
+                    "comment": "Refreshes user token."
+                  },
+                  "activityProcessed": true,
+                  "dialog": "AuthenticationDialog"
+                },
+                {
+                  "$kind": "Microsoft.Graph.Calendar.AcceptEvent",
+                  "$designer": {
+                    "id": "2F9RxQ",
+                    "comment": "Updates the user's response to 'accepted' for the provided event."
+                  },
+                  "resultProperty": "$result",
+                  "token": "=turn.token.token",
+                  "eventId": "=$event.Id"
+                },
+                {
+                  "$kind": "Microsoft.SetProperty",
+                  "$designer": {
+                    "id": "Xs8DT3",
+                    "comment": "Updates the event response in state so the card UI will be updated."
+                  },
+                  "property": "$event.Response",
+                  "value": "='accepted'"
+                },
+                {
+                  "$kind": "Microsoft.SendActivity",
+                  "$designer": {
+                    "id": "P5pp9f"
+                  },
+                  "activity": "${SendActivity_P5pp9f()}"
+                }
+              ],
+              "elseActions": [
+                {
+                  "$kind": "Microsoft.SendActivity",
+                  "$designer": {
+                    "id": "tptZo3"
+                  },
+                  "activity": "${SendActivity_tptZo3()}"
+                }
+              ]
+            }
           ]
-        },
-        {
-          "$kind": "Microsoft.BeginDialog",
-          "$designer": {
-            "id": "r6bf1q",
-            "comment": "Refreshes user token."
-          },
-          "activityProcessed": true,
-          "dialog": "AuthenticationDialog"
-        },
-        {
-          "$kind": "Microsoft.Graph.Calendar.AcceptEvent",
-          "$designer": {
-            "id": "2F9RxQ",
-            "comment": "Updates the user's response to 'accepted' for the provided event."
-          },
-          "resultProperty": "$result",
-          "token": "=turn.token.token",
-          "eventId": "=$event.Id"
-        },
-        {
-          "$kind": "Microsoft.SetProperty",
-          "$designer": {
-            "id": "Xs8DT3",
-            "comment": "Updates the event response in state so the card UI will be updated."
-          },
-          "property": "$event.Response",
-          "value": "='accepted'"
-        },
-        {
-          "$kind": "Microsoft.SendActivity",
-          "$designer": {
-            "id": "P5pp9f"
-          },
-          "activity": "${SendActivity_P5pp9f()}"
         }
       ]
     },
@@ -193,42 +214,63 @@
                 "event": "=$event"
               }
             }
+          ],
+          "elseActions": [
+            {
+              "$kind": "Microsoft.IfCondition",
+              "$designer": {
+                "id": "T2Ub07",
+                "comment": "If the event's organizer requested responses, they can decline it."
+              },
+              "condition": "=$event.responseRequested",
+              "actions": [
+                {
+                  "$kind": "Microsoft.BeginDialog",
+                  "$designer": {
+                    "id": "8wZGwZ",
+                    "comment": "Refreshes user token."
+                  },
+                  "activityProcessed": true,
+                  "dialog": "AuthenticationDialog"
+                },
+                {
+                  "$kind": "Microsoft.Graph.Calendar.DeclineEvent",
+                  "$designer": {
+                    "id": "w2IgGa",
+                    "comment": "Updates the user's response to 'declined' for the provided event."
+                  },
+                  "resultProperty": "$result",
+                  "token": "=turn.token.token",
+                  "eventId": "=$event.Id"
+                },
+                {
+                  "$kind": "Microsoft.SetProperty",
+                  "$designer": {
+                    "id": "yzE1s5",
+                    "comment": "Updates the event response in state so the card UI will be updated."
+                  },
+                  "property": "$event.Response",
+                  "value": "='declined'"
+                },
+                {
+                  "$kind": "Microsoft.SendActivity",
+                  "$designer": {
+                    "id": "3DZbbg"
+                  },
+                  "activity": "${SendActivity_3DZbbg()}"
+                }
+              ],
+              "elseActions": [
+                {
+                  "$kind": "Microsoft.SendActivity",
+                  "$designer": {
+                    "id": "hlCvkR"
+                  },
+                  "activity": "${SendActivity_hlCvkR()}"
+                }
+              ]
+            }
           ]
-        },
-        {
-          "$kind": "Microsoft.BeginDialog",
-          "$designer": {
-            "id": "8wZGwZ",
-            "comment": "Refreshes user token."
-          },
-          "activityProcessed": true,
-          "dialog": "AuthenticationDialog"
-        },
-        {
-          "$kind": "Microsoft.Graph.Calendar.DeclineEvent",
-          "$designer": {
-            "id": "w2IgGa",
-            "comment": "Updates the user's response to 'declined' for the provided event."
-          },
-          "resultProperty": "$result",
-          "token": "=turn.token.token",
-          "eventId": "=$event.Id"
-        },
-        {
-          "$kind": "Microsoft.SetProperty",
-          "$designer": {
-            "id": "yzE1s5",
-            "comment": "Updates the event response in state so the card UI will be updated."
-          },
-          "property": "$event.Response",
-          "value": "='declined'"
-        },
-        {
-          "$kind": "Microsoft.SendActivity",
-          "$designer": {
-            "id": "3DZbbg"
-          },
-          "activity": "${SendActivity_3DZbbg()}"
         }
       ]
     },
@@ -278,40 +320,58 @@
           ],
           "elseActions": [
             {
-              "$kind": "Microsoft.BeginDialog",
+              "$kind": "Microsoft.IfCondition",
               "$designer": {
-                "id": "MIElov",
-                "comment": "Refreshes user token."
+                "id": "z7VIU1",
+                "comment": "If the event's organizer requested responses, they can tentatively accept it."
               },
-              "activityProcessed": true,
-              "dialog": "AuthenticationDialog"
-            },
-            {
-              "$kind": "Microsoft.Graph.Calendar.TentativelyAcceptEvent",
-              "$designer": {
-                "id": "baSSxn",
-                "comment": "Updates the user's response to 'tentativelyAccepted' for the provided event."
-              },
-              "resultProperty": "$result",
-              "token": "=turn.token.token",
-              "eventId": "=$event.Id"
-              "event": "=$event"
-            },
-            {
-              "$kind": "Microsoft.SetProperty",
-              "$designer": {
-                "id": "C0GtDY",
-                "comment": "Updates the event response in state so the card UI will be updated."
-              },
-              "property": "$event.Response",
-              "value": "='tentativelyAccepted'"
-            },
-            {
-              "$kind": "Microsoft.SendActivity",
-              "$designer": {
-                "id": "S2mcC8"
-              },
-              "activity": "${SendActivity_S2mcC8()}"
+              "condition": "=$event.responseRequested",
+              "actions": [
+                {
+                  "$kind": "Microsoft.BeginDialog",
+                  "$designer": {
+                    "id": "MIElov",
+                    "comment": "Refreshes user token."
+                  },
+                  "activityProcessed": true,
+                  "dialog": "AuthenticationDialog"
+                },
+                {
+                  "$kind": "Microsoft.Graph.Calendar.TentativelyAcceptEvent",
+                  "$designer": {
+                    "id": "baSSxn",
+                    "comment": "Updates the user's response to 'tentativelyAccepted' for the provided event."
+                  },
+                  "resultProperty": "$result",
+                  "token": "=turn.token.token",
+                  "eventId": "=$event.Id"
+                },
+                {
+                  "$kind": "Microsoft.SetProperty",
+                  "$designer": {
+                    "id": "C0GtDY",
+                    "comment": "Updates the event response in state so the card UI will be updated."
+                  },
+                  "property": "$event.Response",
+                  "value": "='tentativelyAccepted'"
+                },
+                {
+                  "$kind": "Microsoft.SendActivity",
+                  "$designer": {
+                    "id": "S2mcC8"
+                  },
+                  "activity": "${SendActivity_S2mcC8()}"
+                }
+              ],
+              "elseActions": [
+                {
+                  "$kind": "Microsoft.SendActivity",
+                  "$designer": {
+                    "id": "ThozAb"
+                  },
+                  "activity": "${SendActivity_ThozAb()}"
+                }
+              ]
             }
           ]
         }

--- a/skills/declarative/Calendar/Calendar/dialogs/RespondToEventDialog/language-generation/en-us/RespondToEventDialog.en-us.lg
+++ b/skills/declarative/Calendar/Calendar/dialogs/RespondToEventDialog/language-generation/en-us/RespondToEventDialog.en-us.lg
@@ -33,3 +33,12 @@
 # SendActivity_uJzLWh()
 - You are the meeting organizer. I can help you cancel it instead.
 - You are the meeting owner. I'll help you cancel it instead.
+
+# SendActivity_ThozAb()
+- The event organizer didn't requested responses for this meeting.
+
+# SendActivity_hlCvkR()
+- The event organizer didn't requested responses for this meeting.
+
+# SendActivity_tptZo3()
+- The event organizer didn't requested responses for this meeting.


### PR DESCRIPTION
Fixes #1340

### Purpose

This PR fixes the error thrown when marking an event as tentative.
It was trying to send a response when the event's organizer had disabled the responses for the event. 
The same fix was applied to accept and decline event actions.
Also, it fixes the error thrown when the organizer tries to respond to its own event.

### Changes

- Updated `RespondToEventDialog.dialog`:
   - Moving the actions inside the _elseActions_ block in the **_event.isOrganizer_** condition.
   - Adding a condition to evaluate **_event.responseRequested_** property before sending the responses.
   - Passing the **_event_** property instead of only the **_event.Id_** to update the event.
- Updated `RespondToEventDialog.en-us.lg` including 3 new activities in the case the event's responses are disabled.
- Updated `CalendarSkillEventModel` class including the mapping for the **_ResponseRequested_** property.

### Tests

These images show the calendar bot working as expected in the different scenarios.
![image](https://user-images.githubusercontent.com/44245136/192561415-7b156d4e-bb56-4070-9d30-816dbd443909.png)

![image](https://user-images.githubusercontent.com/44245136/192562318-79c8dcf9-f407-48ec-af28-ad5b5720cc81.png)

![image](https://user-images.githubusercontent.com/44245136/192562168-acc03f6d-f36b-4f3d-a134-95feb370d83b.png)
