### PR TITLE
fix: Update the current turn count instead of MaxTurnCount in TimeoutChoiceInput

### DIFF
--- a/packages/Telephony/Actions/TimeoutChoiceInput.cs
+++ b/packages/Telephony/Actions/TimeoutChoiceInput.cs
@@ -71,7 +71,7 @@ namespace Microsoft.Bot.Components.Telephony.Actions
 
                 //We need to set interrupted here or it will discard the continueconversation event...
                 dc.State.SetValue(TurnPath.Interrupted, true);
-                return await base.ContinueDialogAsync(dc, cancellationToken).ConfigureAwait(false);
+                return await ContinueTimeoutChoiceInputDialogAsync(dc, cancellationToken).ConfigureAwait(false);
             }
             else
             {
@@ -107,6 +107,11 @@ namespace Microsoft.Bot.Components.Telephony.Actions
                 //End dirty hack
             }
 
+            return await ContinueTimeoutChoiceInputDialogAsync(dc, cancellationToken).ConfigureAwait(false);
+        }
+
+        protected virtual async Task<DialogTurnResult> ContinueTimeoutChoiceInputDialogAsync(DialogContext dc, CancellationToken cancellationToken = default(CancellationToken))
+        {
             return await base.ContinueDialogAsync(dc, cancellationToken).ConfigureAwait(false);
         }
 

--- a/packages/Telephony/Actions/TimeoutChoiceInput.cs
+++ b/packages/Telephony/Actions/TimeoutChoiceInput.cs
@@ -64,7 +64,10 @@ namespace Microsoft.Bot.Components.Telephony.Actions
             if (!interrupted && activity.Type != ActivityTypes.Message && activity.Name == ActivityEventNames.ContinueConversation)
             {
                 //Set max turns so that we evaluate the default when we visit the inputdialog.
-                MaxTurnCount = 1;
+                if (MaxTurnCount != null)
+                {
+                    dc.State.SetValue(TURN_COUNT_PROPERTY, this.MaxTurnCount.GetValue(dc.State) + 1);
+                }
 
                 //We need to set interrupted here or it will discard the continueconversation event...
                 dc.State.SetValue(TurnPath.Interrupted, true);

--- a/packages/Telephony/Actions/TimeoutChoiceInput.cs
+++ b/packages/Telephony/Actions/TimeoutChoiceInput.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
 using System.Runtime.CompilerServices;
 using System.Security.Claims;
 using System.Threading;
@@ -110,7 +113,7 @@ namespace Microsoft.Bot.Components.Telephony.Actions
             return await ContinueTimeoutChoiceInputDialogAsync(dc, cancellationToken).ConfigureAwait(false);
         }
 
-        protected virtual async Task<DialogTurnResult> ContinueTimeoutChoiceInputDialogAsync(DialogContext dc, CancellationToken cancellationToken = default(CancellationToken))
+        protected virtual async Task<DialogTurnResult> ContinueTimeoutChoiceInputDialogAsync(DialogContext dc, CancellationToken cancellationToken = default)
         {
             return await base.ContinueDialogAsync(dc, cancellationToken).ConfigureAwait(false);
         }

--- a/tests/unit/packages/Microsoft.Bot.Components.Telephony.Tests/TimeoutChoiceInputTests.cs
+++ b/tests/unit/packages/Microsoft.Bot.Components.Telephony.Tests/TimeoutChoiceInputTests.cs
@@ -1,0 +1,67 @@
+﻿using Microsoft.Bot.Builder.Dialogs;
+using Microsoft.Bot.Builder;
+using Microsoft.Bot.Components.Telephony.Actions;
+using Microsoft.Bot.Schema;
+using Moq;
+using System.Threading.Tasks;
+using Xunit;
+using Microsoft.Bot.Builder.Dialogs.Memory;
+using Microsoft.Bot.Builder.Dialogs.Memory.Scopes;
+using System.Collections.Generic;
+using System.Threading;
+
+namespace Microsoft.Bot.Components.Telephony.Tests
+{
+    public class TimeoutChoiceInputTests
+    {
+        [Fact]
+        public async Task TimeoutChoiceInput_TurnCountIsCorrectlyUpdated()
+        {
+            // Setup
+            Mock<ITurnContext> mockTurnContext = new Mock<ITurnContext>();
+            mockTurnContext
+                .SetupGet(ctx => ctx.Activity)
+                .Returns(new Activity() { Type = ActivityTypes.Event, Name = ActivityEventNames.ContinueConversation });
+
+            DialogStateManagerConfiguration configuration = new DialogStateManagerConfiguration()
+            {
+                MemoryScopes = new System.Collections.Generic.List<MemoryScope>(){ new ThisMemoryScope(), new TurnMemoryScope() }
+            };
+
+            var turnState = new TurnContextStateCollection();
+            turnState.Add(configuration);
+
+            mockTurnContext
+                .SetupGet(ctx => ctx.TurnState)
+                .Returns(turnState);
+
+            DialogContext dc = new DialogContext(new DialogSet(), mockTurnContext.Object, new DialogState());
+            var stateDictionary = new Dictionary<string, object>();
+            stateDictionary["turnCount"] = 0;
+            stateDictionary["interrupted"] = false;
+            dc.Stack.Add(new DialogInstance() { Id = "TimeoutTest", State = stateDictionary });
+
+            dc.State.SetValue("this.turnCount", 0);
+
+            TimeoutChoiceInputTestHelper timeoutChoiceInput = new TimeoutChoiceInputTestHelper();
+            timeoutChoiceInput.MaxTurnCount = new AdaptiveExpressions.Properties.IntExpression(3);
+
+            // Act
+            await timeoutChoiceInput.ContinueDialogAsync(dc);
+
+            // Assert
+            Assert.Equal(4, dc.State.GetValue<int>("this.turnCount", () => 0));
+            Assert.True(dc.State.GetValue<bool>(TurnPath.Interrupted, () => false));
+        }
+
+        private class TimeoutChoiceInputTestHelper : TimeoutChoiceInput
+        {
+            public TimeoutChoiceInputTestHelper(): base() { }
+
+            protected override Task<DialogTurnResult> ContinueTimeoutChoiceInputDialogAsync(DialogContext dc, CancellationToken cancellationToken = default(CancellationToken))
+            {
+                return Task.FromResult(new DialogTurnResult(DialogTurnStatus.Complete));
+            }
+        }
+    }
+}

