### PR TITLE
bump: [DotNet] Update generators and skill bots to NET 8

### DIFF
--- a/generators/generator-bot-adaptive/generators/app/index.js
+++ b/generators/generator-bot-adaptive/generators/app/index.js
@@ -197,7 +197,7 @@ module.exports = class extends BaseGenerator {
             appSettings.runtime.command = `func start --script-root ${path.join(
               'bin',
               'Debug',
-              'net6.0'
+              'net8.0'
             )}`;
             break;
           default:

--- a/generators/generator-bot-adaptive/generators/app/templates/dotnet/functions/botName.csproj
+++ b/generators/generator-bot-adaptive/generators/app/templates/dotnet/functions/botName.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AzureFunctionsVersion>v4</AzureFunctionsVersion>
     <_FunctionsSkipCleanOutput>true</_FunctionsSkipCleanOutput>
   </PropertyGroup>
@@ -14,7 +14,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.7" />
     <PackageReference Include="Microsoft.AspNetCore.OData" Version="7.5.2" />
     <PackageReference Include="Microsoft.Azure.Functions.Extensions" Version="1.1.0" />
-    <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="<%= sdkVersion %>" />
+ <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="<%= sdkVersion %>" />
     <PackageReference Include="Microsoft.Bot.Builder.AI.QnA" Version="<%= sdkVersion %>" />
     <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime" Version="<%= sdkVersion %>" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="3.1.22" />

--- a/generators/generator-bot-adaptive/generators/app/templates/dotnet/webapp/botName.csproj
+++ b/generators/generator-bot-adaptive/generators/app/templates/dotnet/webapp/botName.csproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AspNetCoreHostingModel>OutOfProcess</AspNetCoreHostingModel>
   </PropertyGroup>
   <ItemGroup>
@@ -10,7 +10,7 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.7" />
+ <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.7" />
     <PackageReference Include="Microsoft.Bot.Builder.AI.Luis" Version="<%= sdkVersion %>" />
     <PackageReference Include="Microsoft.Bot.Builder.AI.QnA" Version="<%= sdkVersion %>" />
     <PackageReference Include="Microsoft.Bot.Builder.Dialogs.Adaptive.Runtime" Version="<%= sdkVersion %>" /><%- packageReferences %>

--- a/generators/generator-bot-adaptive/platforms.js
+++ b/generators/generator-bot-adaptive/platforms.js
@@ -3,7 +3,7 @@
 
 const dotnet = {
   name: 'dotnet',
-  defaultSdkVersion: '4.21.2',
+  defaultSdkVersion: '4.22.4',
 };
 
 const js = {

--- a/generators/generator-bot-adaptive/test/dotnet-functions.test.js
+++ b/generators/generator-bot-adaptive/test/dotnet-functions.test.js
@@ -37,8 +37,8 @@ describe(`generator-bot-adaptive --platform ${platform} --integration ${integrat
 
     const botProjectGuidExpression = new RegExp(
       `Project\\(\\"\\{${projectType}\\}\\"\\) = \\"${botName}\\", ` +
-        `\\"${botName}\\\\${botName}.csproj\\", ` +
-        `\\"\\{(.+)\\}\\"`,
+      `\\"${botName}\\\\${botName}.csproj\\", ` +
+      `\\"\\{(.+)\\}\\"`,
       'gi'
     );
 
@@ -90,7 +90,7 @@ describe(`generator-bot-adaptive --platform ${platform} --integration ${integrat
           command: `func start --script-root ${path.join(
             'bin',
             'Debug',
-            'net6.0'
+            'net8.0'
           )}`,
           key: `adaptive-runtime-${platform}-${integration}`,
         },
@@ -125,7 +125,7 @@ describe(`generator-bot-adaptive --platform ${platform} --integration ${integrat
       {
         botName,
         packageReferences: '',
-        sdkVersion: '4.21.2',
+        sdkVersion: '4.22.4',
       }
     );
 

--- a/generators/generator-bot-adaptive/test/dotnet-functions.test.js
+++ b/generators/generator-bot-adaptive/test/dotnet-functions.test.js
@@ -37,8 +37,8 @@ describe(`generator-bot-adaptive --platform ${platform} --integration ${integrat
 
     const botProjectGuidExpression = new RegExp(
       `Project\\(\\"\\{${projectType}\\}\\"\\) = \\"${botName}\\", ` +
-      `\\"${botName}\\\\${botName}.csproj\\", ` +
-      `\\"\\{(.+)\\}\\"`,
+        `\\"${botName}\\\\${botName}.csproj\\", ` +
+        `\\"\\{(.+)\\}\\"`,
       'gi'
     );
 

--- a/generators/generator-bot-adaptive/test/dotnet-webapp.test.js
+++ b/generators/generator-bot-adaptive/test/dotnet-webapp.test.js
@@ -37,8 +37,8 @@ describe(`generator-bot-adaptive --platform ${platform} --integration ${integrat
 
     const botProjectGuidExpression = new RegExp(
       `Project\\(\\"\\{${projectType}\\}\\"\\) = \\"${botName}\\", ` +
-        `\\"${botName}\\\\${botName}.csproj\\", ` +
-        `\\"\\{(.+)\\}\\"`,
+      `\\"${botName}\\\\${botName}.csproj\\", ` +
+      `\\"\\{(.+)\\}\\"`,
       'gi'
     );
 
@@ -106,7 +106,7 @@ describe(`generator-bot-adaptive --platform ${platform} --integration ${integrat
       {
         botName,
         packageReferences: '',
-        sdkVersion: '4.21.2',
+        sdkVersion: '4.22.4',
       }
     );
 

--- a/generators/generator-bot-adaptive/test/dotnet-webapp.test.js
+++ b/generators/generator-bot-adaptive/test/dotnet-webapp.test.js
@@ -37,8 +37,8 @@ describe(`generator-bot-adaptive --platform ${platform} --integration ${integrat
 
     const botProjectGuidExpression = new RegExp(
       `Project\\(\\"\\{${projectType}\\}\\"\\) = \\"${botName}\\", ` +
-      `\\"${botName}\\\\${botName}.csproj\\", ` +
-      `\\"\\{(.+)\\}\\"`,
+        `\\"${botName}\\\\${botName}.csproj\\", ` +
+        `\\"\\{(.+)\\}\\"`,
       'gi'
     );
 

--- a/skills/csharp/calendarskill/Adapters/DefaultAdapter.cs
+++ b/skills/csharp/calendarskill/Adapters/DefaultAdapter.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System;
-using System.Threading.Tasks;
 using CalendarSkill.Responses.Shared;
 using CalendarSkill.Services;
 using Microsoft.Bot.Builder;
@@ -16,6 +14,9 @@ using Microsoft.Bot.Solutions.Middleware;
 using Microsoft.Bot.Solutions.Responses;
 using Microsoft.Extensions.Logging;
 using SkillServiceLibrary.Utilities;
+using System;
+using System.Threading.Tasks;
+using SetSpeakMiddleware = Microsoft.Bot.Solutions.Middleware.SetSpeakMiddleware;
 
 namespace CalendarSkill.Adapters
 {

--- a/skills/csharp/calendarskill/CalendarSkill.csproj
+++ b/skills/csharp/calendarskill/CalendarSkill.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <UserSecretsId>2bdd896c-393e-47c4-b6b9-a47238550b83</UserSecretsId>
     <NoWarn>NU1701</NoWarn>
   </PropertyGroup>

--- a/skills/csharp/calendarskill/Deployment/Scripts/publish.ps1
+++ b/skills/csharp/calendarskill/Deployment/Scripts/publish.ps1
@@ -69,7 +69,7 @@ if (Test-Path $zipPath) {
 }
 
 # Perform dotnet publish step ahead of zipping up
-$publishFolder = $(Join-Path $projFolder 'bin\release\net6.0')
+$publishFolder = $(Join-Path $projFolder 'bin\release\net8.0')
 dotnet publish -c release -o $publishFolder -v q > $logFile
 
 if($?) {

--- a/skills/csharp/calendarskill/Responses/Shared/CalendarCommonStrings.Designer.cs
+++ b/skills/csharp/calendarskill/Responses/Shared/CalendarCommonStrings.Designer.cs
@@ -19,7 +19,7 @@ namespace CalendarSkill.Responses.Shared {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class CalendarCommonStrings {

--- a/skills/csharp/calendarskill/Startup.cs
+++ b/skills/csharp/calendarskill/Startup.cs
@@ -27,6 +27,7 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using SkillServiceLibrary.Utilities;
+using AllowedCallersClaimsValidator = SkillServiceLibrary.Utilities.AllowedCallersClaimsValidator;
 
 namespace CalendarSkill
 {

--- a/skills/csharp/emailskill/Deployment/Scripts/publish.ps1
+++ b/skills/csharp/emailskill/Deployment/Scripts/publish.ps1
@@ -69,7 +69,7 @@ if (Test-Path $zipPath) {
 }
 
 # Perform dotnet publish step ahead of zipping up
-$publishFolder = $(Join-Path $projFolder 'bin\release\net6.0')
+$publishFolder = $(Join-Path $projFolder 'bin\release\net8.0')
 dotnet publish -c release -o $publishFolder -v q > $logFile
 
 if($?) {

--- a/skills/csharp/emailskill/EmailSkill.csproj
+++ b/skills/csharp/emailskill/EmailSkill.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <UserSecretsId>3383fcc5-4017-4e0a-9103-68603b68fe1d</UserSecretsId>
     <NoWarn>NU1701</NoWarn>
   </PropertyGroup>

--- a/skills/csharp/experimental/automotiveskill/AutomotiveSkill.csproj
+++ b/skills/csharp/experimental/automotiveskill/AutomotiveSkill.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <UserSecretsId>6a3184c3-074e-45b9-ad93-eceb8268ec01</UserSecretsId>
     <NoWarn>NU1701</NoWarn>
   </PropertyGroup>

--- a/skills/csharp/experimental/automotiveskill/Deployment/Scripts/publish.ps1
+++ b/skills/csharp/experimental/automotiveskill/Deployment/Scripts/publish.ps1
@@ -69,7 +69,7 @@ if (Test-Path $zipPath) {
 }
 
 # Perform dotnet publish step ahead of zipping up
-$publishFolder = $(Join-Path $projFolder 'bin\release\net6.0')
+$publishFolder = $(Join-Path $projFolder 'bin\release\net8.0')
 dotnet publish -c release -o $publishFolder -v q > $logFile
 
 if($?) {

--- a/skills/csharp/experimental/bingsearchskill/BingSearchSkill.csproj
+++ b/skills/csharp/experimental/bingsearchskill/BingSearchSkill.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <UserSecretsId>dce3ac16-dce5-4fd3-b97a-0f23791e65fc</UserSecretsId>
   </PropertyGroup>
 

--- a/skills/csharp/experimental/bingsearchskill/Deployment/Scripts/publish.ps1
+++ b/skills/csharp/experimental/bingsearchskill/Deployment/Scripts/publish.ps1
@@ -69,7 +69,7 @@ if (Test-Path $zipPath) {
 }
 
 # Perform dotnet publish step ahead of zipping up
-$publishFolder = $(Join-Path $projFolder 'bin\release\net6.0')
+$publishFolder = $(Join-Path $projFolder 'bin\release\net8.0')
 dotnet publish -c release -o $publishFolder -v q > $logFile
 
 if($?) {

--- a/skills/csharp/experimental/eventskill/Deployment/Scripts/publish.ps1
+++ b/skills/csharp/experimental/eventskill/Deployment/Scripts/publish.ps1
@@ -69,7 +69,7 @@ if (Test-Path $zipPath) {
 }
 
 # Perform dotnet publish step ahead of zipping up
-$publishFolder = $(Join-Path $projFolder 'bin\release\net6.0')
+$publishFolder = $(Join-Path $projFolder 'bin\release\net8.0')
 dotnet publish -c release -o $publishFolder -v q > $logFile
 
 if($?) {

--- a/skills/csharp/experimental/eventskill/EventSkill.csproj
+++ b/skills/csharp/experimental/eventskill/EventSkill.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <NoWarn>NU1701</NoWarn>
     <UserSecretsId>12ed3ad7-66e5-4160-b86c-aff9da5cf4b6</UserSecretsId>
   </PropertyGroup>

--- a/skills/csharp/experimental/hospitalityskill/Deployment/Scripts/publish.ps1
+++ b/skills/csharp/experimental/hospitalityskill/Deployment/Scripts/publish.ps1
@@ -69,7 +69,7 @@ if (Test-Path $zipPath) {
 }
 
 # Perform dotnet publish step ahead of zipping up
-$publishFolder = $(Join-Path $projFolder 'bin\release\net6.0')
+$publishFolder = $(Join-Path $projFolder 'bin\release\net8.0')
 dotnet publish -c release -o $publishFolder -v q > $logFile
 
 if($?) {

--- a/skills/csharp/experimental/hospitalityskill/HospitalitySkill.csproj
+++ b/skills/csharp/experimental/hospitalityskill/HospitalitySkill.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <NoWarn>NU1701</NoWarn>
     <UserSecretsId>a1b79856-3ffb-4825-807a-2dd1be342920</UserSecretsId>
   </PropertyGroup>

--- a/skills/csharp/experimental/itsmskill/Deployment/Scripts/publish.ps1
+++ b/skills/csharp/experimental/itsmskill/Deployment/Scripts/publish.ps1
@@ -69,7 +69,7 @@ if (Test-Path $zipPath) {
 }
 
 # Perform dotnet publish step ahead of zipping up
-$publishFolder = $(Join-Path $projFolder 'bin\release\net6.0')
+$publishFolder = $(Join-Path $projFolder 'bin\release\net8.0')
 dotnet publish -c release -o $publishFolder -v q > $logFile
 
 if($?) {

--- a/skills/csharp/experimental/itsmskill/ITSMSkill.csproj
+++ b/skills/csharp/experimental/itsmskill/ITSMSkill.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <NoWarn>NU1701</NoWarn>
   </PropertyGroup>
 

--- a/skills/csharp/experimental/musicskill/Deployment/Scripts/publish.ps1
+++ b/skills/csharp/experimental/musicskill/Deployment/Scripts/publish.ps1
@@ -69,7 +69,7 @@ if (Test-Path $zipPath) {
 }
 
 # Perform dotnet publish step ahead of zipping up
-$publishFolder = $(Join-Path $projFolder 'bin\release\net6.0')
+$publishFolder = $(Join-Path $projFolder 'bin\release\net8.0')
 dotnet publish -c release -o $publishFolder -v q > $logFile
 
 if($?) {

--- a/skills/csharp/experimental/musicskill/MusicSkill.csproj
+++ b/skills/csharp/experimental/musicskill/MusicSkill.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <NoWarn>NU1701</NoWarn>
   </PropertyGroup>
 

--- a/skills/csharp/experimental/newsskill/Deployment/Scripts/publish.ps1
+++ b/skills/csharp/experimental/newsskill/Deployment/Scripts/publish.ps1
@@ -69,7 +69,7 @@ if (Test-Path $zipPath) {
 }
 
 # Perform dotnet publish step ahead of zipping up
-$publishFolder = $(Join-Path $projFolder 'bin\release\net6.0')
+$publishFolder = $(Join-Path $projFolder 'bin\release\net8.0')
 dotnet publish -c release -o $publishFolder -v q > $logFile
 
 if($?) {

--- a/skills/csharp/experimental/newsskill/NewsSkill.csproj
+++ b/skills/csharp/experimental/newsskill/NewsSkill.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <NoWarn>NU1701</NoWarn>
   </PropertyGroup>
   

--- a/skills/csharp/experimental/phoneskill/Deployment/Scripts/publish.ps1
+++ b/skills/csharp/experimental/phoneskill/Deployment/Scripts/publish.ps1
@@ -69,7 +69,7 @@ if (Test-Path $zipPath) {
 }
 
 # Perform dotnet publish step ahead of zipping up
-$publishFolder = $(Join-Path $projFolder 'bin\release\net6.0')
+$publishFolder = $(Join-Path $projFolder 'bin\release\net8.0')
 dotnet publish -c release -o $publishFolder -v q > $logFile
 
 if($?) {

--- a/skills/csharp/experimental/phoneskill/PhoneSkill.csproj
+++ b/skills/csharp/experimental/phoneskill/PhoneSkill.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <NoWarn>NU1701</NoWarn>
     <Platforms>x64</Platforms>
   </PropertyGroup>

--- a/skills/csharp/experimental/restaurantbookingskill/Deployment/Scripts/publish.ps1
+++ b/skills/csharp/experimental/restaurantbookingskill/Deployment/Scripts/publish.ps1
@@ -69,7 +69,7 @@ if (Test-Path $zipPath) {
 }
 
 # Perform dotnet publish step ahead of zipping up
-$publishFolder = $(Join-Path $projFolder 'bin\release\net6.0')
+$publishFolder = $(Join-Path $projFolder 'bin\release\net8.0')
 dotnet publish -c release -o $publishFolder -v q > $logFile
 
 if($?) {

--- a/skills/csharp/experimental/restaurantbookingskill/RestaurantBookingSkill.csproj
+++ b/skills/csharp/experimental/restaurantbookingskill/RestaurantBookingSkill.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <UserSecretsId>6a3184c3-074e-45b9-ad93-eceb8268ec01</UserSecretsId>
     <NoWarn>NU1701</NoWarn>
   </PropertyGroup>

--- a/skills/csharp/experimental/weatherskill/Deployment/Scripts/publish.ps1
+++ b/skills/csharp/experimental/weatherskill/Deployment/Scripts/publish.ps1
@@ -69,7 +69,7 @@ if (Test-Path $zipPath) {
 }
 
 # Perform dotnet publish step ahead of zipping up
-$publishFolder = $(Join-Path $projFolder 'bin\release\net6.0')
+$publishFolder = $(Join-Path $projFolder 'bin\release\net8.0')
 dotnet publish -c release -o $publishFolder -v q > $logFile
 
 if($?) {

--- a/skills/csharp/experimental/weatherskill/WeatherSkill.csproj
+++ b/skills/csharp/experimental/weatherskill/WeatherSkill.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <NoWarn>NU1701</NoWarn>
     <UserSecretsId>bf895f98-5182-4f36-a89d-d52cdde1a45c</UserSecretsId>
   </PropertyGroup>

--- a/skills/csharp/pointofinterestskill/Deployment/Scripts/publish.ps1
+++ b/skills/csharp/pointofinterestskill/Deployment/Scripts/publish.ps1
@@ -69,7 +69,7 @@ if (Test-Path $zipPath) {
 }
 
 # Perform dotnet publish step ahead of zipping up
-$publishFolder = $(Join-Path $projFolder 'bin\release\net6.0')
+$publishFolder = $(Join-Path $projFolder 'bin\release\net8.0')
 dotnet publish -c release -o $publishFolder -v q > $logFile
 
 if($?) {

--- a/skills/csharp/pointofinterestskill/PointOfInterestSkill.csproj
+++ b/skills/csharp/pointofinterestskill/PointOfInterestSkill.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <UserSecretsId>302ba8d8-1f97-40c2-843e-ecf0a2805cf7</UserSecretsId>
     <NoWarn>NU1701</NoWarn>
   </PropertyGroup>

--- a/skills/csharp/shared/SkillServiceLibrary/SkillServiceLibrary.csproj
+++ b/skills/csharp/shared/SkillServiceLibrary/SkillServiceLibrary.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/skills/csharp/tests/SkillServiceLibrary.Fakes/SkillServiceLibrary.Fakes.csproj
+++ b/skills/csharp/tests/SkillServiceLibrary.Fakes/SkillServiceLibrary.Fakes.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/skills/csharp/tests/SkillServiceLibrary.Tests/SkillServiceLibrary.Tests.csproj
+++ b/skills/csharp/tests/SkillServiceLibrary.Tests/SkillServiceLibrary.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/skills/csharp/tests/automotiveskill.tests/AutomotiveSkill.Tests.csproj
+++ b/skills/csharp/tests/automotiveskill.tests/AutomotiveSkill.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <RunPostBuildEvent>OnBuildSuccess</RunPostBuildEvent>
     <NoWarn>NU1701</NoWarn>

--- a/skills/csharp/tests/calendarskill.tests/CalendarSkill.Tests.csproj
+++ b/skills/csharp/tests/calendarskill.tests/CalendarSkill.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <NoWarn>NU1701</NoWarn>
   </PropertyGroup>

--- a/skills/csharp/tests/emailskill.tests/EmailSkill.Tests.csproj
+++ b/skills/csharp/tests/emailskill.tests/EmailSkill.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <NoWarn>NU1701</NoWarn>
   </PropertyGroup>

--- a/skills/csharp/tests/hospitalityskill.tests/HospitalitySkill.Tests.csproj
+++ b/skills/csharp/tests/hospitalityskill.tests/HospitalitySkill.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/skills/csharp/tests/itsmskill.tests/ITSMSkill.Tests.csproj
+++ b/skills/csharp/tests/itsmskill.tests/ITSMSkill.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <NoWarn>NU1701</NoWarn>
   </PropertyGroup>

--- a/skills/csharp/tests/musicskill.Tests/MusicSkill.Tests.csproj
+++ b/skills/csharp/tests/musicskill.Tests/MusicSkill.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <NoWarn>NU1701</NoWarn>
   </PropertyGroup>

--- a/skills/csharp/tests/phoneskill.tests/PhoneSkill.Tests.csproj
+++ b/skills/csharp/tests/phoneskill.tests/PhoneSkill.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <NoWarn>NU1701</NoWarn>
     <Platforms>x64</Platforms>

--- a/skills/csharp/tests/pointofinterestskill.tests/PointOfInterestSkill.Tests.csproj
+++ b/skills/csharp/tests/pointofinterestskill.tests/PointOfInterestSkill.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <NoWarn>NU1701</NoWarn>
   </PropertyGroup>

--- a/skills/csharp/tests/todoskill.tests/ToDoSkill.Tests.csproj
+++ b/skills/csharp/tests/todoskill.tests/ToDoSkill.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <NoWarn>NU1701</NoWarn>
   </PropertyGroup>

--- a/skills/csharp/tests/weatherSkill.tests/WeatherSkill.Tests.csproj
+++ b/skills/csharp/tests/weatherSkill.tests/WeatherSkill.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <NoWarn>NU1701</NoWarn>
   </PropertyGroup>

--- a/skills/csharp/todoskill/Deployment/Scripts/publish.ps1
+++ b/skills/csharp/todoskill/Deployment/Scripts/publish.ps1
@@ -69,7 +69,7 @@ if (Test-Path $zipPath) {
 }
 
 # Perform dotnet publish step ahead of zipping up
-$publishFolder = $(Join-Path $projFolder 'bin\release\net6.0')
+$publishFolder = $(Join-Path $projFolder 'bin\release\net8.0')
 dotnet publish -c release -o $publishFolder -v q > $logFile
 
 if($?) {

--- a/skills/csharp/todoskill/ToDoSkill.csproj
+++ b/skills/csharp/todoskill/ToDoSkill.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <UserSecretsId>d8c5f2ea-e759-4038-8a4b-17e0f81e8a46</UserSecretsId>
     <NoWarn>NU1701</NoWarn>
   </PropertyGroup>

--- a/skills/declarative/Calendar/Calendar/Calendar.csproj
+++ b/skills/declarative/Calendar/Calendar/Calendar.csproj
@@ -1,7 +1,7 @@
 ﻿
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AspNetCoreHostingModel>OutOfProcess</AspNetCoreHostingModel>
     <UserSecretsId>7971aa8f-bc9a-432f-961e-687e2f46537e</UserSecretsId>
   </PropertyGroup>

--- a/skills/declarative/Calendar/Calendar/scripts/deploy.ps1
+++ b/skills/declarative/Calendar/Calendar/scripts/deploy.ps1
@@ -57,7 +57,7 @@ if (Test-Path $zipPath) {
 }
 
 # Perform dotnet publish step ahead of zipping up
-$publishFolder = $(Join-Path $projFolder 'bin\Release\net6.0')
+$publishFolder = $(Join-Path $projFolder 'bin\Release\net8.0')
 dotnet publish -c release -o $publishFolder -v q > $logFile
 
 # Copy bot files to running folder

--- a/skills/declarative/People/People/People.csproj
+++ b/skills/declarative/People/People/People.csproj
@@ -1,7 +1,7 @@
 ﻿
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <AspNetCoreHostingModel>OutOfProcess</AspNetCoreHostingModel>
     <UserSecretsId>66c24573-8ba1-4c8c-8a20-18dbbab26e3a</UserSecretsId>
   </PropertyGroup>

--- a/tests/functional/Libraries/TranscriptConverter/TranscriptConverter.csproj
+++ b/tests/functional/Libraries/TranscriptConverter/TranscriptConverter.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <PackAsTool>true</PackAsTool>
     <AssemblyName>btc</AssemblyName>
   </PropertyGroup>

--- a/tests/functional/Tests/ComponentsFunctionalTests/ComponentsFunctionalTests.csproj
+++ b/tests/functional/Tests/ComponentsFunctionalTests/ComponentsFunctionalTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/tests/functional/Tests/TranscriptTestRunnerTests/TranscriptTestRunnerTests.csproj
+++ b/tests/functional/Tests/TranscriptTestRunnerTests/TranscriptTestRunnerTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/tests/unit/packages/Microsoft.Bot.Components.Telephony.Tests/Microsoft.Bot.Components.Telephony.Tests.csproj
+++ b/tests/unit/packages/Microsoft.Bot.Components.Telephony.Tests/Microsoft.Bot.Components.Telephony.Tests.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
-		<TargetFrameworks Condition="'$(BuildTarget)' == ''">net6.0</TargetFrameworks>
+		<TargetFramework Condition="'$(BuildTarget)' == 'net8'">net8.0</TargetFramework>
+		<TargetFrameworks Condition="'$(BuildTarget)' == ''">net8.0</TargetFrameworks>
 		<Configurations>Debug;Release</Configurations>
 		<LangVersion>latest</LangVersion>
 		<Nullable>disable</Nullable>

--- a/tests/unit/packages/Recognizers/dotnet/Microsoft.Bot.Components.Recognizers.CLURecognizer.Tests.Unit.csproj
+++ b/tests/unit/packages/Recognizers/dotnet/Microsoft.Bot.Components.Recognizers.CLURecognizer.Tests.Unit.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-      <TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
-	  <TargetFrameworks Condition="'$(BuildTarget)' == ''">net6.0</TargetFrameworks>
+      <TargetFramework Condition="'$(BuildTarget)' == 'net8'">net8.0</TargetFramework>
+	  <TargetFrameworks Condition="'$(BuildTarget)' == ''">net8.0</TargetFrameworks>
 	  <Configurations>Debug;Release</Configurations>
 	  <LangVersion>latest</LangVersion>
       <Nullable>enable</Nullable>

--- a/tests/unit/packages/Teams/dotnet/Microsoft.Bot.Components.Teams.Tests.csproj
+++ b/tests/unit/packages/Teams/dotnet/Microsoft.Bot.Components.Teams.Tests.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
-		<TargetFrameworks Condition="'$(BuildTarget)' == ''">net6.0</TargetFrameworks>
+		<TargetFramework Condition="'$(BuildTarget)' == 'net8'">net8.0</TargetFramework>
+		<TargetFrameworks Condition="'$(BuildTarget)' == ''">net8.0</TargetFrameworks>
 		<Configurations>Debug;Release</Configurations>
 		<LangVersion>latest</LangVersion>
 		<Nullable>disable</Nullable>

--- a/tests/unit/skills/calendar/Microsoft.Bot.Dialogs.Tests.Skills.Calendar.csproj
+++ b/tests/unit/skills/calendar/Microsoft.Bot.Dialogs.Tests.Skills.Calendar.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
-		<TargetFrameworks Condition="'$(BuildTarget)' == ''">net6.0</TargetFrameworks>
+		<TargetFramework Condition="'$(BuildTarget)' == 'net8'">net8.0</TargetFramework>
+		<TargetFrameworks Condition="'$(BuildTarget)' == ''">net8.0</TargetFrameworks>
 		<Configurations>Debug;Release</Configurations>
 		<LangVersion>latest</LangVersion>
 		<Nullable>disable</Nullable>

--- a/tests/unit/skills/common/Microsoft.Bot.Dialogs.Tests.Common.csproj
+++ b/tests/unit/skills/common/Microsoft.Bot.Dialogs.Tests.Common.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/tests/unit/skills/people/Microsoft.Bot.Dialogs.Tests.Skills.People.csproj
+++ b/tests/unit/skills/people/Microsoft.Bot.Dialogs.Tests.Skills.People.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework Condition="'$(BuildTarget)' == 'net6'">net6.0</TargetFramework>
-		<TargetFrameworks Condition="'$(BuildTarget)' == ''">net6.0</TargetFrameworks>
+		<TargetFramework Condition="'$(BuildTarget)' == 'net8'">net8.0</TargetFramework>
+		<TargetFrameworks Condition="'$(BuildTarget)' == ''">net8.0</TargetFrameworks>
 		<Configurations>Debug;Release</Configurations>
 		<LangVersion>latest</LangVersion>
 		<Nullable>disable</Nullable>


### PR DESCRIPTION
Fixes #1559
#minor

### Purpose

This PR changes the .NET version used from .NET 6.0 to .NET 8.0 in the bot generators and the SDK samples.

### Changes
- Update defaultSdkVersion from 4.21.2 to 4.22.4.
- Update to .NET 8.0 the base generator template.
- Update to .NET 8.0 for all skill projects and test projects.
- Update to .NET 8.0 the functional tests projects.
- Fix CalendarSkill references.

### Tests
The following image shows a bot generated with the .NET 8 version and version 4.22.4 for the BotBuilder SDK packages.
![image](https://github.com/southworks/botframework-components/assets/122501764/fc928fa1-f388-4332-9fcc-c6dbcc9fa903)