### PR TITLE
fix: Components/Yarn assistance - yarn install error

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -10381,15 +10381,6 @@ resolve@1.1.7:
   languageName: node
   linkType: hard
 
-"semver@npm:^7.3.8":
-  version: 7.3.8
-  resolution: "semver@npm:7.3.8"
-  dependencies:
-    lru-cache: ^6.0.0
-  bin:
-    semver: bin/semver.js
-  checksum: cfb9c2101dae4ee93c415471f48797c750174d65def4e06ff691bf910194cc6ca92793e597be8302175ceb640100a3da36451e7656320da53b51167eeaf11eb5
-
 "send@npm:0.18.0":
   version: 0.18.0
   resolution: "send@npm:0.18.0"


### PR DESCRIPTION
#minor

### Purpose
This PR fixes the following error when trying to run `yarn install`:

_Type Error: Cannot read properties of undefined (reading 'toUpperCase')_ 

### Changes
- Removed `semver@npm:^7.3.8` unnecessary addition from _yarn.lock_ file.