### PR TITLE
fix: Two broken links in readme

### DIFF
--- a/generators/generator-bot-adaptive/README.md
+++ b/generators/generator-bot-adaptive/README.md
@@ -23,7 +23,7 @@ If you need to create your own templates, you can use this generator as a base, 
 
 ### From the command-line
 
-This template can also be installed from the [command line](https://github.com/microsoft/botframework-components/blob/main/generators/command-line-instructions).
+This template can also be installed from the [command line](https://github.com/microsoft/botframework-components/blob/main/generators/command-line-instructions.md).
 
 ## License
 

--- a/generators/generator-bot-adaptive/README.md
+++ b/generators/generator-bot-adaptive/README.md
@@ -19,7 +19,7 @@ This template contains scaffold code for publishing your bot to either Azure Fun
 
 ### Creating your own templates
 
-If you need to create your own templates, you can use this generator as a base, and extend it to meet your needs with [Yeoman generator composition](https://yeoman.io/authoring/composability.html). Learn more about creating your own templates in [our documentation](https://aka.ms/bf-create-templates).
+If you need to create your own templates, you can use this generator as a base, and extend it to meet your needs with [Yeoman generator composition](https://yeoman.io/authoring/composability.html).
 
 ### From the command-line
 


### PR DESCRIPTION
Fixes #minor

### Description

This readme is also published to npmjs here: [https://www.npmjs.com/package/@microsoft/generator-bot-adaptive?activeTab=readme](https://www.npmjs.com/package/@microsoft/generator-bot-adaptive?activeTab=readme)

I could not find the intended target of the  "our documentation" link, so I deleted that.
