### PR TITLE
fix: Register BotWithLookup to fix ArgumentNullException for OnTurn

### DIFF
--- a/packages/Telephony/TelephonyBotComponent.cs
+++ b/packages/Telephony/TelephonyBotComponent.cs
@@ -6,6 +6,7 @@ namespace Microsoft.Bot.Components.Telephony
     using Microsoft.Bot.Builder;
     using Microsoft.Bot.Builder.Dialogs.Declarative;
     using Microsoft.Bot.Components.Telephony.Actions;
+    using Microsoft.Bot.Components.Telephony.Common;
     using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.DependencyInjection;
 
@@ -27,7 +28,7 @@ namespace Microsoft.Bot.Components.Telephony
             services.AddSingleton<DeclarativeType>(sp => new DeclarativeType<BatchTerminationCharacterInput>(BatchRegexInput.Kind));
             services.AddSingleton<DeclarativeType>(sp => new DeclarativeType<TimeoutChoiceInput>(TimeoutChoiceInput.Kind));
             services.AddSingleton<DeclarativeType>(sp => new DeclarativeType<SerialNumberInput>(SerialNumberInput.Kind));
-			services.AddSingleton<IBot, BotWithLookup>();
+            services.AddSingleton<IBot, BotWithLookup>();
         }
     }
 }

--- a/packages/Telephony/TelephonyBotComponent.cs
+++ b/packages/Telephony/TelephonyBotComponent.cs
@@ -27,6 +27,7 @@ namespace Microsoft.Bot.Components.Telephony
             services.AddSingleton<DeclarativeType>(sp => new DeclarativeType<BatchTerminationCharacterInput>(BatchRegexInput.Kind));
             services.AddSingleton<DeclarativeType>(sp => new DeclarativeType<TimeoutChoiceInput>(TimeoutChoiceInput.Kind));
             services.AddSingleton<DeclarativeType>(sp => new DeclarativeType<SerialNumberInput>(SerialNumberInput.Kind));
+			services.AddSingleton<IBot, BotWithLookup>();
         }
     }
 }


### PR DESCRIPTION
<!-- This repository only accepts pull requests related to open issues, please link the open issue in description below. -->
<!-- See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. -->
<!-- For example - Close #123: Description goes here. -->

Fixes #1380 

### Purpose
This PR registers BotWithLookup as the IBot implementation instead of the AdaptiveDialogBot that comes as default for a composer default. This is because we need to store a reference to the OnTurnAsync method of the AdaptiveDialogBot, so unless we register BotWithLookup, the constructor won't be called and OnTurn will be set to null.

### Changes


### Tests
No changes in functionality. Fixing a DI issue.

### Feature Plan

