### PR TITLE
fix: Change Confidence Score Parse in CLU Recognizer to use Current Culture

### DIFF
--- a/packages/Recognizers/ConversationLanguageUnderstanding/dotnet/CluExtensions.cs
+++ b/packages/Recognizers/ConversationLanguageUnderstanding/dotnet/CluExtensions.cs
@@ -22,7 +22,7 @@ namespace Microsoft.Bot.Components.Recognizers.CLURecognizer
                         NormalizedValue(category),
                         new IntentScore
                         {
-                            Score = confidenceScore == null ? 0.0 : double.Parse(confidenceScore, CultureInfo.InvariantCulture),
+                            Score = confidenceScore == null ? 0.0 : double.Parse(confidenceScore, CultureInfo.CurrentCulture),
                         });
                 }
             }


### PR DESCRIPTION
<!-- This repository only accepts pull requests related to open issues, please link the open issue in description below. -->
<!-- See https://help.github.com/articles/closing-issues-using-keywords/ to learn about automation. -->
<!-- For example - Close #123: Description goes here. -->
Fixes #1510 
### Purpose

<!--What is the context of this pull request? Why is it being done? -->
Currently, when the CLU Recognizer gets the intent result from CLU, it parses the confidence score (expected to be between 0-1) without respect to the user's culture. This causes issues with languages where a `.` decimal point is not used to represent fractional numbers. In some cultures, such as Spanish or French, decimal values are represented with different characters, such as a `,`. Confidence scores for these cultures are currently parsed incorrectly and result in confidence score values that are out of bounds.
### Changes

<!-- Are there any changes that need to be called out as significant or particularly difficult to grasp? (Include illustrative screenshots for context if applicable.) -->
- In `CluExtensions.cs` on line 25, change `double.Parse` to use `CultureInfo.CurrentCulture` instead of `CultureInfo.InvariantCulture`.

### Tests

<!-- Is this covered by existing tests or new ones? If no, why not? -->
- Covered by existing tests. The parsed confidence score should be valid for any culture. Tests passing successfully.
- Also tested the change in a sample Composer bot using the CLU recognizer. Works as expected with confidence scores parsed to between 0 and 1.
### Feature Plan

<!-- Are there any remaining steps or dependencies before this issue can be fully resolved? If so, describe and link to any relevant pull requests or issues. -->
No other changes required.