--- a/tests/unit/packages/Microsoft.Bot.Components.Telephony.Tests/TimeoutChoiceInputTests.cs
+++ b/tests/unit/packages/Microsoft.Bot.Components.Telephony.Tests/TimeoutChoiceInputTests.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.Bot.Builder.Dialogs;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.Bot.Builder.Dialogs;
 using Microsoft.Bot.Builder;
 using Microsoft.Bot.Components.Telephony.Actions;
 using Microsoft.Bot.Schema;
@@ -18,14 +21,14 @@ namespace Microsoft.Bot.Components.Telephony.Tests
         public async Task TimeoutChoiceInput_TurnCountIsCorrectlyUpdated()
         {
             // Setup
-            Mock<ITurnContext> mockTurnContext = new Mock<ITurnContext>();
+            var mockTurnContext = new Mock<ITurnContext>();
             mockTurnContext
                 .SetupGet(ctx => ctx.Activity)
-                .Returns(new Activity() { Type = ActivityTypes.Event, Name = ActivityEventNames.ContinueConversation });
+                .Returns(new Activity { Type = ActivityTypes.Event, Name = ActivityEventNames.ContinueConversation });
 
-            DialogStateManagerConfiguration configuration = new DialogStateManagerConfiguration()
+            var configuration = new DialogStateManagerConfiguration
             {
-                MemoryScopes = new System.Collections.Generic.List<MemoryScope>(){ new ThisMemoryScope(), new TurnMemoryScope() }
+                MemoryScopes = new List<MemoryScope>{ new ThisMemoryScope(), new TurnMemoryScope() }
             };
 
             var turnState = new TurnContextStateCollection();
@@ -35,15 +38,15 @@ namespace Microsoft.Bot.Components.Telephony.Tests
                 .SetupGet(ctx => ctx.TurnState)
                 .Returns(turnState);
 
-            DialogContext dc = new DialogContext(new DialogSet(), mockTurnContext.Object, new DialogState());
+            var dc = new DialogContext(new DialogSet(), mockTurnContext.Object, new DialogState());
             var stateDictionary = new Dictionary<string, object>();
             stateDictionary["turnCount"] = 0;
             stateDictionary["interrupted"] = false;
-            dc.Stack.Add(new DialogInstance() { Id = "TimeoutTest", State = stateDictionary });
+            dc.Stack.Add(new DialogInstance { Id = "TimeoutTest", State = stateDictionary });
 
             dc.State.SetValue("this.turnCount", 0);
 
-            TimeoutChoiceInputTestHelper timeoutChoiceInput = new TimeoutChoiceInputTestHelper();
+            var timeoutChoiceInput = new TimeoutChoiceInputTestHelper();
             timeoutChoiceInput.MaxTurnCount = new AdaptiveExpressions.Properties.IntExpression(3);
 
             // Act
@@ -58,7 +61,7 @@ namespace Microsoft.Bot.Components.Telephony.Tests
         {
             public TimeoutChoiceInputTestHelper(): base() { }
 
-            protected override Task<DialogTurnResult> ContinueTimeoutChoiceInputDialogAsync(DialogContext dc, CancellationToken cancellationToken = default(CancellationToken))
+            protected override Task<DialogTurnResult> ContinueTimeoutChoiceInputDialogAsync(DialogContext dc, CancellationToken cancellationToken = default)
             {
                 return Task.FromResult(new DialogTurnResult(DialogTurnStatus.Complete));
             }


### PR DESCRIPTION
<!-- This repository only accepts pull requests related to open issues, please link the open issue in description below. -->
<!-- See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. -->
<!-- For example - Close #123: Description goes here. -->

Fixes #1393: Default value bug in TimeoutChoiceInput

### Purpose

We are currently updating the MaxTurnCount instead of this.turnCount for the timer workflow which is affecting other conversations due to MaxTurnCount being a global value.

### Changes

Update this.turnCount instead of MaxTurnCount so the changes are local to the action

### Tests

Added tests to check for the turnCount being updated

### Feature Plan


