### PR TITLE
fix: Component Governance security vulnerability for node-fetch 2.6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "adal-node": "0.2.4",
     "async": "2.6.4",
     "axios": "1.2.1",
+    "cross-fetch": "3.1.5",
+    "node-fetch": "2.6.7",
     "@azure/identity": "3.1.2",
     "@azure/ms-rest-js": "2.6.4",
     "@xmldom/xmldom": "0.8.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2668,12 +2668,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cross-fetch@npm:^3.0.5":
-  version: 3.1.4
-  resolution: "cross-fetch@npm:3.1.4"
+"cross-fetch@npm:3.1.5":
+  version: 3.1.5
+  resolution: "cross-fetch@npm:3.1.5"
   dependencies:
-    node-fetch: 2.6.1
-  checksum: 47b33bc773d53f19805eeac914e7d76e022a1aee3b7a55277fae3d3d1a0cff354b92c4ec6c5d99aeef3e5757c2719e94c37879ba846c33de892e68a655758b61
+    node-fetch: 2.6.7
+  checksum: a9a3f2320b83c1af2eeafad9271fbe2ee9f2c07e48c6cbdf181ed58efbcc5bdb777864141b8dfa26675ac0e5ff92903bb13a928f6e25354bbdd5f09d5f667620
   languageName: node
   linkType: hard
 
@@ -7409,14 +7409,7 @@ fsevents@^1.2.3:
   languageName: node
   linkType: hard
 
-"node-fetch@npm:2.6.1, node-fetch@npm:^2.6.0":
-  version: 2.6.1
-  resolution: "node-fetch@npm:2.6.1"
-  checksum: cbb171635e538162b977eac5dfe7a1e07a9a02e991924377a6435502291e2f823d306b95aabc455caebf4a118ccf836868462bc70ccc3095af02bb9da61fda37
-  languageName: node
-  linkType: hard
-
-"node-fetch@npm:^2.6.7":
+"node-fetch@npm:2.6.7":
   version: 2.6.7
   resolution: "node-fetch@npm:2.6.7"
   dependencies:


### PR DESCRIPTION
Fixes #minor

Vulnerability alert title: Governed repositories microsoft/botframework-components main CVE-2022-0235
Web page: [FuseLabs](https://fuselabs.visualstudio.com/)/[SDK_v4](https://fuselabs.visualstudio.com/SDK_v4)/[Compliance](https://fuselabs.visualstudio.com/SDK_v4/_componentGovernance/177327)/[Component Governance](https://fuselabs.visualstudio.com/SDK_v4/_componentGovernance/177327)

### Description
High severity alert: node-fetch is vulnerable to Exposure of Sensitive Information to an Unauthorized Actor
Upgrade node-fetch from 2.6.1 to 2.6.7

### Prior fixes
The current PR includes the fixes in these PRs. If you merge this one, you don't need to merge these.
#### From PR #1436 for @xmldom/xmldom
Upgrade to "adal-node": "0.2.4" 
Upgrade to "@xmldom/xmldom": "0.8.6"
#### From PR #1438 for follow-redirects and axios
Upgrade to "axios": "1.2.1"
Upgrade to "@azure/identity": "3.1.2"
Upgrade to "@azure/ms-rest-js": "2.6.4"
#### From PR #1439 for async
Upgrade to async 2.6.4

### The fix
Using resolutions...
Upgrade to "cross-fetch": "3.1.5" (node-fetch is a dependency of cross-fetch)
Upgrade to "node-fetch": "2.6.7"
