### PR TITLE
feat: [#1514] Port DotNet CLU Recognizer component to JS

### DIFF
--- a/packages/Recognizers/ConversationLanguageUnderstanding/dotnet/README.md
+++ b/packages/Recognizers/ConversationLanguageUnderstanding/dotnet/README.md
@@ -6,10 +6,6 @@ This recognizer helps you add a custom recognizer to an empty bot built with Bot
 ## Installation
 In order to enable the CLU recognizer, you must first install the [CLU recognizer package](https://www.nuget.org/packages/Microsoft.Bot.Components.Recognizers.CLURecognizer) from NuGet in your Composer project. 
 
-```
-Note: This package is currently only available for C# bots.
-```
-
 1. Create a new Composer bot using the `Empty Bot` template.
 
 2. Open the Package Manager in Composer.

--- a/packages/Recognizers/ConversationLanguageUnderstanding/js/.eslintrc.json
+++ b/packages/Recognizers/ConversationLanguageUnderstanding/js/.eslintrc.json
@@ -1,0 +1,21 @@
+{
+  "parser": "@typescript-eslint/parser",
+  "plugins": ["@typescript-eslint"],
+  "extends": [
+    "../../../.eslintrc.json",
+    "plugin:@typescript-eslint/recommended"
+  ],
+  "ignorePatterns": ["lib"],
+  "rules": {
+    "@typescript-eslint/no-unused-vars": [
+      "error",
+      {
+        "args": "after-used",
+        "argsIgnorePattern": "^_",
+        "caughtErrors": "all",
+        "caughtErrorsIgnorePattern": "^_",
+        "varsIgnorePattern": "^_"
+      }
+    ]
+  }
+}

--- a/packages/Recognizers/ConversationLanguageUnderstanding/js/.eslintrc.json
+++ b/packages/Recognizers/ConversationLanguageUnderstanding/js/.eslintrc.json
@@ -2,7 +2,7 @@
   "parser": "@typescript-eslint/parser",
   "plugins": ["@typescript-eslint"],
   "extends": [
-    "../../../.eslintrc.json",
+    "../../../../.eslintrc.json",
     "plugin:@typescript-eslint/recommended"
   ],
   "ignorePatterns": ["lib"],

--- a/packages/Recognizers/ConversationLanguageUnderstanding/js/.gitignore
+++ b/packages/Recognizers/ConversationLanguageUnderstanding/js/.gitignore
@@ -1,0 +1,4 @@
+_ts3.4
+lib
+node_modules
+*.tsbuildinfo

--- a/packages/Recognizers/ConversationLanguageUnderstanding/js/README.md
+++ b/packages/Recognizers/ConversationLanguageUnderstanding/js/README.md
@@ -1,0 +1,47 @@
+# Conversation Language Understanding (CLU) Recognizer
+
+## Summary
+This recognizer helps you add a custom recognizer to an empty bot built with Bot Framework Composer in order to use the [Conversation Language Understanding Service](https://learn.microsoft.com/en-us/azure/cognitive-services/language-service/conversational-language-understanding/overview) in place of the now deprecated LUIS.
+
+## Installation
+In order to enable the CLU recognizer, you must first install the [CLU recognizer package](https://www.npmjs.com/package/@microsoft/bot-components-clu-recognizer) from NPM in your Composer project. 
+
+1. Create a new Composer bot using the `Empty Bot` template.
+
+2. Open the Package Manager in Composer.
+
+3. Search for `ConversationLanguageUnderstandingRecognizer` and install the package.
+
+## Configuration
+To enable the Conversation Language Understanding recognizer, complete the following steps:
+
+1. Select `Custom` as your root dialog's recognizer type. 
+
+2. Paste the following JSON into the custom recognizer configuration window:
+
+```json
+{
+  "$kind": "Microsoft.CluRecognizer",
+  "projectName": "<your project name>",
+  "endpoint": "<your endpoint, including https://>",
+  "endpointKey": "<your endpoint key>",
+  "deploymentName": "<your deployment name>"
+}
+```
+3. Update the `projectName`, `endpoint`, `endpointKey`, and `deploymentName` fields with the values from your Conversation Language Understanding service.
+
+    - The `deploymentName` value can be found in the `Deploying a model` blade under `Deployments` inside `Language Studio`.
+  
+    - The `endpoint` value can be found in the `Deploying a model` blade under `Deployments` inside `Language Studio` by clicking on the `Get prediction URL` option. It can also be found in the `Keys & Endpoint` blade of your Language resource in the Azure Portal. The endpoint should take the format `https://<language-resource-name>.cognitiveservices.azure.com`. Ensure that the trailing slash is *omitted*.
+
+    - The `projectName` and `endpointKey` values can be found in your `Project Settings` blade under `Azure Language Resource` inside `Language Studio`.
+
+Ensure that you have selected the correct values for each field. Using the wrong values can lead to errors when running the bot.
+
+## Usage
+Once you have configured intents and entities in your Conversation Language Understanding project, custom intent triggers and the CLU intent triggers should function as normal. When creating a new intent trigger in a Composer bot, make sure that the `intent` value of the trigger matches the intent in the deployed Language resource (case-sensitive).
+
+Since the Conversation Language Understanding recognizer is a modified version of the existing LUIS recognizer, the workflow elements work the same. In addition the respective LUIS events and telemetry are written out to the logs.
+
+## Limitations
+Please remember that Composer does not integrate natively with Conversation Language Understanding, so managing intents and entities **must** be done in the Language Studio portal instead of Composer.

--- a/packages/Recognizers/ConversationLanguageUnderstanding/js/package.json
+++ b/packages/Recognizers/ConversationLanguageUnderstanding/js/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "@microsoft/bot-components-clu-recognizer",
+  "author": "Microsoft Corp.",
+  "description": "Rule system for the Microsoft BotBuilder adaptive dialog system, with integration specific to Microsoft Teams.",
+  "version": "1.0.0",
+  "license": "MIT",
+  "keywords": [
+    "msbot-component",
+    "msbot-action",
+    "msbot-trigger"
+  ],
+  "bugs": {
+    "url": "https://github.com/microsoft/botframework-components/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/microsoft/botframework-components.git"
+  },
+  "scripts": {
+    "build": "tsc -b",
+    "clean": "rimraf lib tsconfig.tsbuildinfo",
+    "lint": "eslint . --ext .js,.ts"
+  },
+  "files": [
+    "lib",
+    "schemas",
+    "src"
+  ],
+  "main": "lib/index.js",
+  "types": "lib/index.d.ts",
+  "devDependencies": {
+    "@tsconfig/recommended": "^1.0.1",
+    "@typescript-eslint/eslint-plugin": "^4.28.2",
+    "@typescript-eslint/parser": "^4.28.2",
+    "adaptive-expressions": "4.19.3",
+    "botbuilder": "4.19.3",
+    "botbuilder-dialogs": "4.19.3",
+    "botbuilder-dialogs-adaptive-runtime-core": "4.19.3-preview",
+    "botbuilder-dialogs-declarative": "4.19.3-preview",
+    "botframework-connector": "4.19.3",
+    "eslint": "^7.30.0",
+    "eslint-plugin-prettier": "latest",
+    "rimraf": "^3.0.2",
+    "typescript": "^4.0.5"
+  },
+  "dependencies": {
+    "@azure/ms-rest-js": "^2.7.0"
+  }
+}

--- a/packages/Recognizers/ConversationLanguageUnderstanding/js/package.json
+++ b/packages/Recognizers/ConversationLanguageUnderstanding/js/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@microsoft/bot-components-clu-recognizer",
   "author": "Microsoft Corp.",
-  "description": "This library implements .NET support for Composer with Conversation Language Understanding.",
+  "description": "This library implements node.js support for Composer with Conversation Language Understanding.",
   "version": "1.0.0",
   "license": "MIT",
   "keywords": [

--- a/packages/Recognizers/ConversationLanguageUnderstanding/js/package.json
+++ b/packages/Recognizers/ConversationLanguageUnderstanding/js/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@microsoft/bot-components-clu-recognizer",
   "author": "Microsoft Corp.",
-  "description": "Rule system for the Microsoft BotBuilder adaptive dialog system, with integration specific to Microsoft Teams.",
+  "description": "This library implements .NET support for Composer with Conversation Language Understanding.",
   "version": "1.0.0",
   "license": "MIT",
   "keywords": [
     "msbot-component",
-    "msbot-action",
-    "msbot-trigger"
+    "msbot-recognizer",
+    "composer",
+    "botframework",
+    "botbuilder"
   ],
   "bugs": {
     "url": "https://github.com/microsoft/botframework-components/issues"

--- a/packages/Recognizers/ConversationLanguageUnderstanding/js/schemas/Microsoft.CluRecognizer.schema
+++ b/packages/Recognizers/ConversationLanguageUnderstanding/js/schemas/Microsoft.CluRecognizer.schema
@@ -1,0 +1,56 @@
+{
+    "$schema": "https://schemas.botframework.com/schemas/component/v1.0/component.schema",
+    "$role": "implements(Microsoft.IRecognizer)",
+    "title": "CLU Recognizer",
+    "description": "CLU recognizer.",
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+        "id": {
+            "type": "string",
+            "title": "Id",
+            "description": "Optional unique id using with RecognizerSet. Other recognizers should return 'DeferToRecognizer_{Id}' intent when cross training data for this recognizer."
+        },
+        "projectName": {
+            "$ref": "schema:#/definitions/stringExpression",
+            "title": "CLU project name",
+            "description": "The project name of your CLU service."
+        },
+        "deploymentName": {
+            "$ref": "schema:#/definitions/stringExpression",
+            "title": "CLU deployment name",
+            "description": "The deployment name for your CLU service."
+        },
+        "endpoint": {
+            "$ref": "schema:#/definitions/stringExpression",
+            "title": "CLU endpoint",
+            "description": "Endpoint to use for CLU service like https://{your-clu-service-name}.cognitiveservices.azure.com."
+        },
+        "endpointKey": {
+            "$ref": "schema:#/definitions/stringExpression",
+            "title": "CLU endpoint key",
+            "description": "The endpoint key for your CLU service."
+        },
+        "includeAPIResults": {
+            "$ref": "schema:#/definitions/booleanExpression",
+            "title": "Include CLU API results",
+            "description": "Optional gets or sets a value indicating whether CLU API results should be included in the RecognizerResult returned. If null, then defaults to false."
+        },
+        "cluRequestBodyStringIndexType": {
+            "$ref": "schema:#/definitions/stringExpression",
+            "title": "The string index type to include in the CLU request body",
+            "description": "Optional value indicating the string index type to include in the the CLU request body. If null, then the TextElement_V8 string value is used."
+        },
+        "cluApiVersion": {
+            "$ref": "schema:#/definitions/stringExpression",
+            "title": "CLU API version",
+            "description": "Optional CLU version to target. If null, then the 2022-05-01 string value is used."
+        }
+    },
+    "required": [
+        "projectName",
+        "endpoint",
+        "endpointKey",
+        "deploymentName"
+    ]
+}

--- a/packages/Recognizers/ConversationLanguageUnderstanding/js/src/clu/cluAdaptiveRecognizer.ts
+++ b/packages/Recognizers/ConversationLanguageUnderstanding/js/src/clu/cluAdaptiveRecognizer.ts
@@ -81,7 +81,7 @@ export class CluAdaptiveRecognizer extends Recognizer {
 
   /**
    * Gets or sets the flag to determine if personal information should be logged in telemetry.
-   * @returns The flag to indicate in personal information should be logged in telemetry.
+   * @returns The flag to indicate if personal information should be logged in telemetry.
    */
   get logPersonalInformation(): string | boolean {
     return this._logPersonalInformation.expressionText;
@@ -104,8 +104,8 @@ export class CluAdaptiveRecognizer extends Recognizer {
   }
 
   /**
-   * Gets or sets a value indicating the string index type to include in the the CLU request body.
-   * @returns A value indicating the string index type to include in the the CLU request body.
+   * Gets or sets a value indicating the string index type to include in the CLU request body.
+   * @returns A value indicating the string index type to include in the CLU request body.
    */
   get cluRequestBodyStringIndexType(): string {
     return this._cluRequestBodyStringIndexType.expressionText;

--- a/packages/Recognizers/ConversationLanguageUnderstanding/js/src/clu/cluAdaptiveRecognizer.ts
+++ b/packages/Recognizers/ConversationLanguageUnderstanding/js/src/clu/cluAdaptiveRecognizer.ts
@@ -1,0 +1,130 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { Activity, RecognizerResult } from 'botbuilder';
+import { DialogContext, Recognizer } from 'botbuilder-dialogs';
+import { BoolExpression, StringExpression } from 'adaptive-expressions';
+import { CluConstants } from '../cluConstants';
+import { CluMainRecognizer } from './cluMainRecognizer';
+import { CluRecognizerOptions } from '../cluRecognizerOptions';
+import { CluApplication } from '../cluApplication';
+import { DefaultHttpClientFactory } from '../defaultHttpClientFactory';
+
+export class CluAdaptiveRecognizer extends Recognizer {
+  public static readonly $kind: string = 'Microsoft.CluRecognizer';
+  private _projectName: StringExpression = new StringExpression();
+  private _endpoint: StringExpression = new StringExpression();
+  private _endpointKey: StringExpression = new StringExpression();
+  private _deploymentName: StringExpression = new StringExpression();
+  private _logPersonalInformation: BoolExpression = new BoolExpression(
+    '=settings.runtimeSettings.telemetry.logPersonalInformation'
+  );
+  private _includeAPIResults: BoolExpression = new BoolExpression();
+  private _cluRequestBodyStringIndexType: StringExpression = new StringExpression(
+    CluConstants.RequestOptions.StringIndexType
+  );
+  private _cluApiVersion: StringExpression = new StringExpression(
+    CluConstants.RequestOptions.ApiVersion
+  );
+
+  get projectName() {
+    return this._projectName.value;
+  }
+  set projectName(value: string) {
+    this._projectName = new StringExpression(value);
+  }
+
+  get endpoint() {
+    return this._endpoint.value;
+  }
+  set endpoint(value: string) {
+    this._endpoint = new StringExpression(value);
+  }
+
+  get endpointKey() {
+    return this._endpointKey.value;
+  }
+  set endpointKey(value: string) {
+    this._endpointKey = new StringExpression(value);
+  }
+
+  get deploymentName() {
+    return this._deploymentName.value;
+  }
+  set deploymentName(value: string) {
+    this._deploymentName = new StringExpression(value);
+  }
+
+  get logPersonalInformation() {
+    return this._logPersonalInformation.value;
+  }
+  set logPersonalInformation(value: boolean) {
+    this._logPersonalInformation = new BoolExpression(value);
+  }
+
+  get includeAPIResults() {
+    return this._includeAPIResults.value;
+  }
+  set includeAPIResults(value: boolean) {
+    this._includeAPIResults = new BoolExpression(value);
+  }
+
+  get cluRequestBodyStringIndexType() {
+    return this._cluRequestBodyStringIndexType.value;
+  }
+  set cluRequestBodyStringIndexType(value: string) {
+    this._cluRequestBodyStringIndexType = new StringExpression(value);
+  }
+
+  get cluApiVersion() {
+    return this._cluApiVersion.value;
+  }
+  set cluApiVersion(value: string) {
+    this._cluApiVersion = new StringExpression(value);
+  }
+
+  async recognize(
+    dialogContext: DialogContext,
+    activity: Activity,
+    telemetryProperties?: Record<string, string>,
+    telemetryMetrics?: Record<string, number>
+  ): Promise<RecognizerResult> {
+    const recognizer = new CluMainRecognizer(
+      this.recognizerOptions(dialogContext),
+      new DefaultHttpClientFactory(dialogContext.context).create()
+    );
+    const result = await recognizer.recognize(dialogContext, activity);
+    this.trackRecognizerResult(
+      dialogContext,
+      CluConstants.TrackEventOptions.RecognizerResultEventName,
+      this.fillRecognizerResultTelemetryProperties(
+        result,
+        telemetryProperties ?? {},
+        dialogContext
+      ),
+      telemetryMetrics
+    );
+    return result;
+  }
+
+  recognizerOptions(dialogContext: DialogContext): CluRecognizerOptions {
+    const application = new CluApplication(
+      this._projectName.getValue(dialogContext.state),
+      this._endpointKey.getValue(dialogContext.state),
+      this._endpoint.getValue(dialogContext.state),
+      this._deploymentName.getValue(dialogContext.state)
+    );
+
+    return new CluRecognizerOptions(application, {
+      telemetryClient: this.telemetryClient,
+      logPersonalInformation: this._logPersonalInformation.getValue(
+        dialogContext.state
+      ),
+      includeAPIResults: this._includeAPIResults.getValue(dialogContext.state),
+      cluRequestBodyStringIndexType: this._cluRequestBodyStringIndexType.getValue(
+        dialogContext.state
+      ),
+      cluApiVersion: this._cluApiVersion.getValue(dialogContext.state),
+    });
+  }
+}

--- a/packages/Recognizers/ConversationLanguageUnderstanding/js/src/clu/cluAdaptiveRecognizer.ts
+++ b/packages/Recognizers/ConversationLanguageUnderstanding/js/src/clu/cluAdaptiveRecognizer.ts
@@ -20,13 +20,14 @@ export class CluAdaptiveRecognizer extends Recognizer {
   private _endpointKey: StringExpression = new StringExpression();
   private _deploymentName: StringExpression = new StringExpression();
   private _logPersonalInformation: BoolExpression = new BoolExpression(
-    '=settings.runtimeSettings.telemetry.logPersonalInformation',
+    '=settings.runtimeSettings.telemetry.logPersonalInformation'
   );
   private _includeAPIResults: BoolExpression = new BoolExpression();
-  private _cluRequestBodyStringIndexType: StringExpression =
-    new StringExpression(CluConstants.RequestOptions.StringIndexType);
+  private _cluRequestBodyStringIndexType: StringExpression = new StringExpression(
+    CluConstants.RequestOptions.StringIndexType
+  );
   private _cluApiVersion: StringExpression = new StringExpression(
-    CluConstants.RequestOptions.ApiVersion,
+    CluConstants.RequestOptions.ApiVersion
   );
 
   /**
@@ -133,11 +134,11 @@ export class CluAdaptiveRecognizer extends Recognizer {
     dialogContext: DialogContext,
     activity: Activity,
     telemetryProperties?: Record<string, string>,
-    telemetryMetrics?: Record<string, number>,
+    telemetryMetrics?: Record<string, number>
   ): Promise<RecognizerResult> {
     const recognizer = new CluMainRecognizer(
       this.recognizerOptions(dialogContext),
-      new DefaultHttpClientFactory(dialogContext.context).create(),
+      new DefaultHttpClientFactory(dialogContext.context).create()
     );
     const result = await recognizer.recognize(dialogContext, activity);
     this.trackRecognizerResult(
@@ -146,9 +147,9 @@ export class CluAdaptiveRecognizer extends Recognizer {
       this.fillRecognizerResultTelemetryProperties(
         result,
         telemetryProperties ?? {},
-        dialogContext,
+        dialogContext
       ),
-      telemetryMetrics,
+      telemetryMetrics
     );
     return result;
   }
@@ -163,17 +164,18 @@ export class CluAdaptiveRecognizer extends Recognizer {
       this._projectName.getValue(dialogContext.state),
       this._endpointKey.getValue(dialogContext.state),
       this._endpoint.getValue(dialogContext.state),
-      this._deploymentName.getValue(dialogContext.state),
+      this._deploymentName.getValue(dialogContext.state)
     );
 
     return new CluRecognizerOptions(application, {
       telemetryClient: this.telemetryClient,
       logPersonalInformation: this._logPersonalInformation.getValue(
-        dialogContext.state,
+        dialogContext.state
       ),
       includeAPIResults: this._includeAPIResults.getValue(dialogContext.state),
-      cluRequestBodyStringIndexType:
-        this._cluRequestBodyStringIndexType.getValue(dialogContext.state),
+      cluRequestBodyStringIndexType: this._cluRequestBodyStringIndexType.getValue(
+        dialogContext.state
+      ),
       cluApiVersion: this._cluApiVersion.getValue(dialogContext.state),
     });
   }
@@ -184,7 +186,7 @@ export class CluAdaptiveRecognizer extends Recognizer {
   protected fillRecognizerResultTelemetryProperties(
     recognizerResult: RecognizerResult,
     telemetryProperties: Record<string, string>,
-    dialogContext: DialogContext,
+    dialogContext: DialogContext
   ): Record<string, string> {
     // Get top two intents.
     const [firstIntent, secondIntent] = Object.entries(recognizerResult.intents)
@@ -195,11 +197,11 @@ export class CluAdaptiveRecognizer extends Recognizer {
     const properties: Record<string, string> = {
       [CluConstants.Telemetry.ProjectNameProperty]: this._projectName.value,
       [CluConstants.Telemetry.IntentProperty]: firstIntent?.intent ?? '',
-      [CluConstants.Telemetry.IntentScoreProperty]:
-        firstIntent?.score.toLocaleString('en-US'),
+      [CluConstants.Telemetry
+        .IntentScoreProperty]: firstIntent?.score.toLocaleString('en-US'),
       [CluConstants.Telemetry.Intent2Property]: secondIntent?.intent ?? '',
-      [CluConstants.Telemetry.IntentScore2Property]:
-        secondIntent?.score.toLocaleString('en-US'),
+      [CluConstants.Telemetry
+        .IntentScore2Property]: secondIntent?.score.toLocaleString('en-US'),
       [CluConstants.Telemetry.FromIdProperty]:
         dialogContext.context.activity?.from?.id,
     };

--- a/packages/Recognizers/ConversationLanguageUnderstanding/js/src/clu/cluAdaptiveRecognizer.ts
+++ b/packages/Recognizers/ConversationLanguageUnderstanding/js/src/clu/cluAdaptiveRecognizer.ts
@@ -20,14 +20,13 @@ export class CluAdaptiveRecognizer extends Recognizer {
   private _endpointKey: StringExpression = new StringExpression();
   private _deploymentName: StringExpression = new StringExpression();
   private _logPersonalInformation: BoolExpression = new BoolExpression(
-    '=settings.runtimeSettings.telemetry.logPersonalInformation'
+    '=settings.runtimeSettings.telemetry.logPersonalInformation',
   );
   private _includeAPIResults: BoolExpression = new BoolExpression();
-  private _cluRequestBodyStringIndexType: StringExpression = new StringExpression(
-    CluConstants.RequestOptions.StringIndexType
-  );
+  private _cluRequestBodyStringIndexType: StringExpression =
+    new StringExpression(CluConstants.RequestOptions.StringIndexType);
   private _cluApiVersion: StringExpression = new StringExpression(
-    CluConstants.RequestOptions.ApiVersion
+    CluConstants.RequestOptions.ApiVersion,
   );
 
   /**
@@ -39,7 +38,7 @@ export class CluAdaptiveRecognizer extends Recognizer {
    * Gets or sets the projectName of your Conversation Language Understanding service.
    * @returns The project name of your Conversation Language Understanding service.
    */
-  get projectName() {
+  get projectName(): string {
     return this._projectName.expressionText;
   }
   set projectName(value: string) {
@@ -50,7 +49,7 @@ export class CluAdaptiveRecognizer extends Recognizer {
    * Gets or sets the endpoint for your Conversation Language Understanding service.
    * @returns The endpoint of your Conversation Language Understanding service.
    */
-  get endpoint() {
+  get endpoint(): string {
     return this._endpoint.expressionText;
   }
   set endpoint(value: string) {
@@ -61,7 +60,7 @@ export class CluAdaptiveRecognizer extends Recognizer {
    * Gets or sets the endpointKey for your Conversation Language Understanding service.
    * @returns The endpoint key for your Conversation Language Understanding service.
    */
-  get endpointKey() {
+  get endpointKey(): string {
     return this._endpointKey.expressionText;
   }
   set endpointKey(value: string) {
@@ -72,7 +71,7 @@ export class CluAdaptiveRecognizer extends Recognizer {
    * Gets or sets the deploymentName for your Conversation Language Understanding service.
    * @returns The deployment name for your Conversation Language Understanding service.
    */
-  get deploymentName() {
+  get deploymentName(): string {
     return this._deploymentName.expressionText;
   }
   set deploymentName(value: string) {
@@ -83,7 +82,7 @@ export class CluAdaptiveRecognizer extends Recognizer {
    * Gets or sets the flag to determine if personal information should be logged in telemetry.
    * @returns The flag to indicate in personal information should be logged in telemetry.
    */
-  get logPersonalInformation() {
+  get logPersonalInformation(): string | boolean {
     return this._logPersonalInformation.expressionText;
   }
   set logPersonalInformation(value: string | boolean) {
@@ -96,7 +95,7 @@ export class CluAdaptiveRecognizer extends Recognizer {
    * This is mainly useful for testing or getting access to CLU features not yet in the SDK.
    * @returns True to include API results.
    */
-  get includeAPIResults() {
+  get includeAPIResults(): string | boolean {
     return this._includeAPIResults.expressionText;
   }
   set includeAPIResults(value: string | boolean) {
@@ -107,7 +106,7 @@ export class CluAdaptiveRecognizer extends Recognizer {
    * Gets or sets a value indicating the string index type to include in the the CLU request body.
    * @returns A value indicating the string index type to include in the the CLU request body.
    */
-  get cluRequestBodyStringIndexType() {
+  get cluRequestBodyStringIndexType(): string {
     return this._cluRequestBodyStringIndexType.expressionText;
   }
   set cluRequestBodyStringIndexType(value: string) {
@@ -120,7 +119,7 @@ export class CluAdaptiveRecognizer extends Recognizer {
    * This can be helpful combined with the includeAPIResults flag to get access to CLU features not yet in the SDK.
    * @returns A value indicating the CLU API version to use.
    */
-  get cluApiVersion() {
+  get cluApiVersion(): string {
     return this._cluApiVersion.expressionText;
   }
   set cluApiVersion(value: string) {
@@ -134,11 +133,11 @@ export class CluAdaptiveRecognizer extends Recognizer {
     dialogContext: DialogContext,
     activity: Activity,
     telemetryProperties?: Record<string, string>,
-    telemetryMetrics?: Record<string, number>
+    telemetryMetrics?: Record<string, number>,
   ): Promise<RecognizerResult> {
     const recognizer = new CluMainRecognizer(
       this.recognizerOptions(dialogContext),
-      new DefaultHttpClientFactory(dialogContext.context).create()
+      new DefaultHttpClientFactory(dialogContext.context).create(),
     );
     const result = await recognizer.recognize(dialogContext, activity);
     this.trackRecognizerResult(
@@ -147,9 +146,9 @@ export class CluAdaptiveRecognizer extends Recognizer {
       this.fillRecognizerResultTelemetryProperties(
         result,
         telemetryProperties ?? {},
-        dialogContext
+        dialogContext,
       ),
-      telemetryMetrics
+      telemetryMetrics,
     );
     return result;
   }
@@ -164,18 +163,17 @@ export class CluAdaptiveRecognizer extends Recognizer {
       this._projectName.getValue(dialogContext.state),
       this._endpointKey.getValue(dialogContext.state),
       this._endpoint.getValue(dialogContext.state),
-      this._deploymentName.getValue(dialogContext.state)
+      this._deploymentName.getValue(dialogContext.state),
     );
 
     return new CluRecognizerOptions(application, {
       telemetryClient: this.telemetryClient,
       logPersonalInformation: this._logPersonalInformation.getValue(
-        dialogContext.state
+        dialogContext.state,
       ),
       includeAPIResults: this._includeAPIResults.getValue(dialogContext.state),
-      cluRequestBodyStringIndexType: this._cluRequestBodyStringIndexType.getValue(
-        dialogContext.state
-      ),
+      cluRequestBodyStringIndexType:
+        this._cluRequestBodyStringIndexType.getValue(dialogContext.state),
       cluApiVersion: this._cluApiVersion.getValue(dialogContext.state),
     });
   }
@@ -186,7 +184,7 @@ export class CluAdaptiveRecognizer extends Recognizer {
   protected fillRecognizerResultTelemetryProperties(
     recognizerResult: RecognizerResult,
     telemetryProperties: Record<string, string>,
-    dialogContext?: DialogContext
+    dialogContext: DialogContext,
   ): Record<string, string> {
     // Get top two intents.
     const [firstIntent, secondIntent] = Object.entries(recognizerResult.intents)
@@ -197,13 +195,13 @@ export class CluAdaptiveRecognizer extends Recognizer {
     const properties: Record<string, string> = {
       [CluConstants.Telemetry.ProjectNameProperty]: this._projectName.value,
       [CluConstants.Telemetry.IntentProperty]: firstIntent?.intent ?? '',
-      [CluConstants.Telemetry
-        .IntentScoreProperty]: firstIntent?.score.toLocaleString('en-US'),
+      [CluConstants.Telemetry.IntentScoreProperty]:
+        firstIntent?.score.toLocaleString('en-US'),
       [CluConstants.Telemetry.Intent2Property]: secondIntent?.intent ?? '',
-      [CluConstants.Telemetry
-        .IntentScore2Property]: secondIntent?.score.toLocaleString('en-US'),
-      [CluConstants.Telemetry.FromIdProperty]: dialogContext?.context.activity
-        ?.from?.id!,
+      [CluConstants.Telemetry.IntentScore2Property]:
+        secondIntent?.score.toLocaleString('en-US'),
+      [CluConstants.Telemetry.FromIdProperty]:
+        dialogContext.context.activity?.from?.id,
     };
 
     if (!recognizerResult.entities) {
@@ -214,11 +212,10 @@ export class CluAdaptiveRecognizer extends Recognizer {
     // Use the LogPersonalInformation flag to toggle logging PII data, text is a common example.
     if (
       this.logPersonalInformation &&
-      !dialogContext?.context.activity?.text?.trim()
+      !dialogContext.context.activity?.text?.trim()
     ) {
-      properties[
-        CluConstants.Telemetry.QuestionProperty
-      ] = dialogContext?.context.activity.text!;
+      properties[CluConstants.Telemetry.QuestionProperty] =
+        dialogContext.context.activity.text;
     }
 
     // Additional Properties can override "stock" properties.

--- a/packages/Recognizers/ConversationLanguageUnderstanding/js/src/clu/cluMainRecognizer.ts
+++ b/packages/Recognizers/ConversationLanguageUnderstanding/js/src/clu/cluMainRecognizer.ts
@@ -1,0 +1,162 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { TurnContext, Activity, RecognizerResult } from 'botbuilder';
+import { CluRecognizerOptionsBase } from '../cluRecognizerOptionsBase';
+import { HttpClient } from '@azure/ms-rest-js';
+import { CluConstants } from '../cluConstants';
+import { DialogContext } from 'botbuilder-dialogs';
+
+export class CluMainRecognizer {
+  public logPersonalInformation: boolean = false;
+  private readonly cacheKey: string;
+
+  constructor(
+    private readonly recognizerOptions: CluRecognizerOptionsBase,
+    private readonly httpClient: HttpClient
+  ) {
+    const { endpoint, projectName } = recognizerOptions.application;
+    this.cacheKey = endpoint + projectName;
+  }
+
+  recognize(
+    utterance: string,
+    recognizerOptions?: CluRecognizerOptionsBase
+  ): Promise<RecognizerResult>;
+  recognize(
+    turnContext: TurnContext,
+    recognizerOptions?: CluRecognizerOptionsBase,
+    telemetryProperties?: Record<string, string>,
+    telemetryMetrics?: Record<string, number>
+  ): Promise<RecognizerResult>;
+  recognize(
+    dialogContext: DialogContext,
+    activity: Activity,
+    recognizerOptions?: CluRecognizerOptionsBase,
+    telemetryProperties?: Record<string, string>,
+    telemetryMetrics?: Record<string, number>
+  ): Promise<RecognizerResult>;
+  recognize(
+    utteranceOrContext: string | TurnContext | DialogContext,
+    ...rest: any[]
+  ): Promise<RecognizerResult> {
+    if (typeof utteranceOrContext === 'string') {
+      return this.recognizeWithUtterance(utteranceOrContext, ...rest);
+    }
+
+    const params =
+      utteranceOrContext instanceof TurnContext ? [, ...rest] : rest;
+    return this.recognizeWithContext(utteranceOrContext, ...params);
+  }
+
+  protected onRecognizerResult(
+    recognizerResult: RecognizerResult,
+    turnContext: TurnContext,
+    telemetryProperties?: Record<string, string>,
+    telemetryMetrics?: Record<string, number>
+  ) {
+    this.recognizerOptions.telemetryClient.trackEvent({
+      name: CluConstants.Telemetry.CluResult,
+      properties: this.fillCluEventProperties(
+        recognizerResult,
+        turnContext,
+        telemetryProperties
+      ),
+      metrics: telemetryMetrics,
+    });
+  }
+
+  protected fillCluEventProperties(
+    recognizerResult: RecognizerResult,
+    turnContext: TurnContext,
+    telemetryProperties?: Record<string, string>
+  ) {
+    // Get top two intents.
+    const [firstIntent, secondIntent] = Object.entries(recognizerResult.intents)
+      .map(([intent, { score = 0 }]) => ({ intent, score }))
+      .sort((a, b) => b.score - a.score);
+
+    // Add the intent score and conversation id properties
+    const properties = {
+      [CluConstants.Telemetry.ProjectNameProperty]: this.recognizerOptions
+        .application.projectName,
+      [CluConstants.Telemetry.IntentProperty]: firstIntent?.intent ?? '',
+      [CluConstants.Telemetry
+        .IntentScoreProperty]: firstIntent?.score.toLocaleString('en-US'),
+      [CluConstants.Telemetry.Intent2Property]: secondIntent?.intent ?? '',
+      [CluConstants.Telemetry
+        .IntentScore2Property]: secondIntent?.score.toLocaleString('en-US'),
+      [CluConstants.Telemetry.FromIdProperty]: turnContext.activity?.from?.id,
+    };
+
+    if (!recognizerResult.entities) {
+      properties[CluConstants.Telemetry.EntitiesProperty] =
+        recognizerResult.entities;
+    }
+
+    // Use the LogPersonalInformation flag to toggle logging PII data, text is a common example.
+    if (this.logPersonalInformation && !turnContext.activity?.text?.trim()) {
+      properties[CluConstants.Telemetry.QuestionProperty] =
+        turnContext.activity.text;
+    }
+
+    // Additional Properties can override "stock" properties.
+    if (telemetryProperties != null) {
+      return Object.assign({}, properties, telemetryProperties);
+    }
+
+    return properties;
+  }
+
+  private recognizeWithUtterance(
+    utterance: string,
+    predictionOptions?: CluRecognizerOptionsBase
+  ) {
+    const recognizer = predictionOptions ?? this.recognizerOptions;
+    return recognizer.recognize(utterance, this.httpClient);
+  }
+
+  private async recognizeWithContext(
+    context: TurnContext | DialogContext,
+    activity?: Activity,
+    predictionOptions?: CluRecognizerOptionsBase,
+    telemetryProperties?: Record<string, string>,
+    telemetryMetrics?: Record<string, number>
+  ) {
+    const turnContext =
+      context instanceof TurnContext ? context : context.context;
+    const recognizer = predictionOptions ?? this.recognizerOptions;
+    const cached = turnContext.turnState.get(this.cacheKey);
+
+    if (cached) {
+      this.recognizerOptions.telemetryClient.trackEvent({
+        name: CluConstants.TrackEventOptions.ReadFromCachedResultEventName,
+        metrics: telemetryMetrics,
+        properties: telemetryProperties,
+      });
+      return cached;
+    }
+
+    const result =
+      context instanceof TurnContext
+      ? await recognizer.recognize(turnContext, this.httpClient)
+      : await recognizer.recognize(context, activity!, this.httpClient)
+
+    this.onRecognizerResult(
+      result,
+      turnContext,
+      telemetryProperties,
+      telemetryMetrics
+    );
+
+    turnContext.turnState.set(this.cacheKey, result);
+
+    this.recognizerOptions.telemetryClient.trackEvent({
+      name: CluConstants.TrackEventOptions.ResultCachedEventName,
+      metrics: telemetryMetrics,
+      properties: telemetryProperties,
+    });
+
+    return result;
+  }
+}

--- a/packages/Recognizers/ConversationLanguageUnderstanding/js/src/clu/cluMainRecognizer.ts
+++ b/packages/Recognizers/ConversationLanguageUnderstanding/js/src/clu/cluMainRecognizer.ts
@@ -1,6 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+/* eslint-disable  @typescript-eslint/no-non-null-assertion */
+/* eslint-disable  @typescript-eslint/no-explicit-any */
+
 import {
   TurnContext,
   Activity,
@@ -38,7 +41,7 @@ export class CluMainRecognizer {
    */
   constructor(
     private readonly recognizerOptions: CluRecognizerOptionsBase,
-    private readonly httpClient: HttpClient
+    private readonly httpClient: HttpClient,
   ) {
     this.telemetryClient =
       recognizerOptions.telemetryClient ?? new NullTelemetryClient();
@@ -59,7 +62,7 @@ export class CluMainRecognizer {
    */
   recognize(
     utterance: string,
-    recognizerOptions?: CluRecognizerOptionsBase
+    recognizerOptions?: CluRecognizerOptionsBase,
   ): Promise<RecognizerResult>;
   /**
    * Return results of the analysis (Suggested actions and intents).
@@ -74,7 +77,7 @@ export class CluMainRecognizer {
     turnContext: TurnContext,
     recognizerOptions?: CluRecognizerOptionsBase,
     telemetryProperties?: Record<string, string>,
-    telemetryMetrics?: Record<string, number>
+    telemetryMetrics?: Record<string, number>,
   ): Promise<RecognizerResult>;
   /**
    * Return results of the analysis (Suggested actions and intents).
@@ -91,7 +94,7 @@ export class CluMainRecognizer {
     activity: Activity,
     recognizerOptions?: CluRecognizerOptionsBase,
     telemetryProperties?: Record<string, string>,
-    telemetryMetrics?: Record<string, number>
+    telemetryMetrics?: Record<string, number>,
   ): Promise<RecognizerResult>;
   recognize(
     utteranceOrContext: string | TurnContext | DialogContext,
@@ -102,7 +105,7 @@ export class CluMainRecognizer {
     }
 
     const params =
-      utteranceOrContext instanceof TurnContext ? [, ...rest] : rest;
+      utteranceOrContext instanceof TurnContext ? [null, ...rest] : rest;
     return this.recognizeWithContext(utteranceOrContext, ...params);
   }
 
@@ -117,14 +120,14 @@ export class CluMainRecognizer {
     recognizerResult: RecognizerResult,
     turnContext: TurnContext,
     telemetryProperties?: Record<string, string>,
-    telemetryMetrics?: Record<string, number>
-  ) {
+    telemetryMetrics?: Record<string, number>,
+  ): void {
     this.telemetryClient.trackEvent({
       name: CluConstants.Telemetry.CluResult,
       properties: this.fillCluEventProperties(
         recognizerResult,
         turnContext,
-        telemetryProperties
+        telemetryProperties,
       ),
       metrics: telemetryMetrics,
     });
@@ -141,8 +144,8 @@ export class CluMainRecognizer {
   protected fillCluEventProperties(
     recognizerResult: RecognizerResult,
     turnContext: TurnContext,
-    telemetryProperties?: Record<string, string>
-  ) {
+    telemetryProperties?: Record<string, string>,
+  ): Record<string, string> {
     // Get top two intents.
     const [firstIntent, secondIntent] = Object.entries(recognizerResult.intents)
       .map(([intent, { score = 0 }]) => ({ intent, score }))
@@ -150,14 +153,14 @@ export class CluMainRecognizer {
 
     // Add the intent score and conversation id properties.
     const properties = {
-      [CluConstants.Telemetry.ProjectNameProperty]: this.recognizerOptions
-        .application.projectName,
+      [CluConstants.Telemetry.ProjectNameProperty]:
+        this.recognizerOptions.application.projectName,
       [CluConstants.Telemetry.IntentProperty]: firstIntent?.intent ?? '',
-      [CluConstants.Telemetry
-        .IntentScoreProperty]: firstIntent?.score.toLocaleString('en-US'),
+      [CluConstants.Telemetry.IntentScoreProperty]:
+        firstIntent?.score.toLocaleString('en-US'),
       [CluConstants.Telemetry.Intent2Property]: secondIntent?.intent ?? '',
-      [CluConstants.Telemetry
-        .IntentScore2Property]: secondIntent?.score.toLocaleString('en-US'),
+      [CluConstants.Telemetry.IntentScore2Property]:
+        secondIntent?.score.toLocaleString('en-US'),
       [CluConstants.Telemetry.FromIdProperty]: turnContext.activity?.from?.id,
     };
 
@@ -188,7 +191,7 @@ export class CluMainRecognizer {
    */
   private recognizeWithUtterance(
     utterance: string,
-    predictionOptions?: CluRecognizerOptionsBase
+    predictionOptions?: CluRecognizerOptionsBase,
   ) {
     const recognizer = predictionOptions ?? this.recognizerOptions;
     return recognizer.recognize(utterance, this.httpClient);
@@ -208,7 +211,7 @@ export class CluMainRecognizer {
     activity?: Activity,
     predictionOptions?: CluRecognizerOptionsBase,
     telemetryProperties?: Record<string, string>,
-    telemetryMetrics?: Record<string, number>
+    telemetryMetrics?: Record<string, number>,
   ) {
     const turnContext =
       context instanceof TurnContext ? context : context.context;
@@ -233,7 +236,7 @@ export class CluMainRecognizer {
       result,
       turnContext,
       telemetryProperties,
-      telemetryMetrics
+      telemetryMetrics,
     );
 
     turnContext.turnState.set(this.cacheKey, result);

--- a/packages/Recognizers/ConversationLanguageUnderstanding/js/src/clu/cluMainRecognizer.ts
+++ b/packages/Recognizers/ConversationLanguageUnderstanding/js/src/clu/cluMainRecognizer.ts
@@ -41,7 +41,7 @@ export class CluMainRecognizer {
    */
   constructor(
     private readonly recognizerOptions: CluRecognizerOptionsBase,
-    private readonly httpClient: HttpClient,
+    private readonly httpClient: HttpClient
   ) {
     this.telemetryClient =
       recognizerOptions.telemetryClient ?? new NullTelemetryClient();
@@ -62,7 +62,7 @@ export class CluMainRecognizer {
    */
   recognize(
     utterance: string,
-    recognizerOptions?: CluRecognizerOptionsBase,
+    recognizerOptions?: CluRecognizerOptionsBase
   ): Promise<RecognizerResult>;
   /**
    * Return results of the analysis (Suggested actions and intents).
@@ -77,7 +77,7 @@ export class CluMainRecognizer {
     turnContext: TurnContext,
     recognizerOptions?: CluRecognizerOptionsBase,
     telemetryProperties?: Record<string, string>,
-    telemetryMetrics?: Record<string, number>,
+    telemetryMetrics?: Record<string, number>
   ): Promise<RecognizerResult>;
   /**
    * Return results of the analysis (Suggested actions and intents).
@@ -94,7 +94,7 @@ export class CluMainRecognizer {
     activity: Activity,
     recognizerOptions?: CluRecognizerOptionsBase,
     telemetryProperties?: Record<string, string>,
-    telemetryMetrics?: Record<string, number>,
+    telemetryMetrics?: Record<string, number>
   ): Promise<RecognizerResult>;
   recognize(
     utteranceOrContext: string | TurnContext | DialogContext,
@@ -120,14 +120,14 @@ export class CluMainRecognizer {
     recognizerResult: RecognizerResult,
     turnContext: TurnContext,
     telemetryProperties?: Record<string, string>,
-    telemetryMetrics?: Record<string, number>,
+    telemetryMetrics?: Record<string, number>
   ): void {
     this.telemetryClient.trackEvent({
       name: CluConstants.Telemetry.CluResult,
       properties: this.fillCluEventProperties(
         recognizerResult,
         turnContext,
-        telemetryProperties,
+        telemetryProperties
       ),
       metrics: telemetryMetrics,
     });
@@ -144,7 +144,7 @@ export class CluMainRecognizer {
   protected fillCluEventProperties(
     recognizerResult: RecognizerResult,
     turnContext: TurnContext,
-    telemetryProperties?: Record<string, string>,
+    telemetryProperties?: Record<string, string>
   ): Record<string, string> {
     // Get top two intents.
     const [firstIntent, secondIntent] = Object.entries(recognizerResult.intents)
@@ -153,14 +153,14 @@ export class CluMainRecognizer {
 
     // Add the intent score and conversation id properties.
     const properties = {
-      [CluConstants.Telemetry.ProjectNameProperty]:
-        this.recognizerOptions.application.projectName,
+      [CluConstants.Telemetry.ProjectNameProperty]: this.recognizerOptions
+        .application.projectName,
       [CluConstants.Telemetry.IntentProperty]: firstIntent?.intent ?? '',
-      [CluConstants.Telemetry.IntentScoreProperty]:
-        firstIntent?.score.toLocaleString('en-US'),
+      [CluConstants.Telemetry
+        .IntentScoreProperty]: firstIntent?.score.toLocaleString('en-US'),
       [CluConstants.Telemetry.Intent2Property]: secondIntent?.intent ?? '',
-      [CluConstants.Telemetry.IntentScore2Property]:
-        secondIntent?.score.toLocaleString('en-US'),
+      [CluConstants.Telemetry
+        .IntentScore2Property]: secondIntent?.score.toLocaleString('en-US'),
       [CluConstants.Telemetry.FromIdProperty]: turnContext.activity?.from?.id,
     };
 
@@ -191,7 +191,7 @@ export class CluMainRecognizer {
    */
   private recognizeWithUtterance(
     utterance: string,
-    predictionOptions?: CluRecognizerOptionsBase,
+    predictionOptions?: CluRecognizerOptionsBase
   ) {
     const recognizer = predictionOptions ?? this.recognizerOptions;
     return recognizer.recognize(utterance, this.httpClient);
@@ -211,7 +211,7 @@ export class CluMainRecognizer {
     activity?: Activity,
     predictionOptions?: CluRecognizerOptionsBase,
     telemetryProperties?: Record<string, string>,
-    telemetryMetrics?: Record<string, number>,
+    telemetryMetrics?: Record<string, number>
   ) {
     const turnContext =
       context instanceof TurnContext ? context : context.context;
@@ -236,7 +236,7 @@ export class CluMainRecognizer {
       result,
       turnContext,
       telemetryProperties,
-      telemetryMetrics,
+      telemetryMetrics
     );
 
     turnContext.turnState.set(this.cacheKey, result);

--- a/packages/Recognizers/ConversationLanguageUnderstanding/js/src/clu/cluMainRecognizer.ts
+++ b/packages/Recognizers/ConversationLanguageUnderstanding/js/src/clu/cluMainRecognizer.ts
@@ -1,34 +1,91 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { TurnContext, Activity, RecognizerResult } from 'botbuilder';
+import {
+  TurnContext,
+  Activity,
+  RecognizerResult,
+  BotTelemetryClient,
+  NullTelemetryClient,
+} from 'botbuilder';
 import { CluRecognizerOptionsBase } from '../cluRecognizerOptionsBase';
 import { HttpClient } from '@azure/ms-rest-js';
 import { CluConstants } from '../cluConstants';
 import { DialogContext } from 'botbuilder-dialogs';
 
+/**
+ * A CLU based implementation.
+ */
 export class CluMainRecognizer {
-  public logPersonalInformation: boolean = false;
   private readonly cacheKey: string;
 
+  /**
+   * Gets or sets a value indicating whether to log personal information that came from the user to telemetry.
+   * @returns If true, personal information is logged to Telemetry; otherwise the properties will be filtered.
+   */
+  public logPersonalInformation: boolean;
+
+  /**
+   * Gets the currently configured BotTelemetryClient that logs the CluResult event.
+   * @returns The BotTelemetryClient being used to log events.
+   */
+  public telemetryClient: BotTelemetryClient;
+
+  /**
+   * Initializes a new instance of the CluMainRecognizer class.
+   * @param recognizerOptions The CLU recognizer version options.
+   * @param httpClient The HttpClient for the CLU API calls.
+   */
   constructor(
     private readonly recognizerOptions: CluRecognizerOptionsBase,
     private readonly httpClient: HttpClient
   ) {
+    this.telemetryClient =
+      recognizerOptions.telemetryClient ?? new NullTelemetryClient();
+    this.logPersonalInformation =
+      recognizerOptions.logPersonalInformation ?? false;
     const { endpoint, projectName } = recognizerOptions.application;
     this.cacheKey = endpoint + projectName;
   }
 
+  /**
+   * Return results of the analysis (Suggested actions and intents).
+   *
+   * No telemetry is provided when using this method.
+   * @param utterance The utterance to recognize.
+   * @param recognizerOptions A CluRecognizerOptionsBase instance to be used by the call.
+   * This parameter overrides the default CluRecognizerOptionsBase passed in the constructor.
+   * @returns The CLU results of the analysis of the current message text in the current turn's context activity.
+   */
   recognize(
     utterance: string,
     recognizerOptions?: CluRecognizerOptionsBase
   ): Promise<RecognizerResult>;
+  /**
+   * Return results of the analysis (Suggested actions and intents).
+   * @param turnContext Context object containing information for a single turn of conversation with a user.
+   * @param recognizerOptions A CluRecognizerOptionsBase instance to be used by the call.
+   * This parameter overrides the default CluRecognizerOptionsBase passed in the constructor.
+   * @param telemetryProperties Additional properties to be logged to telemetry with the CluResult event.
+   * @param telemetryMetrics Additional metrics to be logged to telemetry with the CluResult event.
+   * @returns The CLU results of the analysis of the current message text in the current turn's context activity.
+   */
   recognize(
     turnContext: TurnContext,
     recognizerOptions?: CluRecognizerOptionsBase,
     telemetryProperties?: Record<string, string>,
     telemetryMetrics?: Record<string, number>
   ): Promise<RecognizerResult>;
+  /**
+   * Return results of the analysis (Suggested actions and intents).
+   * @param dialogContext Context object containing information for a single turn of conversation with a user.
+   * @param activity Activity to recognize.
+   * @param recognizerOptions A CluRecognizerOptionsBase instance to be used by the call.
+   * This parameter overrides the default CluRecognizerOptionsBase passed in the constructor.
+   * @param telemetryProperties Additional properties to be logged to telemetry with the CluResult event.
+   * @param telemetryMetrics Additional metrics to be logged to telemetry with the CluResult event.
+   * @returns The CLU results of the analysis of the current message text in the current turn's context activity.
+   */
   recognize(
     dialogContext: DialogContext,
     activity: Activity,
@@ -49,13 +106,20 @@ export class CluMainRecognizer {
     return this.recognizeWithContext(utteranceOrContext, ...params);
   }
 
+  /**
+   * Invoked prior to a CluResult being logged.
+   * @param recognizerResult The CLU results for the call.
+   * @param turnContext Context object containing information for a single turn of conversation with a user.
+   * @param telemetryProperties Additional properties to be logged to telemetry with the CluResult event.
+   * @param telemetryMetrics Additional metrics to be logged to telemetry with the CluResult event.
+   */
   protected onRecognizerResult(
     recognizerResult: RecognizerResult,
     turnContext: TurnContext,
     telemetryProperties?: Record<string, string>,
     telemetryMetrics?: Record<string, number>
   ) {
-    this.recognizerOptions.telemetryClient.trackEvent({
+    this.telemetryClient.trackEvent({
       name: CluConstants.Telemetry.CluResult,
       properties: this.fillCluEventProperties(
         recognizerResult,
@@ -66,6 +130,14 @@ export class CluMainRecognizer {
     });
   }
 
+  /**
+   * Fills the event properties for CluResult event for telemetry.
+   * These properties are logged when the recognizer is called.
+   * @param recognizerResult Last activity sent from user.
+   * @param turnContext Context object containing information for a single turn of conversation with a user.
+   * @param telemetryProperties Additional properties to be logged to telemetry with the CluResult event.
+   * @returns A dictionary that is sent as "Properties" to BotTelemetryClient.trackEvent method for the BotMessageSend event.
+   */
   protected fillCluEventProperties(
     recognizerResult: RecognizerResult,
     turnContext: TurnContext,
@@ -76,7 +148,7 @@ export class CluMainRecognizer {
       .map(([intent, { score = 0 }]) => ({ intent, score }))
       .sort((a, b) => b.score - a.score);
 
-    // Add the intent score and conversation id properties
+    // Add the intent score and conversation id properties.
     const properties = {
       [CluConstants.Telemetry.ProjectNameProperty]: this.recognizerOptions
         .application.projectName,
@@ -108,6 +180,12 @@ export class CluMainRecognizer {
     return properties;
   }
 
+  /**
+   * Returns a RecognizerResult object.
+   * @param utterance The utterance to recognize.
+   * @param predictionOptions CluRecognizerOptions implementation to override current properties.
+   * @returns RecognizerResult object.
+   */
   private recognizeWithUtterance(
     utterance: string,
     predictionOptions?: CluRecognizerOptionsBase
@@ -116,6 +194,15 @@ export class CluMainRecognizer {
     return recognizer.recognize(utterance, this.httpClient);
   }
 
+  /**
+   * Returns a RecognizerResult object.
+   * @param context The current dialog context or turn context.
+   * @param activity The activity to recognize.
+   * @param predictionOptions CluRecognizerOptions implementation to override current properties.
+   * @param telemetryProperties Additional properties to be logged to telemetry with the CluResult event.
+   * @param telemetryMetrics Additional metrics to be logged to telemetry with the CluResult event.
+   * @returns RecognizerResult object.
+   */
   private async recognizeWithContext(
     context: TurnContext | DialogContext,
     activity?: Activity,
@@ -129,7 +216,7 @@ export class CluMainRecognizer {
     const cached = turnContext.turnState.get(this.cacheKey);
 
     if (cached) {
-      this.recognizerOptions.telemetryClient.trackEvent({
+      this.telemetryClient.trackEvent({
         name: CluConstants.TrackEventOptions.ReadFromCachedResultEventName,
         metrics: telemetryMetrics,
         properties: telemetryProperties,
@@ -139,8 +226,8 @@ export class CluMainRecognizer {
 
     const result =
       context instanceof TurnContext
-      ? await recognizer.recognize(turnContext, this.httpClient)
-      : await recognizer.recognize(context, activity!, this.httpClient)
+        ? await recognizer.recognize(turnContext, this.httpClient)
+        : await recognizer.recognize(context, activity!, this.httpClient);
 
     this.onRecognizerResult(
       result,
@@ -151,7 +238,7 @@ export class CluMainRecognizer {
 
     turnContext.turnState.set(this.cacheKey, result);
 
-    this.recognizerOptions.telemetryClient.trackEvent({
+    this.telemetryClient.trackEvent({
       name: CluConstants.TrackEventOptions.ResultCachedEventName,
       metrics: telemetryMetrics,
       properties: telemetryProperties,

--- a/packages/Recognizers/ConversationLanguageUnderstanding/js/src/cluApplication.ts
+++ b/packages/Recognizers/ConversationLanguageUnderstanding/js/src/cluApplication.ts
@@ -1,7 +1,17 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+/**
+ * Data describing a CLU application.
+ */
 export class CluApplication {
+  /**
+   * Initializes a new instance of the CluApplication class.
+   * @param projectName CLU project name.
+   * @param endpointKey CLU subscription or endpoint key.
+   * @param endpoint CLU endpoint to use.
+   * @param deploymentName CLU deployment name.
+   */
   constructor(
     public projectName: string,
     public endpointKey: string,
@@ -12,8 +22,7 @@ export class CluApplication {
       throw new Error(`CLU "projectName" parameter cannot be null or empty.`);
     }
 
-    if (!this.isGUID(endpointKey)) {
-      // TODO: Implement this => (!Guid.TryParse(endpointKey, out var _))
+    if (!this.isWellFormatedGUID(endpointKey)) {
       throw new Error(`"${endpointKey}" is not a valid CLU subscription key.`);
     }
 
@@ -22,7 +31,6 @@ export class CluApplication {
     }
 
     if (!this.isWellFormedUriString(endpoint)) {
-      // TODO: Implement this => (!Uri.IsWellFormedUriString(endpoint, UriKind.Absolute))
       throw new Error(`"${endpoint}" is not a valid CLU endpoint.`);
     }
 
@@ -33,18 +41,30 @@ export class CluApplication {
     }
   }
 
-  private isGUID(guid: string){
+  /**
+   * Check if the provided value is a well formated GUID.
+   * @param guid The GUID value.
+   * @returns True if the GUID is well formated.
+   */
+  private isWellFormatedGUID(guid: string) {
     var pattern = /^(((?=.*}$){)|((?!.*}$)))((?!.*-.*)|(?=(.*[-].*){4}))[0-9a-fA-F]{8}[-]?([0-9a-fA-F]{4}[-]?){3}[0-9a-fA-F]{12}?[}]?$/m;
     return !!guid.match(pattern);
   }
 
+  /**
+   * Check if the provided value is a well formated URI.
+   * @param uri The URI string value.
+   * @returns True if the URI is well formated.
+   */
   private isWellFormedUriString(uri: string): boolean {
     try {
       const uriResult = new URL(uri);
-      return ((uriResult.toString() === uri || uriResult.toString() === `${uri}/`) &&
-        (uriResult.protocol === "https:" || uriResult.protocol === "http:"));
+      return (
+        (uriResult.toString() === uri || uriResult.toString() === `${uri}/`) &&
+        (uriResult.protocol === 'https:' || uriResult.protocol === 'http:')
+      );
     } catch (err) {
       return false;
     }
-  };
+  }
 }

--- a/packages/Recognizers/ConversationLanguageUnderstanding/js/src/cluApplication.ts
+++ b/packages/Recognizers/ConversationLanguageUnderstanding/js/src/cluApplication.ts
@@ -1,0 +1,50 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+export class CluApplication {
+  constructor(
+    public projectName: string,
+    public endpointKey: string,
+    public endpoint: string,
+    public deploymentName: string
+  ) {
+    if (!projectName?.trim()) {
+      throw new Error(`CLU "projectName" parameter cannot be null or empty.`);
+    }
+
+    if (!this.isGUID(endpointKey)) {
+      // TODO: Implement this => (!Guid.TryParse(endpointKey, out var _))
+      throw new Error(`"${endpointKey}" is not a valid CLU subscription key.`);
+    }
+
+    if (!endpoint?.trim()) {
+      throw new Error(`CLU "endpoint" parameter cannot be null or empty.`);
+    }
+
+    if (!this.isWellFormedUriString(endpoint)) {
+      // TODO: Implement this => (!Uri.IsWellFormedUriString(endpoint, UriKind.Absolute))
+      throw new Error(`"${endpoint}" is not a valid CLU endpoint.`);
+    }
+
+    if (!deploymentName?.trim()) {
+      throw new Error(
+        `CLU "deploymentName" parameter cannot be null or empty.`
+      );
+    }
+  }
+
+  private isGUID(guid: string){
+    var pattern = /^(((?=.*}$){)|((?!.*}$)))((?!.*-.*)|(?=(.*[-].*){4}))[0-9a-fA-F]{8}[-]?([0-9a-fA-F]{4}[-]?){3}[0-9a-fA-F]{12}?[}]?$/m;
+    return !!guid.match(pattern);
+  }
+
+  private isWellFormedUriString(uri: string): boolean {
+    try {
+      const uriResult = new URL(uri);
+      return ((uriResult.toString() === uri || uriResult.toString() === `${uri}/`) &&
+        (uriResult.protocol === "https:" || uriResult.protocol === "http:"));
+    } catch (err) {
+      return false;
+    }
+  };
+}

--- a/packages/Recognizers/ConversationLanguageUnderstanding/js/src/cluApplication.ts
+++ b/packages/Recognizers/ConversationLanguageUnderstanding/js/src/cluApplication.ts
@@ -16,7 +16,7 @@ export class CluApplication {
     public projectName: string,
     public endpointKey: string,
     public endpoint: string,
-    public deploymentName: string
+    public deploymentName: string,
   ) {
     if (!projectName?.trim()) {
       throw new Error(`CLU "projectName" parameter cannot be null or empty.`);
@@ -36,7 +36,7 @@ export class CluApplication {
 
     if (!deploymentName?.trim()) {
       throw new Error(
-        `CLU "deploymentName" parameter cannot be null or empty.`
+        `CLU "deploymentName" parameter cannot be null or empty.`,
       );
     }
   }
@@ -47,7 +47,8 @@ export class CluApplication {
    * @returns True if the GUID is well formated.
    */
   private isWellFormatedGUID(guid: string) {
-    var pattern = /^(((?=.*}$){)|((?!.*}$)))((?!.*-.*)|(?=(.*[-].*){4}))[0-9a-fA-F]{8}[-]?([0-9a-fA-F]{4}[-]?){3}[0-9a-fA-F]{12}?[}]?$/m;
+    const pattern =
+      /^(((?=.*}$){)|((?!.*}$)))((?!.*-.*)|(?=(.*[-].*){4}))[0-9a-fA-F]{8}[-]?([0-9a-fA-F]{4}[-]?){3}[0-9a-fA-F]{12}?[}]?$/m;
     return !!guid.match(pattern);
   }
 
@@ -63,7 +64,7 @@ export class CluApplication {
         (uriResult.toString() === uri || uriResult.toString() === `${uri}/`) &&
         (uriResult.protocol === 'https:' || uriResult.protocol === 'http:')
       );
-    } catch (err) {
+    } catch {
       return false;
     }
   }

--- a/packages/Recognizers/ConversationLanguageUnderstanding/js/src/cluApplication.ts
+++ b/packages/Recognizers/ConversationLanguageUnderstanding/js/src/cluApplication.ts
@@ -16,7 +16,7 @@ export class CluApplication {
     public projectName: string,
     public endpointKey: string,
     public endpoint: string,
-    public deploymentName: string,
+    public deploymentName: string
   ) {
     if (!projectName?.trim()) {
       throw new Error(`CLU "projectName" parameter cannot be null or empty.`);
@@ -36,7 +36,7 @@ export class CluApplication {
 
     if (!deploymentName?.trim()) {
       throw new Error(
-        `CLU "deploymentName" parameter cannot be null or empty.`,
+        `CLU "deploymentName" parameter cannot be null or empty.`
       );
     }
   }
@@ -47,8 +47,7 @@ export class CluApplication {
    * @returns True if the GUID is well formated.
    */
   private isWellFormatedGUID(guid: string) {
-    const pattern =
-      /^(((?=.*}$){)|((?!.*}$)))((?!.*-.*)|(?=(.*[-].*){4}))[0-9a-fA-F]{8}[-]?([0-9a-fA-F]{4}[-]?){3}[0-9a-fA-F]{12}?[}]?$/m;
+    const pattern = /^(((?=.*}$){)|((?!.*}$)))((?!.*-.*)|(?=(.*[-].*){4}))[0-9a-fA-F]{8}[-]?([0-9a-fA-F]{4}[-]?){3}[0-9a-fA-F]{12}?[}]?$/m;
     return !!guid.match(pattern);
   }
 

--- a/packages/Recognizers/ConversationLanguageUnderstanding/js/src/cluConstants.ts
+++ b/packages/Recognizers/ConversationLanguageUnderstanding/js/src/cluConstants.ts
@@ -2,57 +2,180 @@
 // Licensed under the MIT License.
 
 class TrackEventOptions {
+  /**
+   * The name of the recognizer result event to track.
+   */
   static readonly RecognizerResultEventName: string = 'CluResult';
+
+  /**
+   * The name of the clu result cached event to track.
+   */
   static readonly ResultCachedEventName: string = 'CluResultCached';
+
+  /**
+   * The name of the read from cached clu result event to track.
+   */
   static readonly ReadFromCachedResultEventName: string =
     'ReadFromCachedCluResult';
 }
 
 class ResponseOptions {
+  /**
+   * The CLU response result key.
+   */
   static readonly ResultKey: string = 'result';
+
+  /**
+   * The CLU response prediction key.
+   */
   static readonly PredictionKey: string = 'prediction';
 }
 
 class TraceOptions {
+  /**
+   * The name of the CLU trace activity.
+   */
   static readonly ActivityName: string = 'CluRecognizer';
+
+  /**
+   * The value type for a CLU trace activity.
+   */
   static readonly TraceType: string = 'https://www.clu.ai/schemas/trace';
+
+  /**
+   * The context label for a CLU trace activity.
+   */
   static readonly TraceLabel: string = 'Clu Trace';
 }
 
 class HttpClientOptions {
+  /**
+   * The default logical name of the HttpClient to create.
+   */
   static readonly DefaultLogicalName: string = 'clu';
+
+  /**
+   * The default time in milliseconds to wait before the request times out.
+   */
   static readonly Timeout: number = 100000;
 }
 
 class Telemetry {
+  /**
+   * The Key used when storing a CLU Result in a custom event within telemetry.
+   */
   static readonly CluResult: string = 'CluResult';
+
+  /**
+   * The Key used when storing a CLU Project Name in a custom event within telemetry.
+   */
   static readonly ProjectNameProperty: string = 'projectName';
+
+  /**
+   * The Key used when storing a CLU intent in a custom event within telemetry.
+   */
   static readonly IntentProperty: string = 'intent';
+
+  /**
+   * The Key used when storing a CLU intent score in a custom event within telemetry.
+   */
   static readonly IntentScoreProperty: string = 'intentScore';
+
+  /**
+   * The Key used when storing a CLU intent in a custom event within telemetry.
+   */
   static readonly Intent2Property: string = 'intent2';
+
+  /**
+   * The Key used when storing a CLU intent score in a custom event within telemetry.
+   */
   static readonly IntentScore2Property: string = 'intentScore2';
+
+  /**
+   * The Key used when storing CLU entities in a custom event within telemetry.
+   */
   static readonly EntitiesProperty: string = 'entities';
+
+  /**
+   * The Key used when storing the CLU query in a custom event within telemetry.
+   */
   static readonly QuestionProperty: string = 'question';
+
+  /**
+   * The Key used when storing the FromId in a custom event within telemetry.
+   */
   static readonly FromIdProperty: string = 'fromId';
 }
 
 class RequestOptions {
+  /**
+   * The Kind value of the CLU request body.
+   */
   static readonly Kind: string = 'Conversation';
+
+  /**
+   * The Conversation Item Id value of the CLU request body.
+   */
   static readonly ConversationItemId: string = '1';
+
+  /**
+   * The Conversation Item Participant Id value of the CLU request body.
+   */
   static readonly ConversationItemParticipantId: string = '1';
+
+  /**
+   * The String Index Type value of the CLU request body.
+   */
   static readonly StringIndexType: string = 'TextElement_V8';
+
+  /**
+   * The API Version of the CLU service.
+   */
   static readonly ApiVersion: string = '2022-05-01';
+
+  /**
+   * The name of the CLU subscription key header.
+   */
   static readonly SubscriptionKeyHeaderName: string =
     'Ocp-Apim-Subscription-Key';
 }
 
+/**
+ * The CLU Constants.
+ */
 export class CluConstants {
+  /**
+   * The recognizer result response property name to include the CLU result.
+   */
   static readonly RecognizerResultResponsePropertyName: string = 'cluResult';
 
+  /**
+   * The CLU track event constants.
+   */
   static readonly TrackEventOptions = TrackEventOptions;
+
+  /**
+   * The CLU response constants.
+   */
   static readonly ResponseOptions = ResponseOptions;
+
+  /**
+   * The CLU trace constants.
+   */
   static readonly TraceOptions = TraceOptions;
+
+  /**
+   * The CLU HttpClient constants.
+   */
   static readonly HttpClientOptions = HttpClientOptions;
+
+  /**
+   * The BotTelemetryClient event and property names that are logged by default.
+   */
   static readonly Telemetry = Telemetry;
+
+  /**
+   * The CLU request body default constants.
+   */
   static readonly RequestOptions = RequestOptions;
 }

--- a/packages/Recognizers/ConversationLanguageUnderstanding/js/src/cluConstants.ts
+++ b/packages/Recognizers/ConversationLanguageUnderstanding/js/src/cluConstants.ts
@@ -1,0 +1,58 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+class TrackEventOptions {
+  static readonly RecognizerResultEventName: string = 'CluResult';
+  static readonly ResultCachedEventName: string = 'CluResultCached';
+  static readonly ReadFromCachedResultEventName: string =
+    'ReadFromCachedCluResult';
+}
+
+class ResponseOptions {
+  static readonly ResultKey: string = 'result';
+  static readonly PredictionKey: string = 'prediction';
+}
+
+class TraceOptions {
+  static readonly ActivityName: string = 'CluRecognizer';
+  static readonly TraceType: string = 'https://www.clu.ai/schemas/trace';
+  static readonly TraceLabel: string = 'Clu Trace';
+}
+
+class HttpClientOptions {
+  static readonly DefaultLogicalName: string = 'clu';
+  static readonly Timeout: number = 100000;
+}
+
+class Telemetry {
+  static readonly CluResult: string = 'CluResult';
+  static readonly ProjectNameProperty: string = 'projectName';
+  static readonly IntentProperty: string = 'intent';
+  static readonly IntentScoreProperty: string = 'intentScore';
+  static readonly Intent2Property: string = 'intent2';
+  static readonly IntentScore2Property: string = 'intentScore2';
+  static readonly EntitiesProperty: string = 'entities';
+  static readonly QuestionProperty: string = 'question';
+  static readonly FromIdProperty: string = 'fromId';
+}
+
+class RequestOptions {
+  static readonly Kind: string = 'Conversation';
+  static readonly ConversationItemId: string = '1';
+  static readonly ConversationItemParticipantId: string = '1';
+  static readonly StringIndexType: string = 'TextElement_V8';
+  static readonly ApiVersion: string = '2022-05-01';
+  static readonly SubscriptionKeyHeaderName: string =
+    'Ocp-Apim-Subscription-Key';
+}
+
+export class CluConstants {
+  static readonly RecognizerResultResponsePropertyName: string = 'cluResult';
+
+  static readonly TrackEventOptions = TrackEventOptions;
+  static readonly ResponseOptions = ResponseOptions;
+  static readonly TraceOptions = TraceOptions;
+  static readonly HttpClientOptions = HttpClientOptions;
+  static readonly Telemetry = Telemetry;
+  static readonly RequestOptions = RequestOptions;
+}

--- a/packages/Recognizers/ConversationLanguageUnderstanding/js/src/cluExtensions.ts
+++ b/packages/Recognizers/ConversationLanguageUnderstanding/js/src/cluExtensions.ts
@@ -15,7 +15,7 @@ export class CluExtensions {
    * @returns An object with the extracted intents.
    */
   static extractIntents(
-    cluResult: Record<string, IntentScore>,
+    cluResult: Record<string, IntentScore>
   ): Record<string, IntentScore> {
     const result: Record<string, IntentScore> = {};
     if (!!cluResult?.intents && Array.isArray(cluResult.intents)) {

--- a/packages/Recognizers/ConversationLanguageUnderstanding/js/src/cluExtensions.ts
+++ b/packages/Recognizers/ConversationLanguageUnderstanding/js/src/cluExtensions.ts
@@ -1,0 +1,39 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { IntentScore } from 'botbuilder';
+
+export class CluExtensions {
+  static extractIntents(cluResult: Record<string, IntentScore>) {
+    const result: Record<string, IntentScore> = {};
+    if (!!cluResult?.intents && Array.isArray(cluResult.intents)) {
+      for (const intent of cluResult.intents) {
+        result[this.normalizedValue(intent.category)] = {
+          score: !intent.confidenceScore
+            ? 0.0
+            : Number.parseFloat(intent.confidenceScore),
+        };
+      }
+    }
+    return result;
+  }
+
+  static extractEntities(cluResult: Record<string, any>) {
+    const result: Record<string, any> = {};
+    if (!!cluResult?.entities && Array.isArray(cluResult.entities)) {
+      for (const entity of cluResult.entities) {
+        const normalizedCategory = this.normalizedValue(entity.category);
+        if (!result[normalizedCategory]) {
+          result[normalizedCategory] = [];
+        }
+
+        result[normalizedCategory].push(entity);
+      }
+    }
+    return result;
+  }
+
+  private static normalizedValue(value: string) {
+    return value.replace('.', '_').replace(' ', '_');
+  }
+}

--- a/packages/Recognizers/ConversationLanguageUnderstanding/js/src/cluExtensions.ts
+++ b/packages/Recognizers/ConversationLanguageUnderstanding/js/src/cluExtensions.ts
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+/* eslint-disable  @typescript-eslint/no-explicit-any */
+
 import { IntentScore } from 'botbuilder';
 
 /**
@@ -12,7 +14,9 @@ export class CluExtensions {
    * @param cluResult The CLU Result.
    * @returns An object with the extracted intents.
    */
-  static extractIntents(cluResult: Record<string, IntentScore>) {
+  static extractIntents(
+    cluResult: Record<string, IntentScore>,
+  ): Record<string, IntentScore> {
     const result: Record<string, IntentScore> = {};
     if (!!cluResult?.intents && Array.isArray(cluResult.intents)) {
       for (const intent of cluResult.intents) {
@@ -31,7 +35,7 @@ export class CluExtensions {
    * @param cluResult The CLU Result.
    * @returns An object with the extracted entities.
    */
-  static extractEntities(cluResult: Record<string, any>) {
+  static extractEntities(cluResult: Record<string, any>): Record<string, any> {
     const result: Record<string, any> = {};
     if (!!cluResult?.entities && Array.isArray(cluResult.entities)) {
       for (const entity of cluResult.entities) {

--- a/packages/Recognizers/ConversationLanguageUnderstanding/js/src/cluExtensions.ts
+++ b/packages/Recognizers/ConversationLanguageUnderstanding/js/src/cluExtensions.ts
@@ -3,7 +3,15 @@
 
 import { IntentScore } from 'botbuilder';
 
+/**
+ * Utility class for CLU Results.
+ */
 export class CluExtensions {
+  /**
+   * Extract intents from a CLU Result.
+   * @param cluResult The CLU Result.
+   * @returns An object with the extracted intents.
+   */
   static extractIntents(cluResult: Record<string, IntentScore>) {
     const result: Record<string, IntentScore> = {};
     if (!!cluResult?.intents && Array.isArray(cluResult.intents)) {
@@ -18,6 +26,11 @@ export class CluExtensions {
     return result;
   }
 
+  /**
+   * Extract entities from a CLU Result.
+   * @param cluResult The CLU Result.
+   * @returns An object with the extracted entities.
+   */
   static extractEntities(cluResult: Record<string, any>) {
     const result: Record<string, any> = {};
     if (!!cluResult?.entities && Array.isArray(cluResult.entities)) {

--- a/packages/Recognizers/ConversationLanguageUnderstanding/js/src/cluRecognizerBotComponent.ts
+++ b/packages/Recognizers/ConversationLanguageUnderstanding/js/src/cluRecognizerBotComponent.ts
@@ -9,7 +9,14 @@ import {
 } from 'botbuilder-dialogs-adaptive-runtime-core';
 import { CluAdaptiveRecognizer } from './clu/cluAdaptiveRecognizer';
 
+/**
+ * CLU Recognizer BotComponent definition.
+ */
 export class CluRecognizerBotComponent extends BotComponent {
+  /**
+   * @param services Services collection to register dependency injection.
+   * @param _configuration Configuration for the bot component.
+   */
   configureServices(
     services: ServiceCollection,
     _configuration: Configuration

--- a/packages/Recognizers/ConversationLanguageUnderstanding/js/src/cluRecognizerBotComponent.ts
+++ b/packages/Recognizers/ConversationLanguageUnderstanding/js/src/cluRecognizerBotComponent.ts
@@ -19,7 +19,7 @@ export class CluRecognizerBotComponent extends BotComponent {
    */
   configureServices(
     services: ServiceCollection,
-    _configuration: Configuration
+    _configuration: Configuration,
   ): void {
     services.composeFactory<ComponentDeclarativeTypes[]>(
       'declarativeTypes',
@@ -33,7 +33,7 @@ export class CluRecognizerBotComponent extends BotComponent {
               },
             ];
           },
-        })
+        }),
     );
   }
 }

--- a/packages/Recognizers/ConversationLanguageUnderstanding/js/src/cluRecognizerBotComponent.ts
+++ b/packages/Recognizers/ConversationLanguageUnderstanding/js/src/cluRecognizerBotComponent.ts
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { BotComponent } from 'botbuilder';
+import { ComponentDeclarativeTypes } from 'botbuilder-dialogs-declarative';
+import {
+  Configuration,
+  ServiceCollection,
+} from 'botbuilder-dialogs-adaptive-runtime-core';
+import { CluAdaptiveRecognizer } from './clu/cluAdaptiveRecognizer';
+
+export class CluRecognizerBotComponent extends BotComponent {
+  configureServices(
+    services: ServiceCollection,
+    _configuration: Configuration
+  ): void {
+    services.composeFactory<ComponentDeclarativeTypes[]>(
+      'declarativeTypes',
+      (declarativeTypes) =>
+        declarativeTypes.concat({
+          getDeclarativeTypes() {
+            return [
+              {
+                kind: CluAdaptiveRecognizer.$kind,
+                type: CluAdaptiveRecognizer,
+              },
+            ];
+          },
+        })
+    );
+  }
+}

--- a/packages/Recognizers/ConversationLanguageUnderstanding/js/src/cluRecognizerBotComponent.ts
+++ b/packages/Recognizers/ConversationLanguageUnderstanding/js/src/cluRecognizerBotComponent.ts
@@ -19,7 +19,7 @@ export class CluRecognizerBotComponent extends BotComponent {
    */
   configureServices(
     services: ServiceCollection,
-    _configuration: Configuration,
+    _configuration: Configuration
   ): void {
     services.composeFactory<ComponentDeclarativeTypes[]>(
       'declarativeTypes',
@@ -33,7 +33,7 @@ export class CluRecognizerBotComponent extends BotComponent {
               },
             ];
           },
-        }),
+        })
     );
   }
 }

--- a/packages/Recognizers/ConversationLanguageUnderstanding/js/src/cluRecognizerOptions.ts
+++ b/packages/Recognizers/ConversationLanguageUnderstanding/js/src/cluRecognizerOptions.ts
@@ -13,7 +13,15 @@ import {
 } from './cluRecognizerOptionsBase';
 import { CluExtensions } from './cluExtensions';
 
+/**
+ * Options for CluRecognizerOptions.
+ */
 export class CluRecognizerOptions extends CluRecognizerOptionsBase {
+  /**
+   * Initializes a new instance of the CluRecognizerOptions class.
+   * @param application The CLU application to use to recognize text.
+   * @param fields The fields to load to the base class.
+   */
   constructor(
     application: CluApplication,
     fields?: CluRecognizerOptionsBaseFields
@@ -21,14 +29,23 @@ export class CluRecognizerOptions extends CluRecognizerOptionsBase {
     super(application, fields);
   }
 
+  /**
+   * @inheritdoc
+   */
   recognize(
     utterance: string,
     httpClient: HttpClient
   ): Promise<RecognizerResult>;
+  /**
+   * @inheritdoc
+   */
   recognize(
     turnContext: TurnContext,
     httpClient: HttpClient
   ): Promise<RecognizerResult>;
+  /**
+   * @inheritdoc
+   */
   recognize(
     dialogContext: DialogContext,
     activity: Activity,
@@ -112,7 +129,13 @@ export class CluRecognizerOptions extends CluRecognizerOptionsBase {
       [CluConstants.RequestOptions.SubscriptionKeyHeaderName]: this.application
         .endpointKey,
     });
-    const resource = new WebResource(uri.href, 'POST', JSON.stringify(body), {}, headers);
+    const resource = new WebResource(
+      uri.href,
+      'POST',
+      JSON.stringify(body),
+      {},
+      headers
+    );
     const response = await httpClient.sendRequest(resource);
 
     return response.parsedBody;

--- a/packages/Recognizers/ConversationLanguageUnderstanding/js/src/cluRecognizerOptions.ts
+++ b/packages/Recognizers/ConversationLanguageUnderstanding/js/src/cluRecognizerOptions.ts
@@ -1,6 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+/* eslint-disable  @typescript-eslint/no-non-null-assertion */
+/* eslint-disable  @typescript-eslint/no-explicit-any */
+
 import { TurnContext, Activity, RecognizerResult } from 'botbuilder';
 import { DialogContext } from 'botbuilder-dialogs';
 import { HttpClient, HttpHeaders, WebResource } from '@azure/ms-rest-js';
@@ -24,7 +27,7 @@ export class CluRecognizerOptions extends CluRecognizerOptionsBase {
    */
   constructor(
     application: CluApplication,
-    fields?: CluRecognizerOptionsBaseFields
+    fields?: CluRecognizerOptionsBaseFields,
   ) {
     super(application, fields);
   }
@@ -34,14 +37,14 @@ export class CluRecognizerOptions extends CluRecognizerOptionsBase {
    */
   recognize(
     utterance: string,
-    httpClient: HttpClient
+    httpClient: HttpClient,
   ): Promise<RecognizerResult>;
   /**
    * @inheritdoc
    */
   recognize(
     turnContext: TurnContext,
-    httpClient: HttpClient
+    httpClient: HttpClient,
   ): Promise<RecognizerResult>;
   /**
    * @inheritdoc
@@ -49,17 +52,17 @@ export class CluRecognizerOptions extends CluRecognizerOptionsBase {
   recognize(
     dialogContext: DialogContext,
     activity: Activity,
-    httpClient: HttpClient
+    httpClient: HttpClient,
   ): Promise<RecognizerResult>;
   recognize(
     utteranceOrContext: string | TurnContext | DialogContext,
     activityOrHttpClient: Activity | HttpClient,
-    httpClient?: HttpClient
+    httpClient?: HttpClient,
   ): Promise<RecognizerResult> {
     if (typeof utteranceOrContext === 'string') {
       return this.recognizeWithUtterance(
         utteranceOrContext,
-        activityOrHttpClient as HttpClient
+        activityOrHttpClient as HttpClient,
       );
     }
 
@@ -78,7 +81,7 @@ export class CluRecognizerOptions extends CluRecognizerOptionsBase {
   private async recognizeWithTurnContext(
     turnContext: TurnContext,
     utterance: string,
-    httpClient: HttpClient
+    httpClient: HttpClient,
   ): Promise<RecognizerResult> {
     let recognizerResult: RecognizerResult;
     let cluResponse = null;
@@ -89,7 +92,7 @@ export class CluRecognizerOptions extends CluRecognizerOptionsBase {
       cluResponse = await this.getCluResponse(utterance, httpClient);
       recognizerResult = this.buildRecognizerResultFromCluResponse(
         cluResponse,
-        utterance
+        utterance,
       );
     }
 
@@ -103,7 +106,7 @@ export class CluRecognizerOptions extends CluRecognizerOptionsBase {
       CluConstants.TraceOptions.ActivityName,
       traceInfo,
       CluConstants.TraceOptions.TraceType,
-      CluConstants.TraceOptions.TraceLabel
+      CluConstants.TraceOptions.TraceLabel,
     );
 
     return recognizerResult;
@@ -111,12 +114,12 @@ export class CluRecognizerOptions extends CluRecognizerOptionsBase {
 
   private async recognizeWithUtterance(
     utterance: string,
-    httpClient: HttpClient
+    httpClient: HttpClient,
   ): Promise<RecognizerResult> {
     if (!utterance?.trim()) {
       return { text: utterance, intents: {} };
     } else {
-      var cluResponse = await this.getCluResponse(utterance, httpClient);
+      const cluResponse = await this.getCluResponse(utterance, httpClient);
       return this.buildRecognizerResultFromCluResponse(cluResponse, utterance);
     }
   }
@@ -126,15 +129,15 @@ export class CluRecognizerOptions extends CluRecognizerOptionsBase {
     const body = this.buildRequestBody(utterance);
     const headers = new HttpHeaders({
       'Content-Type': 'application/json',
-      [CluConstants.RequestOptions.SubscriptionKeyHeaderName]: this.application
-        .endpointKey,
+      [CluConstants.RequestOptions.SubscriptionKeyHeaderName]:
+        this.application.endpointKey,
     });
     const resource = new WebResource(
       uri.href,
       'POST',
       JSON.stringify(body),
       {},
-      headers
+      headers,
     );
     const response = await httpClient.sendRequest(resource);
 
@@ -162,9 +165,9 @@ export class CluRecognizerOptions extends CluRecognizerOptionsBase {
 
   private buildRecognizerResultFromCluResponse(
     cluResponse: any,
-    utterance: string
+    utterance: string,
   ): RecognizerResult {
-    var prediction =
+    const prediction =
       cluResponse[CluConstants.ResponseOptions.ResultKey]?.[
         CluConstants.ResponseOptions.PredictionKey
       ];
@@ -177,9 +180,8 @@ export class CluRecognizerOptions extends CluRecognizerOptionsBase {
     };
 
     if (this.includeAPIResults) {
-      recognizerResult[
-        CluConstants.RecognizerResultResponsePropertyName
-      ] = cluResponse;
+      recognizerResult[CluConstants.RecognizerResultResponsePropertyName] =
+        cluResponse;
     }
 
     return recognizerResult;
@@ -188,7 +190,7 @@ export class CluRecognizerOptions extends CluRecognizerOptionsBase {
   private buildUri(): URL {
     const uri = new URL(
       '/language/:analyze-conversations',
-      this.application.endpoint
+      this.application.endpoint,
     );
 
     uri.searchParams.append('api-version', this.cluApiVersion);

--- a/packages/Recognizers/ConversationLanguageUnderstanding/js/src/cluRecognizerOptions.ts
+++ b/packages/Recognizers/ConversationLanguageUnderstanding/js/src/cluRecognizerOptions.ts
@@ -1,0 +1,175 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { TurnContext, Activity, RecognizerResult } from 'botbuilder';
+import { DialogContext } from 'botbuilder-dialogs';
+import { HttpClient, HttpHeaders, WebResource } from '@azure/ms-rest-js';
+
+import { CluApplication } from './cluApplication';
+import { CluConstants } from './cluConstants';
+import {
+  CluRecognizerOptionsBase,
+  CluRecognizerOptionsBaseFields,
+} from './cluRecognizerOptionsBase';
+import { CluExtensions } from './cluExtensions';
+
+export class CluRecognizerOptions extends CluRecognizerOptionsBase {
+  constructor(
+    application: CluApplication,
+    fields?: CluRecognizerOptionsBaseFields
+  ) {
+    super(application, fields);
+  }
+
+  recognize(
+    utterance: string,
+    httpClient: HttpClient
+  ): Promise<RecognizerResult>;
+  recognize(
+    turnContext: TurnContext,
+    httpClient: HttpClient
+  ): Promise<RecognizerResult>;
+  recognize(
+    dialogContext: DialogContext,
+    activity: Activity,
+    httpClient: HttpClient
+  ): Promise<RecognizerResult>;
+  recognize(
+    utteranceOrContext: string | TurnContext | DialogContext,
+    activityOrHttpClient: Activity | HttpClient,
+    httpClient?: HttpClient
+  ): Promise<RecognizerResult> {
+    if (typeof utteranceOrContext === 'string') {
+      return this.recognizeWithUtterance(
+        utteranceOrContext,
+        activityOrHttpClient as HttpClient
+      );
+    }
+
+    const [context, activity, client] =
+      utteranceOrContext instanceof TurnContext
+        ? [utteranceOrContext, utteranceOrContext.activity, httpClient]
+        : [
+            utteranceOrContext.context,
+            activityOrHttpClient as Activity,
+            httpClient,
+          ];
+
+    return this.recognizeWithTurnContext(context, activity.text, client!);
+  }
+
+  private async recognizeWithTurnContext(
+    turnContext: TurnContext,
+    utterance: string,
+    httpClient: HttpClient
+  ): Promise<RecognizerResult> {
+    let recognizerResult: RecognizerResult;
+    let cluResponse = null;
+
+    if (!utterance?.trim()) {
+      return { text: utterance, intents: {} };
+    } else {
+      cluResponse = await this.getCluResponse(utterance, httpClient);
+      recognizerResult = this.buildRecognizerResultFromCluResponse(
+        cluResponse,
+        utterance
+      );
+    }
+
+    const traceInfo = {
+      recognizerResult,
+      cluModel: this.application.projectName,
+      cluResult: cluResponse,
+    };
+
+    await turnContext.sendTraceActivity(
+      CluConstants.TraceOptions.ActivityName,
+      traceInfo,
+      CluConstants.TraceOptions.TraceType,
+      CluConstants.TraceOptions.TraceLabel
+    );
+
+    return recognizerResult;
+  }
+
+  private async recognizeWithUtterance(
+    utterance: string,
+    httpClient: HttpClient
+  ): Promise<RecognizerResult> {
+    if (!utterance?.trim()) {
+      return { text: utterance, intents: {} };
+    } else {
+      var cluResponse = await this.getCluResponse(utterance, httpClient);
+      return this.buildRecognizerResultFromCluResponse(cluResponse, utterance);
+    }
+  }
+
+  private async getCluResponse(utterance: string, httpClient: HttpClient) {
+    const uri = this.buildUri();
+    const body = this.buildRequestBody(utterance);
+    const headers = new HttpHeaders({
+      'Content-Type': 'application/json',
+      [CluConstants.RequestOptions.SubscriptionKeyHeaderName]: this.application
+        .endpointKey,
+    });
+    const resource = new WebResource(uri.href, 'POST', JSON.stringify(body), {}, headers);
+    const response = await httpClient.sendRequest(resource);
+
+    return response.parsedBody;
+  }
+
+  private buildRequestBody(utterance: string) {
+    return {
+      kind: CluConstants.RequestOptions.Kind,
+      analysisInput: {
+        conversationItem: {
+          id: CluConstants.RequestOptions.ConversationItemId,
+          participantId:
+            CluConstants.RequestOptions.ConversationItemParticipantId,
+          text: utterance,
+        },
+      },
+      parameters: {
+        projectName: this.application.projectName,
+        deploymentName: this.application.deploymentName,
+        stringIndexType: this.cluRequestBodyStringIndexType,
+      },
+    };
+  }
+
+  private buildRecognizerResultFromCluResponse(
+    cluResponse: any,
+    utterance: string
+  ): RecognizerResult {
+    var prediction =
+      cluResponse[CluConstants.ResponseOptions.ResultKey]?.[
+        CluConstants.ResponseOptions.PredictionKey
+      ];
+
+    const recognizerResult: RecognizerResult = {
+      text: utterance,
+      alteredText: utterance,
+      intents: CluExtensions.extractIntents(prediction),
+      entities: CluExtensions.extractEntities(prediction),
+    };
+
+    if (this.includeAPIResults) {
+      recognizerResult[
+        CluConstants.RecognizerResultResponsePropertyName
+      ] = cluResponse;
+    }
+
+    return recognizerResult;
+  }
+
+  private buildUri(): URL {
+    const uri = new URL(
+      '/language/:analyze-conversations',
+      this.application.endpoint
+    );
+
+    uri.searchParams.append('api-version', this.cluApiVersion);
+
+    return uri;
+  }
+}

--- a/packages/Recognizers/ConversationLanguageUnderstanding/js/src/cluRecognizerOptions.ts
+++ b/packages/Recognizers/ConversationLanguageUnderstanding/js/src/cluRecognizerOptions.ts
@@ -27,7 +27,7 @@ export class CluRecognizerOptions extends CluRecognizerOptionsBase {
    */
   constructor(
     application: CluApplication,
-    fields?: CluRecognizerOptionsBaseFields,
+    fields?: CluRecognizerOptionsBaseFields
   ) {
     super(application, fields);
   }
@@ -37,14 +37,14 @@ export class CluRecognizerOptions extends CluRecognizerOptionsBase {
    */
   recognize(
     utterance: string,
-    httpClient: HttpClient,
+    httpClient: HttpClient
   ): Promise<RecognizerResult>;
   /**
    * @inheritdoc
    */
   recognize(
     turnContext: TurnContext,
-    httpClient: HttpClient,
+    httpClient: HttpClient
   ): Promise<RecognizerResult>;
   /**
    * @inheritdoc
@@ -52,17 +52,17 @@ export class CluRecognizerOptions extends CluRecognizerOptionsBase {
   recognize(
     dialogContext: DialogContext,
     activity: Activity,
-    httpClient: HttpClient,
+    httpClient: HttpClient
   ): Promise<RecognizerResult>;
   recognize(
     utteranceOrContext: string | TurnContext | DialogContext,
     activityOrHttpClient: Activity | HttpClient,
-    httpClient?: HttpClient,
+    httpClient?: HttpClient
   ): Promise<RecognizerResult> {
     if (typeof utteranceOrContext === 'string') {
       return this.recognizeWithUtterance(
         utteranceOrContext,
-        activityOrHttpClient as HttpClient,
+        activityOrHttpClient as HttpClient
       );
     }
 
@@ -81,7 +81,7 @@ export class CluRecognizerOptions extends CluRecognizerOptionsBase {
   private async recognizeWithTurnContext(
     turnContext: TurnContext,
     utterance: string,
-    httpClient: HttpClient,
+    httpClient: HttpClient
   ): Promise<RecognizerResult> {
     let recognizerResult: RecognizerResult;
     let cluResponse = null;
@@ -92,7 +92,7 @@ export class CluRecognizerOptions extends CluRecognizerOptionsBase {
       cluResponse = await this.getCluResponse(utterance, httpClient);
       recognizerResult = this.buildRecognizerResultFromCluResponse(
         cluResponse,
-        utterance,
+        utterance
       );
     }
 
@@ -106,7 +106,7 @@ export class CluRecognizerOptions extends CluRecognizerOptionsBase {
       CluConstants.TraceOptions.ActivityName,
       traceInfo,
       CluConstants.TraceOptions.TraceType,
-      CluConstants.TraceOptions.TraceLabel,
+      CluConstants.TraceOptions.TraceLabel
     );
 
     return recognizerResult;
@@ -114,7 +114,7 @@ export class CluRecognizerOptions extends CluRecognizerOptionsBase {
 
   private async recognizeWithUtterance(
     utterance: string,
-    httpClient: HttpClient,
+    httpClient: HttpClient
   ): Promise<RecognizerResult> {
     if (!utterance?.trim()) {
       return { text: utterance, intents: {} };
@@ -129,15 +129,15 @@ export class CluRecognizerOptions extends CluRecognizerOptionsBase {
     const body = this.buildRequestBody(utterance);
     const headers = new HttpHeaders({
       'Content-Type': 'application/json',
-      [CluConstants.RequestOptions.SubscriptionKeyHeaderName]:
-        this.application.endpointKey,
+      [CluConstants.RequestOptions.SubscriptionKeyHeaderName]: this.application
+        .endpointKey,
     });
     const resource = new WebResource(
       uri.href,
       'POST',
       JSON.stringify(body),
       {},
-      headers,
+      headers
     );
     const response = await httpClient.sendRequest(resource);
 
@@ -165,7 +165,7 @@ export class CluRecognizerOptions extends CluRecognizerOptionsBase {
 
   private buildRecognizerResultFromCluResponse(
     cluResponse: any,
-    utterance: string,
+    utterance: string
   ): RecognizerResult {
     const prediction =
       cluResponse[CluConstants.ResponseOptions.ResultKey]?.[
@@ -180,8 +180,9 @@ export class CluRecognizerOptions extends CluRecognizerOptionsBase {
     };
 
     if (this.includeAPIResults) {
-      recognizerResult[CluConstants.RecognizerResultResponsePropertyName] =
-        cluResponse;
+      recognizerResult[
+        CluConstants.RecognizerResultResponsePropertyName
+      ] = cluResponse;
     }
 
     return recognizerResult;
@@ -190,7 +191,7 @@ export class CluRecognizerOptions extends CluRecognizerOptionsBase {
   private buildUri(): URL {
     const uri = new URL(
       '/language/:analyze-conversations',
-      this.application.endpoint,
+      this.application.endpoint
     );
 
     uri.searchParams.append('api-version', this.cluApiVersion);

--- a/packages/Recognizers/ConversationLanguageUnderstanding/js/src/cluRecognizerOptionsBase.ts
+++ b/packages/Recognizers/ConversationLanguageUnderstanding/js/src/cluRecognizerOptionsBase.ts
@@ -44,13 +44,13 @@ export abstract class CluRecognizerOptionsBase {
    * Gets or sets a value indicating whether to log personal information that came from the user to telemetry.
    * @returns If true, personal information is logged to Telemetry; otherwise the properties will be filtered.
    */
-  logPersonalInformation: boolean = false;
+  logPersonalInformation = false;
 
   /**
    * Gets or sets a value indicating whether flag to indicate if full results from the CLU API should be returned with the recognizer result.
    * @returns A value indicating whether full results from the CLU API should be returned with the recognizer result.
    */
-  includeAPIResults: boolean = false;
+  includeAPIResults = false;
 
   /**
    * Gets or sets a value indicating the string index type to include in the the CLU request body.
@@ -68,7 +68,7 @@ export abstract class CluRecognizerOptionsBase {
    * Gets the CLU application used to recognize text.
    * @returns The CLU application to use to recognize text.
    */
-  get application() {
+  get application(): CluApplication {
     return this._application;
   }
 
@@ -79,7 +79,7 @@ export abstract class CluRecognizerOptionsBase {
    */
   protected constructor(
     application: CluApplication,
-    fields?: CluRecognizerOptionsBaseFields
+    fields?: CluRecognizerOptionsBaseFields,
   ) {
     if (!application) {
       throw new Error();
@@ -98,17 +98,17 @@ export abstract class CluRecognizerOptionsBase {
 
   abstract recognize(
     turnContext: TurnContext,
-    httpClient: HttpClient
+    httpClient: HttpClient,
   ): Promise<RecognizerResult>;
 
   abstract recognize(
     dialogContext: DialogContext,
     activity: Activity,
-    httpClient: HttpClient
+    httpClient: HttpClient,
   ): Promise<RecognizerResult>;
 
   abstract recognize(
     utterance: string,
-    httpClient: HttpClient
+    httpClient: HttpClient,
   ): Promise<RecognizerResult>;
 }

--- a/packages/Recognizers/ConversationLanguageUnderstanding/js/src/cluRecognizerOptionsBase.ts
+++ b/packages/Recognizers/ConversationLanguageUnderstanding/js/src/cluRecognizerOptionsBase.ts
@@ -1,0 +1,73 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import {
+  BotTelemetryClient,
+  NullTelemetryClient,
+  Activity,
+  RecognizerResult,
+  TurnContext,
+} from 'botbuilder';
+
+import { CluApplication } from './cluApplication';
+import { CluConstants } from './cluConstants';
+import { HttpClient } from '@azure/ms-rest-js';
+import { DialogContext } from 'botbuilder-dialogs';
+
+export interface CluRecognizerOptionsBaseFields {
+  telemetryClient: BotTelemetryClient;
+  logPersonalInformation: boolean;
+  includeAPIResults: boolean;
+  cluRequestBodyStringIndexType: string;
+  cluApiVersion: string;
+}
+
+export abstract class CluRecognizerOptionsBase {
+  private _application!: CluApplication;
+
+  timeout: number = CluConstants.HttpClientOptions.Timeout;
+  telemetryClient: BotTelemetryClient;
+  logPersonalInformation: boolean = false;
+  includeAPIResults: boolean = false;
+  cluRequestBodyStringIndexType: string;
+  cluApiVersion: string;
+
+  get application() {
+    return this._application;
+  }
+
+  protected constructor(
+    application: CluApplication,
+    fields?: CluRecognizerOptionsBaseFields
+  ) {
+    if (!application) {
+      throw new Error();
+    }
+
+    this._application = application;
+    this.telemetryClient = fields?.telemetryClient ?? new NullTelemetryClient();
+    this.logPersonalInformation = fields?.logPersonalInformation ?? false;
+    this.includeAPIResults = fields?.includeAPIResults ?? false;
+    this.cluRequestBodyStringIndexType =
+      fields?.cluRequestBodyStringIndexType ??
+      CluConstants.RequestOptions.StringIndexType;
+    this.cluApiVersion =
+      fields?.cluApiVersion ?? CluConstants.RequestOptions.ApiVersion;
+  }
+
+  abstract recognize(
+    turnContext: TurnContext,
+    httpClient: HttpClient
+  ): Promise<RecognizerResult>;
+
+  abstract recognize(
+    dialogContext: DialogContext,
+    activity: Activity,
+    httpClient: HttpClient
+  ): Promise<RecognizerResult>;
+
+  abstract recognize(
+    utterance: string,
+    httpClient: HttpClient
+  ): Promise<RecognizerResult>;
+}

--- a/packages/Recognizers/ConversationLanguageUnderstanding/js/src/cluRecognizerOptionsBase.ts
+++ b/packages/Recognizers/ConversationLanguageUnderstanding/js/src/cluRecognizerOptionsBase.ts
@@ -79,7 +79,7 @@ export abstract class CluRecognizerOptionsBase {
    */
   protected constructor(
     application: CluApplication,
-    fields?: CluRecognizerOptionsBaseFields,
+    fields?: CluRecognizerOptionsBaseFields
   ) {
     if (!application) {
       throw new Error();
@@ -98,17 +98,17 @@ export abstract class CluRecognizerOptionsBase {
 
   abstract recognize(
     turnContext: TurnContext,
-    httpClient: HttpClient,
+    httpClient: HttpClient
   ): Promise<RecognizerResult>;
 
   abstract recognize(
     dialogContext: DialogContext,
     activity: Activity,
-    httpClient: HttpClient,
+    httpClient: HttpClient
   ): Promise<RecognizerResult>;
 
   abstract recognize(
     utterance: string,
-    httpClient: HttpClient,
+    httpClient: HttpClient
   ): Promise<RecognizerResult>;
 }

--- a/packages/Recognizers/ConversationLanguageUnderstanding/js/src/cluRecognizerOptionsBase.ts
+++ b/packages/Recognizers/ConversationLanguageUnderstanding/js/src/cluRecognizerOptionsBase.ts
@@ -22,20 +22,61 @@ export interface CluRecognizerOptionsBaseFields {
   cluApiVersion: string;
 }
 
+/**
+ * CLU Recognizer Options.
+ */
 export abstract class CluRecognizerOptionsBase {
   private _application!: CluApplication;
 
+  /**
+   * Gets or sets the time in milliseconds to wait before the request times out.
+   * @returns The time in milliseconds to wait before the request times out. Default is 100000 milliseconds.
+   */
   timeout: number = CluConstants.HttpClientOptions.Timeout;
+
+  /**
+   * Gets or sets the BotTelemetryClient used to log the CluResult event.
+   * @returns The client used to log telemetry events.
+   */
   telemetryClient: BotTelemetryClient;
+
+  /**
+   * Gets or sets a value indicating whether to log personal information that came from the user to telemetry.
+   * @returns If true, personal information is logged to Telemetry; otherwise the properties will be filtered.
+   */
   logPersonalInformation: boolean = false;
+
+  /**
+   * Gets or sets a value indicating whether flag to indicate if full results from the CLU API should be returned with the recognizer result.
+   * @returns A value indicating whether full results from the CLU API should be returned with the recognizer result.
+   */
   includeAPIResults: boolean = false;
+
+  /**
+   * Gets or sets a value indicating the string index type to include in the the CLU request body.
+   * @returns A value indicating the string index type to include in the the CLU request body.
+   */
   cluRequestBodyStringIndexType: string;
+
+  /**
+   * Gets or sets a value indicating the api version of the CLU service.
+   * @returns A value indicating the api version of the CLU service.
+   */
   cluApiVersion: string;
 
+  /**
+   * Gets the CLU application used to recognize text.
+   * @returns The CLU application to use to recognize text.
+   */
   get application() {
     return this._application;
   }
 
+  /**
+   * Initializes a new instance of the CluRecognizerOptionsBase class.
+   * @param application An instance of CluApplication.
+   * @param fields The fields to load to the base class.
+   */
   protected constructor(
     application: CluApplication,
     fields?: CluRecognizerOptionsBaseFields

--- a/packages/Recognizers/ConversationLanguageUnderstanding/js/src/defaultHttpClientFactory.ts
+++ b/packages/Recognizers/ConversationLanguageUnderstanding/js/src/defaultHttpClientFactory.ts
@@ -11,7 +11,7 @@ import {
 import { TurnContext } from 'botbuilder';
 import { ConnectorClient } from 'botframework-connector';
 
-const botbuilderPackageJson = require('botbuilder/package.json');
+import botbuilderPackageJson from 'botbuilder/package.json';
 export const USER_AGENT = `Microsoft-BotFramework/3.1 ${
   botbuilderPackageJson.name
 }/${botbuilderPackageJson.version} ${getDefaultUserAgentValue()} `;
@@ -28,7 +28,7 @@ export class DefaultHttpClientFactory {
    */
   constructor(turnContext: TurnContext) {
     const connectorClient = turnContext.turnState.get<ConnectorClient>(
-      turnContext.adapter.ConnectorClientKey
+      turnContext.adapter.ConnectorClientKey,
     );
 
     this.httpClient = new ServiceClient(connectorClient.credentials, {
@@ -44,7 +44,7 @@ export class DefaultHttpClientFactory {
    * Returns the same default HttpClient instance.
    * @returns The same HttpClient instance.
    */
-  create() {
+  create(): HttpClient {
     return this.httpClient;
   }
 }

--- a/packages/Recognizers/ConversationLanguageUnderstanding/js/src/defaultHttpClientFactory.ts
+++ b/packages/Recognizers/ConversationLanguageUnderstanding/js/src/defaultHttpClientFactory.ts
@@ -28,7 +28,7 @@ export class DefaultHttpClientFactory {
    */
   constructor(turnContext: TurnContext) {
     const connectorClient = turnContext.turnState.get<ConnectorClient>(
-      turnContext.adapter.ConnectorClientKey,
+      turnContext.adapter.ConnectorClientKey
     );
 
     this.httpClient = new ServiceClient(connectorClient.credentials, {

--- a/packages/Recognizers/ConversationLanguageUnderstanding/js/src/defaultHttpClientFactory.ts
+++ b/packages/Recognizers/ConversationLanguageUnderstanding/js/src/defaultHttpClientFactory.ts
@@ -1,0 +1,39 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import {
+  ServiceClient,
+  throttlingRetryPolicy,
+  userAgentPolicy,
+  getDefaultUserAgentValue,
+  HttpClient,
+} from '@azure/ms-rest-js';
+import { TurnContext } from 'botbuilder';
+import { ConnectorClient } from 'botframework-connector';
+
+const botbuilderPackageJson = require('botbuilder/package.json');
+export const USER_AGENT = `Microsoft-BotFramework/3.1 ${
+  botbuilderPackageJson.name
+}/${botbuilderPackageJson.version} ${getDefaultUserAgentValue()} `;
+
+export class DefaultHttpClientFactory {
+  private readonly httpClient: HttpClient;
+
+  constructor(turnContext: TurnContext) {
+    const connectorClient = turnContext.turnState.get<ConnectorClient>(
+      turnContext.adapter.ConnectorClientKey
+    );
+
+    this.httpClient = new ServiceClient(connectorClient.credentials, {
+      requestPolicyFactories: (factories) =>
+        factories.concat([
+          throttlingRetryPolicy(),
+          userAgentPolicy({ value: USER_AGENT }),
+        ]),
+    });
+  }
+
+  create() {
+    return this.httpClient;
+  }
+}

--- a/packages/Recognizers/ConversationLanguageUnderstanding/js/src/defaultHttpClientFactory.ts
+++ b/packages/Recognizers/ConversationLanguageUnderstanding/js/src/defaultHttpClientFactory.ts
@@ -16,9 +16,16 @@ export const USER_AGENT = `Microsoft-BotFramework/3.1 ${
   botbuilderPackageJson.name
 }/${botbuilderPackageJson.version} ${getDefaultUserAgentValue()} `;
 
+/**
+ * HttpClientFactory that always returns the same HttpClient instance for CLU calls.
+ */
 export class DefaultHttpClientFactory {
   private readonly httpClient: HttpClient;
 
+  /**
+   * Initializes a new instance of the DefaultHttpClientFactory class.
+   * @param turnContext The current turn context.
+   */
   constructor(turnContext: TurnContext) {
     const connectorClient = turnContext.turnState.get<ConnectorClient>(
       turnContext.adapter.ConnectorClientKey
@@ -33,6 +40,10 @@ export class DefaultHttpClientFactory {
     });
   }
 
+  /**
+   * Returns the same default HttpClient instance.
+   * @returns The same HttpClient instance.
+   */
   create() {
     return this.httpClient;
   }

--- a/packages/Recognizers/ConversationLanguageUnderstanding/js/src/index.ts
+++ b/packages/Recognizers/ConversationLanguageUnderstanding/js/src/index.ts
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+import { CluRecognizerBotComponent } from './cluRecognizerBotComponent';
+
+/**
+ * @module @microsoft/bot-components-clu-recognizer
+ */
+
+export * from './cluApplication';
+export * from './cluConstants';
+export * from './cluRecognizerOptions';
+export * from './cluRecognizerOptionsBase';
+export * from './clu/cluAdaptiveRecognizer';
+export * from './clu/cluMainRecognizer';
+export { CluRecognizerBotComponent };
+export default CluRecognizerBotComponent;

--- a/packages/Recognizers/ConversationLanguageUnderstanding/js/tsconfig.json
+++ b/packages/Recognizers/ConversationLanguageUnderstanding/js/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "@tsconfig/recommended",
+  "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
+    "composite": true,
+    "outDir": "lib",
+    "rootDir": "src",
+    "sourceMap": true,
+    "strict": true
+  }
+}

--- a/packages/Recognizers/ConversationLanguageUnderstanding/js/tsconfig.json
+++ b/packages/Recognizers/ConversationLanguageUnderstanding/js/tsconfig.json
@@ -6,6 +6,7 @@
     "outDir": "lib",
     "rootDir": "src",
     "sourceMap": true,
-    "strict": true
+    "strict": true,
+    "resolveJsonModule": true
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -918,6 +918,27 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@microsoft/bot-components-clu-recognizer@workspace:packages/Recognizers/ConversationLanguageUnderstanding/js":
+  version: 0.0.0-use.local
+  resolution: "@microsoft/bot-components-clu-recognizer@workspace:packages/Recognizers/ConversationLanguageUnderstanding/js"
+  dependencies:
+    "@azure/ms-rest-js": ^2.7.0
+    "@tsconfig/recommended": ^1.0.1
+    "@typescript-eslint/eslint-plugin": ^4.28.2
+    "@typescript-eslint/parser": ^4.28.2
+    adaptive-expressions: 4.19.3
+    botbuilder: 4.19.3
+    botbuilder-dialogs: 4.19.3
+    botbuilder-dialogs-adaptive-runtime-core: 4.19.3-preview
+    botbuilder-dialogs-declarative: 4.19.3-preview
+    botframework-connector: 4.19.3
+    eslint: ^7.30.0
+    eslint-plugin-prettier: latest
+    rimraf: ^3.0.2
+    typescript: ^4.0.5
+  languageName: unknown
+  linkType: soft
+
 "@microsoft/bot-components-helpandcancel@workspace:packages/HelpAndCancel":
   version: 0.0.0-use.local
   resolution: "@microsoft/bot-components-helpandcancel@workspace:packages/HelpAndCancel"


### PR DESCRIPTION
Addresses #1514

### Purpose
This PR ports the [CLU Recognizer's component](https://github.com/southworks/botframework-components/tree/main/packages/Recognizers/ConversationLanguageUnderstanding/dotnet) from DotNet to JS.

### Changes
- Updated DotNet's and added JS README.md.
- Ported DotNet's CLU folder to JS.
- Ported DotNet's root folder to JS.
- Few implementations in DotNet couldn't be ported to JS and has been adapted to work similarly.
- Added code documentation.

### Tests
The following image shows a Composer bot working with the JS CLU Recognizer's component.
![image](https://github.com/southworks/botframework-components/assets/62260472/c48bf8a9-986b-4599-9d38-2a9fe0213c21)

