### PR TITLE
fix: Remove LUIS leftovers from CLU recognizer package and update Readme.

### DIFF
--- a/packages/Recognizers/ConversationLanguageUnderstanding/dotnet/CLU/CluAdaptiveRecognizer.cs
+++ b/packages/Recognizers/ConversationLanguageUnderstanding/dotnet/CLU/CluAdaptiveRecognizer.cs
@@ -5,7 +5,6 @@ using System.Threading;
 using System.Threading.Tasks;
 using AdaptiveExpressions.Properties;
 using Microsoft.Bot.Builder;
-using Microsoft.Bot.Builder.AI.Luis;
 using Microsoft.Bot.Builder.Dialogs;
 using Microsoft.Bot.Components.Recognizers.CLURecognizer;
 using Microsoft.Bot.Components.Recognizers.CLURecognizer.CLU;
@@ -156,7 +155,7 @@ namespace Microsoft.Bot.Components.Recognizers
 
             if (!string.IsNullOrWhiteSpace(entities))
             {
-                properties.Add(LuisTelemetryConstants.EntitiesProperty, entities!);
+                properties.Add(CluConstants.Telemetry.EntitiesProperty, entities!);
             }
 
             // Use the LogPersonalInformation flag to toggle logging PII data, text is a common example

--- a/packages/Recognizers/ConversationLanguageUnderstanding/dotnet/CLU/CluMainRecognizer.cs
+++ b/packages/Recognizers/ConversationLanguageUnderstanding/dotnet/CLU/CluMainRecognizer.cs
@@ -313,7 +313,7 @@ namespace Microsoft.Bot.Components.Recognizers.CLURecognizer.CLU
         /// <summary>
         /// Invoked prior to a CluResult being logged.
         /// </summary>
-        /// <param name="recognizerResult">The Luis Results for the call.</param>
+        /// <param name="recognizerResult">The CLU results for the call.</param>
         /// <param name="turnContext">Context object containing information for a single turn of conversation with a user.</param>
         /// <param name="telemetryProperties">Additional properties to be logged to telemetry with the CluResult event.</param>
         /// <param name="telemetryMetrics">Additional metrics to be logged to telemetry with the CluResult event.</param>

--- a/packages/Recognizers/ConversationLanguageUnderstanding/dotnet/README.md
+++ b/packages/Recognizers/ConversationLanguageUnderstanding/dotnet/README.md
@@ -29,8 +29,7 @@ To enable the Conversation Language Understanding recognizer, complete the follo
   "projectName": "<your project name>",
   "endpoint": "<your endpoint, including https://>",
   "endpointKey": "<your endpoint key>",
-  "deploymentName": "<your deployment name>",
-  "includeAPIResults": true
+  "deploymentName": "<your deployment name>"
 }
 ```
 3. Update the `projectName`, `endpoint`, `endpointKey`, and `deploymentName` fields with the values from your Conversation Language Understanding service.


### PR DESCRIPTION
Fixes #minor

### Purpose

Remove LUIS leftovers from CLU recognizer package and update Readme.

### Changes

- Remove LUIS constants leftovers from CLU recognizer classes (CLUMainRecognizer & CLUAdaptiveRecognizer). 
- Update Readme to include only necessary parameters expected to be passed from Bot Composer. 

### Tests

No need for new unit tests. After the minor changes the existing unit tests are still passing.

<img width="323" alt="image" src="https://user-images.githubusercontent.com/4105189/225966040-2a54c45c-29c4-46a0-b867-72fc4d6328c8.png">