### PR TITLE
Fix aggregation bug in SerialNumberInput and update its configurable properties

### DIFF
--- a/packages/Telephony/Actions/SerialNumberPattern.cs
+++ b/packages/Telephony/Actions/SerialNumberPattern.cs
@@ -38,7 +38,7 @@ namespace Microsoft.Bot.Components.Telephony.Actions
         {
             Groups = textGroups;
 
-            foreach (TextGroup group in Groups)
+            foreach (var group in Groups)
             {
                 PatternLength += group.LengthInChars;
             }
@@ -47,12 +47,12 @@ namespace Microsoft.Bot.Components.Telephony.Actions
         public SerialNumberPattern(string regex, bool allowBatching = false)
         {
             AllowBatching = allowBatching;
-            List<TextGroup> groups = new List<TextGroup>();
-            string[] regexGroups = regex.Split(GroupEndDelimiter, StringSplitOptions.RemoveEmptyEntries);
+            var groups = new List<TextGroup>();
+            var regexGroups = regex.Split(GroupEndDelimiter, StringSplitOptions.RemoveEmptyEntries);
 
             foreach (string regexGroup in regexGroups)
             {
-                TextGroup group = new TextGroup($"{regexGroup})");
+                var group = new TextGroup($"{regexGroup})");
                 PatternLength += group.LengthInChars;
                 groups.Add(group);
             }
@@ -116,8 +116,8 @@ namespace Microsoft.Bot.Components.Telephony.Actions
         {
             get
             {
-                string result = string.Empty;
-                foreach (TextGroup group in Groups)
+                var result = string.Empty;
+                foreach (var group in Groups)
                 {
                     result += group.RegexString;
                 }
@@ -136,9 +136,9 @@ namespace Microsoft.Bot.Components.Telephony.Actions
 
         public Token PatternAt(int patternIndex, out HashSet<char> invalidChars)
         {
-            int cumulativeIndex = 0;
-            int prevGroupCumulative = 0;
-            foreach (TextGroup group in Groups)
+            var cumulativeIndex = 0;
+            var prevGroupCumulative = 0;
+            foreach (var group in Groups)
             {
                 cumulativeIndex += group.LengthInChars;
                 if (cumulativeIndex > patternIndex)
@@ -170,7 +170,7 @@ namespace Microsoft.Bot.Components.Telephony.Actions
         public (char First, char Second) AmbiguousOptions(string inputString, int inputIndex)
         {
             (char, char) result = ('*', '*');
-            char input = inputString[inputIndex];
+            var input = inputString[inputIndex];
 
             switch (input)
             {
@@ -187,14 +187,14 @@ namespace Microsoft.Bot.Components.Telephony.Actions
 
         public bool DetectDigitFixup(string inputString, int inputIndex)
         {
-            char ch = inputString[inputIndex];
+            var ch = inputString[inputIndex];
 
             // Handle (One) = 1
-            string restOfInput = inputString.Substring(inputIndex);
-            string firstToken = restOfInput.Split(' ').FirstOrDefault();
+            var restOfInput = inputString.Substring(inputIndex);
+            var firstToken = restOfInput.Split(' ').FirstOrDefault();
             if (!string.IsNullOrWhiteSpace(firstToken))
             {
-                string token = firstToken;
+                var token = firstToken;
                 if (DigitWordReplacementsTable.ContainsKey(token))
                 {
                     return true;
@@ -207,15 +207,15 @@ namespace Microsoft.Bot.Components.Telephony.Actions
 
         public char DigitFixup(int inputIndex, ref int newOffset)
         {
-            char ch = InputString[inputIndex];
-            char replacement = char.MinValue;
+            var ch = InputString[inputIndex];
+            var replacement = char.MinValue;
 
             // Handle (One) = 1
-            string restOfInput = InputString.Substring(inputIndex);
-            string firstToken = restOfInput.Split(' ').FirstOrDefault();
+            var restOfInput = InputString.Substring(inputIndex);
+            var firstToken = restOfInput.Split(' ').FirstOrDefault();
             if (!string.IsNullOrWhiteSpace(firstToken))
             {
-                string token = firstToken;
+                var token = firstToken;
                 if (DigitWordReplacementsTable.ContainsKey(token))
                 {
                     replacement = DigitWordReplacementsTable[token];
@@ -235,8 +235,8 @@ namespace Microsoft.Bot.Components.Telephony.Actions
 
         public FixupType DetectAlphabetFixup(string inputString, int inputIndex)
         {
-            char ch = inputString[inputIndex];
-            string restOfInput = inputString.Substring(inputIndex);
+            var ch = inputString[inputIndex];
+            var restOfInput = inputString.Substring(inputIndex);
 
             // (A as in Apple)BC
             // ABC, as in Charlie Z as in Zeta.  
@@ -253,15 +253,15 @@ namespace Microsoft.Bot.Components.Telephony.Actions
 
         public char AlphabetFixup(int inputIndex, ref int offset)
         {
-            char ch = InputString[inputIndex];
-            string restOfInput = InputString.Substring(inputIndex);
+            var ch = InputString[inputIndex];
+            var restOfInput = InputString.Substring(inputIndex);
             offset = 1;
             switch (DetectAlphabetFixup(InputString, inputIndex))
             {
                 case FixupType.None:
                     return ch;
                 case FixupType.AlphaMapping:
-                    char replacement = AlphabetReplacementsTable[ch];
+                    var replacement = AlphabetReplacementsTable[ch];
                     return replacement;
                 case FixupType.AsIn:
                     AsInResult asInResult;
@@ -286,7 +286,7 @@ namespace Microsoft.Bot.Components.Telephony.Actions
         {
             InputString = inputString;
 
-            List<string> results = new List<string>();
+            var results = new List<string>();
 
             // Trivial Length check - must be at least pattern length (most likely longer).
             if (inputString.Length < PatternLength && !AllowBatching)
@@ -294,10 +294,10 @@ namespace Microsoft.Bot.Components.Telephony.Actions
                 return results.ToArray();
             }
 
-            int patternIndex = 0;
-            int inputIndex = 0;
+            var patternIndex = 0;
+            var inputIndex = 0;
 
-            List<int> ambiguousInputIndexes = new List<int>();
+            var ambiguousInputIndexes = new List<int>();
             bool isMatch = true;
             string fixedUpString = string.Empty;
 
@@ -372,8 +372,8 @@ namespace Microsoft.Bot.Components.Telephony.Actions
 
         private AmbiguousResult CheckAmbiguous(ref int inputIndex)
         {
-            AmbiguousResult match = new AmbiguousResult();
-            char input = InputString[inputIndex];
+            var match = new AmbiguousResult();
+            var input = InputString[inputIndex];
             match.Ch = input;
 
             switch (input)
@@ -390,8 +390,8 @@ namespace Microsoft.Bot.Components.Telephony.Actions
 
         private AsInResult FindAsInFixup(string input)
         {
-            AsInResult result = new AsInResult();
-            char[] delimiters = { ' ', ',', '.', '/', '-' };
+            var result = new AsInResult();
+            var delimiters = { ' ', ',', '.', '/', '-' };
             var tokens = input.Split(delimiters, StringSplitOptions.RemoveEmptyEntries);
 
             if (tokens.Length > 3 && tokens[0].Length == 1)
@@ -405,7 +405,7 @@ namespace Microsoft.Bot.Components.Telephony.Actions
                 Debug.WriteLine($"'as in' detected character {proposedChar} as the proposed character replacement.");
                 result.FixedUp = true;
                 result.Char = proposedChar;
-                int initialOffset = input.IndexOf(" in ", StringComparison.Ordinal);
+                var initialOffset = input.IndexOf(" in ", StringComparison.Ordinal);
                 result.NewOffset = initialOffset + 4 + tokens[3].Length;
             }
 
@@ -414,8 +414,8 @@ namespace Microsoft.Bot.Components.Telephony.Actions
 
         private InferResult InferMatch(int inputIndex, Token elementType, HashSet<char> invalidChars)
         {
-            InferResult result = new InferResult();
-            char currentInputChar = InputString[inputIndex];
+            var result = new InferResult();
+            var currentInputChar = InputString[inputIndex];
             result.Ch = currentInputChar;
 
             switch (elementType)
@@ -430,9 +430,9 @@ namespace Microsoft.Bot.Components.Telephony.Actions
                     }
                     else
                     {
-                        int newOffset = 1;
+                        var newOffset = 1;
                         result.IsFixedUp = true;
-                        char ch = AlphabetFixup(inputIndex, ref newOffset);
+                        var ch = AlphabetFixup(inputIndex, ref newOffset);
                         if (invalidChars.Contains(ch))
                         {
                             result.IsFixedUp = false;
@@ -446,7 +446,7 @@ namespace Microsoft.Bot.Components.Telephony.Actions
 
                     break;
                 case Token.Both:
-                    AmbiguousResult ambiguousResult = CheckAmbiguous(ref inputIndex);
+                    var ambiguousResult = CheckAmbiguous(ref inputIndex);
                     result.Ch = ambiguousResult.Ch;
                     if (ambiguousResult.IsAmbiguous)
                     {
@@ -467,7 +467,7 @@ namespace Microsoft.Bot.Components.Telephony.Actions
 
         private void TryFixupDigit(int inputIndex, char currentInputChar, Token elementType, InferResult result, HashSet<char> invalidChars)
         {
-            int newOffset = 1;
+            var newOffset = 1;
             result.IsFixedUp = DetectDigitFixup(InputString, inputIndex);
 
             if (char.IsDigit(currentInputChar) == false && !result.IsFixedUp)

--- a/packages/Telephony/Actions/SerialNumberPattern.cs
+++ b/packages/Telephony/Actions/SerialNumberPattern.cs
@@ -391,7 +391,7 @@ namespace Microsoft.Bot.Components.Telephony.Actions
         private AsInResult FindAsInFixup(string input)
         {
             var result = new AsInResult();
-            var delimiters = { ' ', ',', '.', '/', '-' };
+            var delimiters = new char[] { ' ', ',', '.', '/', '-' };
             var tokens = input.Split(delimiters, StringSplitOptions.RemoveEmptyEntries);
 
             if (tokens.Length > 3 && tokens[0].Length == 1)

--- a/packages/Telephony/Actions/SerialNumberPattern.cs
+++ b/packages/Telephony/Actions/SerialNumberPattern.cs
@@ -3,7 +3,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.Linq;
 
@@ -396,7 +395,7 @@ namespace Microsoft.Bot.Components.Telephony.Actions
 
             if (tokens.Length > 3 && tokens[0].Length == 1)
             {
-                char proposedChar = '*';
+                var proposedChar = '*';
                 if (tokens[1].ToLowerInvariant() == "as" && tokens[2].ToLowerInvariant() == "in")
                 {
                     proposedChar = tokens[3][0];

--- a/packages/Telephony/Actions/SerialNumberTextGroup.cs
+++ b/packages/Telephony/Actions/SerialNumberTextGroup.cs
@@ -3,10 +3,8 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
-using System.Runtime.CompilerServices;
 
 namespace Microsoft.Bot.Components.Telephony.Actions
 {
@@ -26,22 +24,22 @@ namespace Microsoft.Bot.Components.Telephony.Actions
             }
 
             // get character ranges
-            int start = regex.IndexOf('[');
-            int end = regex.IndexOf(']');
+            var start = regex.IndexOf('[');
+            var end = regex.IndexOf(']');
             if ((start < 0) || (end < 0) || (end < (start + 2)))
             {
                 throw new ArgumentException("Invalid regular expression");
             }
 
-            string ranges = regex.Substring(start + 1, end - start - 1);
+            var ranges = regex.Substring(start + 1, end - start - 1);
             if (ranges.IndexOf("0-9", StringComparison.OrdinalIgnoreCase) >= 0)
             {
-                this.AcceptsDigits = true;
+                AcceptsDigits = true;
             }
 
             if (ranges.IndexOf("A-Z", StringComparison.OrdinalIgnoreCase) >= 0)
             {
-                this.AcceptsAlphabet = true;
+                AcceptsAlphabet = true;
             }
 
             // check for exclusion set
@@ -49,8 +47,8 @@ namespace Microsoft.Bot.Components.Telephony.Actions
             int endExclude = regex.IndexOf(']', end + 1);
             if ((start > 0) && (endExclude > 0) && (endExclude >= (start + 2)))
             {
-                string invalid = regex.Substring(start + 1, endExclude - start - 1);
-                this.InvalidChars = new HashSet<char>(invalid.ToCharArray());
+                var invalid = regex.Substring(start + 1, endExclude - start - 1);
+                InvalidChars = new HashSet<char>(invalid.ToCharArray());
             }
 
             // get length
@@ -61,8 +59,8 @@ namespace Microsoft.Bot.Components.Telephony.Actions
                 throw new ArgumentException("Invalid regular expression");
             }
 
-            string length = regex.Substring(start + 1, end - start - 1);
-            this.LengthInChars = short.Parse(length, CultureInfo.InvariantCulture);
+            var length = regex.Substring(start + 1, end - start - 1);
+            LengthInChars = short.Parse(length, CultureInfo.InvariantCulture);
         }
 
         public bool AcceptsAlphabet { get; set; } = false;
@@ -99,8 +97,8 @@ namespace Microsoft.Bot.Components.Telephony.Actions
 
         public string GenerateGroupExampleText()
         {
-            string seed = string.Empty;
-            Random rnd = new Random();
+            var seed = string.Empty;
+            var rnd = new Random();
             if (AcceptsAlphabet)
             {
                 seed += "ABCDEFGHIJKLMNOPQRSTUVWXYZ";

--- a/packages/Telephony/Schemas/Microsoft.Telephony.SerialNumberInput.schema
+++ b/packages/Telephony/Schemas/Microsoft.Telephony.SerialNumberInput.schema
@@ -2,10 +2,10 @@
   "$schema": "https://schemas.botframework.com/schemas/component/v1.0/component.schema",
   "$role": "implements(Microsoft.IDialog)",
   "title": "(Preview) Serial Number Input",
-  "description": "Prompts the user for multiple inputs that are aggregated until a regex matches the buffer.",
+  "description": "Prompts the user for multiple inputs that are aggregated until a specified number of alphanumeric characters are reached.",
   "type": "object",
   "required": [
-    "regexPattern",
+    "regexPattern,
     "prompt",
     "*"
   ],
@@ -24,7 +24,7 @@
       "title": "Property",
       "description": "Property to assign the batch result to",
       "examples": [
-        "conversation.BatchResult"
+        "dialog.SerialNumberResult"
       ]
     },
     "prompt": {
@@ -32,7 +32,7 @@
       "title": "Initial prompt",
       "description": "Message to send to collect information.",
       "examples": [
-        "Enter your serial number."
+        "Please provide your seven character alphanumeric serial number."
       ]
     },
     "allowInterruptions": {

--- a/packages/Telephony/Schemas/Microsoft.Telephony.SerialNumberInput.schema
+++ b/packages/Telephony/Schemas/Microsoft.Telephony.SerialNumberInput.schema
@@ -5,18 +5,40 @@
   "description": "Prompts the user for multiple inputs that are aggregated until a specified number of alphanumeric characters are reached.",
   "type": "object",
   "required": [
-    "regexPattern",
+    "acceptAlphabet",
+    "acceptNumbers",
+    "batchLength",
     "prompt",
     "*"
   ],
   "additionalProperties": false,
   "properties": {
-    "regexPattern": {
-      "$ref": "schema:#/definitions/stringExpression",
-      "title": "Regex Match Pattern",
-      "description": "When matched, the batch is completed.",
+    "acceptAlphabet": {
+      "$ref": "schema:#/definitions/booleanExpression",
+      "title": "Accept Alphabet",
+      "description": "Accepts alphabet while aggregating inputs.",
+      "default": true,
       "examples": [
-        "([a-zA-Z]{2})([0-9a-zA-Z]{5})"
+        false,
+        "=dialog.acceptAlphabet"
+      ]
+    },
+    "acceptNumbers": {
+      "$ref": "schema:#/definitions/booleanExpression",
+      "title": "Accept Numbers",
+      "description": "Accepts numbers while aggregating inputs.",
+      "default": true,
+      "examples": [
+        false,
+        "=dialog.acceptNumbers"
+      ]
+    },
+    "batchLength": {
+      "$ref": "schema:#/definitions/integerExpression",
+      "title": "Batch Length",
+      "description": "The number of characters to aggregate before returning the result.",
+      "examples": [
+        "4"
       ]
     },
     "property": {

--- a/packages/Telephony/Schemas/Microsoft.Telephony.SerialNumberInput.schema
+++ b/packages/Telephony/Schemas/Microsoft.Telephony.SerialNumberInput.schema
@@ -5,7 +5,7 @@
   "description": "Prompts the user for multiple inputs that are aggregated until a specified number of alphanumeric characters are reached.",
   "type": "object",
   "required": [
-    "regexPattern,
+    "regexPattern",
     "prompt",
     "*"
   ],

--- a/packages/Telephony/Schemas/Microsoft.Telephony.SerialNumberInput.uischema
+++ b/packages/Telephony/Schemas/Microsoft.Telephony.SerialNumberInput.uischema
@@ -2,17 +2,29 @@
   "$schema": "https://schemas.botframework.com/schemas/ui/v1.0/ui.schema",
   "form": {
     "label": "Aggregate Serial Number Input | Preview",
-    "subtitle": "Aggregate input until a regex matches the buffer.",
+    "subtitle": "Aggregate input until the desired length is matched.",
     "order": [
       "prompt",
-      "regexPattern",
+      "acceptAlphabet",
+      "acceptNumbers",
+      "batchLength",
       "property",
       "allowInterruptions",
       "alwaysPrompt",
       "*"
     ],
     "properties": {
-      "regexPattern": {
+      "batchLength": {
+        "intellisenseScopes": [
+          "variable-scopes"
+        ]
+      },
+      "acceptAlphabet": {
+        "intellisenseScopes": [
+          "variable-scopes"
+        ]
+      },
+      "acceptNumbers": {
         "intellisenseScopes": [
           "variable-scopes"
         ]

--- a/tests/unit/packages/Microsoft.Bot.Components.Telephony.Tests/Integration/SerialNumberInputTests/SerialNumberInput_BaseScenario.test.dialog
+++ b/tests/unit/packages/Microsoft.Bot.Components.Telephony.Tests/Integration/SerialNumberInputTests/SerialNumberInput_BaseScenario.test.dialog
@@ -12,7 +12,9 @@
           "prompt": "Enter serial number number.",
           "continuePrompt": "Please continue with next letter or digit.",
           "confirmationPrompt": "Say or type 1 for {0} or 2 for {1}",
-          "regexPattern": "([0-9a-zA-Z]{5})",
+          "acceptAlphabet": "=coalesce(settings.acceptAlphabet, true)",
+          "acceptNumbers": "=coalesce(settings.acceptNumbers, true)",
+          "batchLength": 5,
           "allowInterruptions": "=coalesce(settings.allowInterruptions, true)",
           "interruptionMask": "^[\\d]+$",
           "alwaysPrompt": "=coalesce(settings.alwaysPrompt, false)"

--- a/tests/unit/packages/Microsoft.Bot.Components.Telephony.Tests/Integration/SerialNumberInputTests/SerialNumberInput_DisregardAggregationWithInputIfLongerThanBatchLength.test.dialog
+++ b/tests/unit/packages/Microsoft.Bot.Components.Telephony.Tests/Integration/SerialNumberInputTests/SerialNumberInput_DisregardAggregationWithInputIfLongerThanBatchLength.test.dialog
@@ -1,0 +1,49 @@
+{
+  "$schema": "../../../tests.schema",
+  "$kind": "Microsoft.Test.Script",
+  "dialog": "SerialNumberInput_BaseScenario.test",
+  "script": [
+    {
+      "$kind": "Microsoft.Test.UserConversationUpdate",
+      "membersAdded": [ "user" ]
+    },
+    {
+      "$kind": "Microsoft.Test.AssertReplyActivity",
+      "assertions": [
+        "type == 'message'",
+        "text == 'Enter serial number number.'"
+      ]
+    },
+    {
+      "$kind": "Microsoft.Test.UserSays",
+      "text": "A"
+    },
+    {
+      "$kind": "Microsoft.Test.UserSays",
+      "text": "B"
+    },
+    {
+      "$kind": "Microsoft.Test.UserSays",
+      "text": "C"
+    },
+    {
+      "$kind": "Microsoft.Test.UserSays",
+      "text": "1"
+    },
+    {
+      "$kind": "Microsoft.Test.UserSays",
+      "text": "22"
+    },
+    {
+      "$kind": "Microsoft.Test.UserSays",
+      "text": "2"
+    },
+    {
+      "$kind": "Microsoft.Test.AssertReplyActivity",
+      "assertions": [
+        "type == 'message'",
+        "text == 'ABC12'"
+      ]
+    }
+  ]
+}

--- a/tests/unit/packages/Microsoft.Bot.Components.Telephony.Tests/Integration/SerialNumberInputTests/SerialNumberInput_DisregardsInputsLongerThanBatchLength.test.dialog
+++ b/tests/unit/packages/Microsoft.Bot.Components.Telephony.Tests/Integration/SerialNumberInputTests/SerialNumberInput_DisregardsInputsLongerThanBatchLength.test.dialog
@@ -1,0 +1,49 @@
+{
+  "$schema": "../../../tests.schema",
+  "$kind": "Microsoft.Test.Script",
+  "dialog": "SerialNumberInput_BaseScenario.test",
+  "script": [
+    {
+      "$kind": "Microsoft.Test.UserConversationUpdate",
+      "membersAdded": [ "user" ]
+    },
+    {
+      "$kind": "Microsoft.Test.AssertReplyActivity",
+      "assertions": [
+        "type == 'message'",
+        "text == 'Enter serial number number.'"
+      ]
+    },
+    {
+      "$kind": "Microsoft.Test.UserSays",
+      "text": "1"
+    },
+    {
+      "$kind": "Microsoft.Test.UserSays",
+      "text": "2"
+    },
+    {
+      "$kind": "Microsoft.Test.UserSays",
+      "text": "3"
+    },
+    {
+      "$kind": "Microsoft.Test.UserSays",
+      "text": "ubiquitous"
+    },
+    {
+      "$kind": "Microsoft.Test.UserSays",
+      "text": "C"
+    },
+    {
+      "$kind": "Microsoft.Test.UserSays",
+      "text": "D"
+    },
+    {
+      "$kind": "Microsoft.Test.AssertReplyActivity",
+      "assertions": [
+        "type == 'message'",
+        "text == '123CD'"
+      ]
+    }
+  ]
+}

--- a/tests/unit/packages/Microsoft.Bot.Components.Telephony.Tests/Integration/SerialNumberInputTests/SerialNumberInput_IgnoresAlphabetWhenConfigured.test.dialog
+++ b/tests/unit/packages/Microsoft.Bot.Components.Telephony.Tests/Integration/SerialNumberInputTests/SerialNumberInput_IgnoresAlphabetWhenConfigured.test.dialog
@@ -1,0 +1,53 @@
+{
+  "$schema": "../../../tests.schema",
+  "$kind": "Microsoft.Test.Script",
+  "dialog": "SerialNumberInput_BaseScenario.test",
+  "script": [
+    {
+      "$kind": "Microsoft.Test.UserConversationUpdate",
+      "membersAdded": [ "user" ]
+    },
+    {
+      "$kind": "Microsoft.Test.AssertReplyActivity",
+      "assertions": [
+        "type == 'message'",
+        "text == 'Enter serial number number.'"
+      ]
+    },
+    {
+      "$kind": "Microsoft.Test.UserSays",
+      "text": "1"
+    },
+    {
+      "$kind": "Microsoft.Test.UserSays",
+      "text": "2"
+    },
+    {
+      "$kind": "Microsoft.Test.UserSays",
+      "text": "3"
+    },
+    {
+      "$kind": "Microsoft.Test.UserSays",
+      "text": "C"
+    },
+    {
+      "$kind": "Microsoft.Test.UserSays",
+      "text": "D"
+    },
+    {
+      "$kind": "Microsoft.Test.UserSays",
+      "text": "4"
+    },
+    {
+      "$kind": "Microsoft.Test.UserSays",
+      "text": "5"
+    },
+    {
+      "$kind": "Microsoft.Test.AssertReplyActivity",
+      "assertions": [
+        "type == 'message'",
+        "text == '12345'"
+      ]
+    }
+  ]
+}

--- a/tests/unit/packages/Microsoft.Bot.Components.Telephony.Tests/Integration/SerialNumberInputTests/SerialNumberInput_IgnoresNumbersWhenConfigured.test.dialog
+++ b/tests/unit/packages/Microsoft.Bot.Components.Telephony.Tests/Integration/SerialNumberInputTests/SerialNumberInput_IgnoresNumbersWhenConfigured.test.dialog
@@ -1,0 +1,53 @@
+{
+  "$schema": "../../../tests.schema",
+  "$kind": "Microsoft.Test.Script",
+  "dialog": "SerialNumberInput_BaseScenario.test",
+  "script": [
+    {
+      "$kind": "Microsoft.Test.UserConversationUpdate",
+      "membersAdded": [ "user" ]
+    },
+    {
+      "$kind": "Microsoft.Test.AssertReplyActivity",
+      "assertions": [
+        "type == 'message'",
+        "text == 'Enter serial number number.'"
+      ]
+    },
+    {
+      "$kind": "Microsoft.Test.UserSays",
+      "text": "1"
+    },
+    {
+      "$kind": "Microsoft.Test.UserSays",
+      "text": "2"
+    },
+    {
+      "$kind": "Microsoft.Test.UserSays",
+      "text": "A"
+    },
+    {
+      "$kind": "Microsoft.Test.UserSays",
+      "text": "B"
+    },
+    {
+      "$kind": "Microsoft.Test.UserSays",
+      "text": "C"
+    },
+    {
+      "$kind": "Microsoft.Test.UserSays",
+      "text": "D"
+    },
+    {
+      "$kind": "Microsoft.Test.UserSays",
+      "text": "E"
+    },
+    {
+      "$kind": "Microsoft.Test.AssertReplyActivity",
+      "assertions": [
+        "type == 'message'",
+        "text == 'ABCDE'"
+      ]
+    }
+  ]
+}

--- a/tests/unit/packages/Microsoft.Bot.Components.Telephony.Tests/SerialNumberInputTests.cs
+++ b/tests/unit/packages/Microsoft.Bot.Components.Telephony.Tests/SerialNumberInputTests.cs
@@ -22,7 +22,6 @@ namespace Microsoft.Bot.Components.Telephony.Tests
             await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer, adapterChannel: Channels.Telephony);
         }
 
-
         [Fact]
         public async Task SerialNumberInput_WithInterruption()
         {
@@ -33,5 +32,39 @@ namespace Microsoft.Bot.Components.Telephony.Tests
                    .AddInMemoryCollection(new Dictionary<string, string>() { { "alwaysPrompt", "true" } })
                    .Build());
         }
+
+        [Fact]
+        public async Task SerialNumberInput_DisregardsInputsLongerThanBatchLength()
+        {
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer, adapterChannel: Channels.Telephony);
+        }
+
+        [Fact]
+        public async Task SerialNumberInput_DisregardAggregationWithInputIfLongerThanBatchLength()
+        {
+            await TestUtils.RunTestScript(_resourceExplorerFixture.ResourceExplorer, adapterChannel: Channels.Telephony);
+        }
+
+        [Fact]
+        public async Task SerialNumberInput_IgnoresAlphabetWhenConfigured()
+        {
+            await TestUtils.RunTestScript(
+               _resourceExplorerFixture.ResourceExplorer,
+               adapterChannel: Channels.Telephony,
+               configuration: new ConfigurationBuilder()
+                   .AddInMemoryCollection(new Dictionary<string, string>() { { "acceptAlphabet", "false" } })
+                   .Build());
+        }
+
+        [Fact]
+        public async Task SerialNumberInput_IgnoresNumbersWhenConfigured()
+        {
+            await TestUtils.RunTestScript(
+               _resourceExplorerFixture.ResourceExplorer,
+               adapterChannel: Channels.Telephony,
+               configuration: new ConfigurationBuilder()
+                   .AddInMemoryCollection(new Dictionary<string, string>() { { "acceptNumbers", "false" } })
+                   .Build());
+        }
     }
- }
+}

--- a/tests/unit/packages/Microsoft.Bot.Components.Telephony.Tests/SerialNumberPatternTests.cs
+++ b/tests/unit/packages/Microsoft.Bot.Components.Telephony.Tests/SerialNumberPatternTests.cs
@@ -36,7 +36,8 @@ namespace Microsoft.Bot.Components.Telephony.Tests
 
         public static IEnumerable<object[]> PatternLengthData => new List<object[]>
         {
-            new object[] { "([0-9]{6})", 6 }
+            new object[] { "([0-9]{6})", 6 },
+            new object[] { "([0-9]{3})([0-9]{6})", 9 }
         };
     }
 }

--- a/tests/unit/packages/Microsoft.Bot.Components.Telephony.Tests/SerialNumberPatternTests.cs
+++ b/tests/unit/packages/Microsoft.Bot.Components.Telephony.Tests/SerialNumberPatternTests.cs
@@ -8,23 +8,35 @@ using Xunit;
 
 namespace Microsoft.Bot.Components.Telephony.Tests
 {
-    public class TextGroupTests
+    public class SerialNumberPatternTests
     {
         [Theory]
         [MemberData(nameof(ConstructorThrowsData))]
         public void TextGroup_Ctor_Throws_With_Bad_Groups(string badRegexPattern)
         {
-            Assert.Throws<ArgumentException>(() => new TextGroup(badRegexPattern));
+            Assert.Throws<ArgumentException>(() => new SerialNumberPattern(badRegexPattern));
         }
 
         public static IEnumerable<object[]> ConstructorThrowsData => new List<object[]>
         {
-            new object[] { string.Empty },
             new object[] { "(][){}" },
             new object[] { "([]{})" },
             new object[] { "(}{)[2]" },
             new object[] { "(}{)[2a]" },
             new object[] { "([2]{})" },
+        };
+
+
+        [Theory]
+        [MemberData(nameof(PatternLengthData))]
+        public void PatternLength_Includes_All_Lengths(string regexPattern, int patternLength)
+        {
+            Assert.Equal(patternLength, new SerialNumberPattern(regexPattern).PatternLength);
+        }
+
+        public static IEnumerable<object[]> PatternLengthData => new List<object[]>
+        {
+            new object[] { "([0-9]{6})", 6 }
         };
     }
 }

--- a/tests/unit/packages/Microsoft.Bot.Components.Telephony.Tests/TextGroupTests.cs
+++ b/tests/unit/packages/Microsoft.Bot.Components.Telephony.Tests/TextGroupTests.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Bot.Components.Telephony.Actions;
+using Microsoft.Bot.Connector;
+using Microsoft.Bot.Schema;
+using Microsoft.Extensions.Configuration;
+using Xunit;
+
+namespace Microsoft.Bot.Components.Telephony.Tests
+{
+    public class TextGroupTests
+    {
+        [Theory]
+        [MemberData(nameof(ConstructorThrowsData))]
+        public void TextGroup_Ctor_Throws_With_Bad_Groups(string badRegexPattern)
+        {
+            Assert.Throws<ArgumentException>(() => new TextGroup(badRegexPattern));
+        }
+
+        public static IEnumerable<object[]> ConstructorThrowsData => new List<object[]>
+        {
+            new object[] { string.Empty },
+            new object[] { "(][){}" },
+            new object[] { "([]{})" },
+            new object[] { "(}{)[2]" },
+            new object[] { "(}{)[2a]" },
+            new object[] { "([2]{})" },
+        };
+    }
+}


### PR DESCRIPTION
Fixes: #1378
Fixes: #1377 by removing the ability for consumers to provide a regex pattern.

## _Important_
The changes in this PR are semantically breaking (i.e., necessitating a major version bump) and the `SerialNumberInput` class may undergo additional changes in future PRs (if not in future iterations of this PR).

While the `SerialNumberInput` class is marked as "preview" when viewing from Composer, it is otherwise not marked as such for code-first consumers of `Microsoft.Bot.Components.Telephony`. Therefore, I consider the PR's changes to be semantically breaking but I'm open to persuasion otherwise.

### Purpose/Changes
- Fixes the aggregation bug of aggregating invalid inputs and entering a permanent failstate
- Removes the ability to provide a regex pattern and simplifies the authoring experience to provide two booleans (`acceptAlphabet` and `acceptNumbers`) and a number (`batchLength`)
- Minor cleanup in `Microsoft.Bot.Components.Telephony`

### Tests
- Added first unit tests for `SerialNumberPattern` and `TextGroup`
- Increased `SerialNumberInput` test coverage by 200%, bringing the grand total to... 6 tests...

