### PR TITLE
fix: Component Governance security vulnerability for System.Drawing.Common 4.7.0

### DIFF
--- a/packages/AdaptiveCards/Microsoft.Bot.Components.AdaptiveCards.csproj
+++ b/packages/AdaptiveCards/Microsoft.Bot.Components.AdaptiveCards.csproj
@@ -20,7 +20,7 @@
 
   <ItemGroup>
     <PackageReference Include="AdaptiveCards.Templating" Version="1.3.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime" Version="4.17.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime" Version="4.18.1" />
 	<PackageReference Include="NewtonSoft.Json" Version="13.0.1" />
   </ItemGroup>
 

--- a/packages/Graph/Microsoft.Bot.Components.Graph.csproj
+++ b/packages/Graph/Microsoft.Bot.Components.Graph.csproj
@@ -20,7 +20,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Graph.Beta" Version="0.39.0-preview" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime" Version="4.17.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime" Version="4.18.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 

--- a/packages/HelpAndCancel/Microsoft.Bot.Components.HelpAndCancel.nuspec
+++ b/packages/HelpAndCancel/Microsoft.Bot.Components.HelpAndCancel.nuspec
@@ -13,7 +13,7 @@
         <description>Contains Adaptive Dialog assets to support Help and Cancel conversational flows in a bot built on the Azure Bot Framework.</description>
         <tags>msbot-component msbot-content conversationalcore helpintent cancelintent preview</tags>
         <dependencies>
-            <dependency id="Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime" version="4.17.1" />
+            <dependency id="Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime" version="4.18.1" />
         </dependencies>
     </metadata>
 

--- a/packages/Recognizers/CustomQuestionAnswering/Microsoft.Bot.Components.Recognizers.CustomQuestionAnsweringRecognizer.csproj
+++ b/packages/Recognizers/CustomQuestionAnswering/Microsoft.Bot.Components.Recognizers.CustomQuestionAnsweringRecognizer.csproj
@@ -25,6 +25,6 @@
 		<Content Include="**/*.uischema" />
 		<None Include="exported/**/*.*" Pack="true" PackagePath="exported" />
 		<None Include="README.md" Condition="Exists('README.md')" Pack="true" PackagePath="" />
-		<PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime" Version="4.17.1" />
+		<PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime" Version="4.18.1" />
 	</ItemGroup>
 </Project>

--- a/packages/Teams/dotnet/Microsoft.Bot.Components.Teams.csproj
+++ b/packages/Teams/dotnet/Microsoft.Bot.Components.Teams.csproj
@@ -35,7 +35,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive" Version="4.17.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive" Version="4.18.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 

--- a/packages/Telephony/Microsoft.Bot.Components.Telephony.csproj
+++ b/packages/Telephony/Microsoft.Bot.Components.Telephony.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime" Version="4.17.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime" Version="4.18.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 

--- a/packages/Welcome/Microsoft.Bot.Components.Welcome.nuspec
+++ b/packages/Welcome/Microsoft.Bot.Components.Welcome.nuspec
@@ -13,7 +13,7 @@
         <description>An Adaptive Dialog for greeting new and returning users on first interaction with your bot built on the Azure Bot Framework.</description>
         <tags>msbot-component msbot-content conversationalcore welcome preview</tags>
         <dependencies>
-            <dependency id="Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime" version="4.17.1" />
+            <dependency id="Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime" version="4.18.1" />
         </dependencies>
     </metadata>
 

--- a/skills/csharp/calendarskill/CalendarSkill.csproj
+++ b/skills/csharp/calendarskill/CalendarSkill.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Microsoft.Azure.CognitiveServices.Language" Version="1.0.1-preview" />
     <PackageReference Include="Microsoft.Azure.CognitiveServices.Search.NewsSearch" Version="2.0.0" />
     <PackageReference Include="Microsoft.Azure.Search" Version="10.0.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.ApplicationInsights.Core" Version="4.17.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.ApplicationInsights.Core" Version="4.18.1" />
     <PackageReference Include="Microsoft.Bot.Solutions" Version="1.0.1" />
     <PackageReference Include="Microsoft.Graph" Version="3.7.0" />
   </ItemGroup>

--- a/skills/declarative/Calendar/Calendar/Calendar.csproj
+++ b/skills/declarative/Calendar/Calendar/Calendar.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.8" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime" Version="4.17.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime" Version="4.18.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\packages\Graph\Microsoft.Bot.Components.Graph.csproj" />

--- a/skills/declarative/People/People/People.csproj
+++ b/skills/declarative/People/People/People.csproj
@@ -12,9 +12,9 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.8" />
-    <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.17.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.AI.QnA" Version="4.17.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime" Version="4.17.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="4.18.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.AI.QnA" Version="4.18.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime" Version="4.18.1" />
     <PackageReference Include="Microsoft.Bot.Components.Graph" Version="1.1.2" />
   </ItemGroup>
 </Project>

