### PR TITLE
fix: lint issues in clu recognizer tests

### DIFF
--- a/tests/unit/packages/Recognizers/js/tests/cluRecognizerOptions.test.ts
+++ b/tests/unit/packages/Recognizers/js/tests/cluRecognizerOptions.test.ts
@@ -115,10 +115,10 @@ describe('CluRecognizerOptions Tests', function () {
 class HttpClientMock implements HttpClient {
   sendRequest(httpRequest: WebResourceLike): Promise<HttpOperationResponse> {
     return Promise.resolve({
-          parsedBody: responseContentStr,
-          headers: new HttpHeaders(),
-          request: httpRequest,
-          status: 200,
-        });
+      parsedBody: responseContentStr,
+      headers: new HttpHeaders(),
+      request: httpRequest,
+      status: 200,
+    });
   }
 }

--- a/tests/unit/packages/Recognizers/js/tests/cluRecognizerOptionsBase.test.ts
+++ b/tests/unit/packages/Recognizers/js/tests/cluRecognizerOptionsBase.test.ts
@@ -82,6 +82,6 @@ class CluRecognizerOptionsBaseMock extends CluRecognizerOptionsBase {
     _activity: unknown,
     _httpClient?: unknown
   ): Promise<RecognizerResult> {
-      return Promise.resolve({ text: 'text', intents: {}, entities: {} });
+    return Promise.resolve({ text: 'text', intents: {}, entities: {} });
   }
 }


### PR DESCRIPTION
#minor

### Purpose
This PR fixes 2 remaining lint issues in the new JS CLU Recognizer's unit tests.

### Changes
- Applied lint autofix on:
   - cluRecognizerOptions.test.ts
   - cluRecognizerOptionsBase.test.ts