### PR TITLE
chore: Update esrp tasks to v2 for Components pipelines

### DIFF
--- a/build/yaml/templates/nuget-signing-steps.yml
+++ b/build/yaml/templates/nuget-signing-steps.yml
@@ -21,7 +21,7 @@ steps:
     filePath: ./build/ExtractCompressNuGet.ps1
     arguments: '$(Build.ArtifactStagingDirectory)\signing  -Extract'
 
-- task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
+- task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@2
   displayName: 'ESRP Signing - strong name (CP-233863-SN)'
   condition: eq(variables.ComponentType, 'codeExtension')
   inputs:
@@ -49,7 +49,7 @@ steps:
     SessionTimeout: 20
 
 
-- task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
+- task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@2
   displayName: 'ESRP Signing - authenticode (CP-230012)'
   condition: eq(variables.ComponentType, 'codeExtension')
   inputs:
@@ -105,7 +105,7 @@ steps:
     arguments: '$(Build.ArtifactStagingDirectory)\signing -Compress'
 
 
-- task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@1
+- task: SFP.build-tasks.custom-build-task-1.EsrpCodeSigning@2
   displayName: 'ESRP Signing - *.nupkg,*.snupkg (CP-401405)'
   inputs:
     ConnectedServiceName: 'ESRP Code Signing Connection 2020a'


### PR DESCRIPTION
### Purpose

Current ESRP signing tasks in Components pipelines are the old version 1. This is not compatible with later Windows versions.

close [https://github.com/microsoft/botframework-components/issues/1402](https://github.com/microsoft/botframework-components/issues/1402)