--- a/tests/functional/Libraries/TranscriptConverter/TranscriptConverter.csproj
+++ b/tests/functional/Libraries/TranscriptConverter/TranscriptConverter.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Bot.Schema" Version="4.17.1" />
+    <PackageReference Include="Microsoft.Bot.Schema" Version="4.18.1" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20574.7" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>

--- a/tests/functional/Libraries/TranscriptTestRunner/TranscriptTestRunner.csproj
+++ b/tests/functional/Libraries/TranscriptTestRunner/TranscriptTestRunner.csproj
@@ -11,8 +11,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AdaptiveExpressions" Version="4.17.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.17.1" />
+    <PackageReference Include="AdaptiveExpressions" Version="4.18.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.18.1" />
     <PackageReference Include="Microsoft.Bot.Connector.DirectLine" Version="3.0.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="3.1.9" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.9" />

--- a/tests/unit/packages/Microsoft.Bot.Components.Telephony.Tests/Microsoft.Bot.Components.Telephony.Tests.csproj
+++ b/tests/unit/packages/Microsoft.Bot.Components.Telephony.Tests/Microsoft.Bot.Components.Telephony.Tests.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive.Testing" Version="4.17.1-preview" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Declarative" Version="4.17.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive.Testing" Version="4.18.1-preview" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Declarative" Version="4.18.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.22" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.22" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />

--- a/tests/unit/packages/Teams/dotnet/Microsoft.Bot.Components.Teams.Tests.csproj
+++ b/tests/unit/packages/Teams/dotnet/Microsoft.Bot.Components.Teams.Tests.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive.Testing" Version="4.17.1-preview" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Declarative" Version="4.17.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive.Testing" Version="4.18.1-preview" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Declarative" Version="4.18.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.22" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.22" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />

--- a/tests/unit/skills/calendar/Microsoft.Bot.Dialogs.Tests.Skills.Calendar.csproj
+++ b/tests/unit/skills/calendar/Microsoft.Bot.Dialogs.Tests.Skills.Calendar.csproj
@@ -7,10 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.17.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive" Version="4.17.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive.Testing" Version="4.17.1-preview" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Declarative" Version="4.17.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.18.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive" Version="4.18.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive.Testing" Version="4.18.1-preview" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Declarative" Version="4.18.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.3" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.3" />

--- a/tests/unit/skills/common/Microsoft.Bot.Dialogs.Tests.Common.csproj
+++ b/tests/unit/skills/common/Microsoft.Bot.Dialogs.Tests.Common.csproj
@@ -6,10 +6,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.17.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive" Version="4.17.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive.Testing" Version="4.17.1-preview" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Declarative" Version="4.17.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.18.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive" Version="4.18.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive.Testing" Version="4.18.1-preview" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Declarative" Version="4.18.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.3" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.3" />

--- a/tests/unit/skills/people/Microsoft.Bot.Dialogs.Tests.Skills.People.csproj
+++ b/tests/unit/skills/people/Microsoft.Bot.Dialogs.Tests.Skills.People.csproj
@@ -6,10 +6,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.17.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive" Version="4.17.1" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive.Testing" Version="4.17.1-preview" />
-    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Declarative" Version="4.17.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.18.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive" Version="4.18.1" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive.Testing" Version="4.18.1-preview" />
+    <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Declarative" Version="4.18.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.3" />
     <PackageReference Include="MSTest.TestFramework" Version="2.2.3" />


### PR DESCRIPTION
#minor

Vulnerability alert title: Governed repositories microsoft/botframework-components main CVE-2021-24112
Web page: [FuseLabs](https://fuselabs.visualstudio.com/)/[SDK_v4](https://fuselabs.visualstudio.com/SDK_v4)/[Compliance](https://fuselabs.visualstudio.com/SDK_v4/_componentGovernance/177327)/[Component Governance](https://fuselabs.visualstudio.com/SDK_v4/_componentGovernance/177327)

### Description
Critical severity alert: Remote code execution vulnerability exists when parsing certain types of graphics files. This vulnerability only exists on systems running on MacOS or Linux.
Upgrade System.Drawing.Common from 4.7.0 to 4.7.2

Dependency tree: 
- Microsoft.Bot.Components.Graph 1.1.2
  - Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime 4.17.1 (a botbuilder-dotnet package)
    - Microsoft.Bot.Builder.Integration.ApplicationInsights.Core (a botbuilder-dotnet package)
      - System.Drawing.Common 4.7.0

The botbuilder-dotnet packages v 4.18.1 have the System.Drawing.Common dependency upgraded to 4.7.2.

### The fix:

Upgrade the botbuilder-dotnet package dependencies from 4.17.1 to 4.18.1.
